### PR TITLE
Add flagcxIsHomoComm() for communicator type verification

### DIFF
--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -135,6 +135,19 @@ flagcxResult_t flagcxHandleFree(flagcxHandlerGroup_t handler)
     return flagcxSuccess;
 }
 
+flagcxResult_t flagcxIsHomoComm(int *isHomo)
+{
+    if (is_homo_comm())
+    {
+        *isHomo = 1;
+    }
+    else
+    {
+        *isHomo = 0;
+    }
+    return flagcxSuccess;
+}
+
 flagcxResult_t flagcxGetVersion(int *version)
 {
     // TODO: check how to return flagcx version including flagcx core and flagcx adaptor

--- a/flagcx/include/flagcx.h
+++ b/flagcx/include/flagcx.h
@@ -96,10 +96,13 @@ struct flagcxHandlerGroup {
 };
 typedef struct flagcxHandlerGroup* flagcxHandlerGroup_t;
 
-/* Init and free FLAGCX handls including flagcxComm_t, flagcxStream_t */
+/* Init and free FlagCX handls including flagcxComm_t, flagcxStream_t */
 flagcxResult_t flagcxHandleInit(flagcxHandlerGroup_t* handler);
 
 flagcxResult_t flagcxHandleFree(flagcxHandlerGroup_t handler);
+
+/* Check if the FlagCX communicator type is homogeneous or heterogeneous */
+flagcxResult_t flagcxIsHomoComm(int *isHomo);
 
 /* Return the version of the FlagCX library in the supplied integer.
  * It contains the underlying adaptor library version and FlagCX core version

--- a/plugin/torch/include/utils_flagcx.hpp
+++ b/plugin/torch/include/utils_flagcx.hpp
@@ -11,11 +11,20 @@ namespace c10d
   {
     AutoFlagcxGroup()
     {
-      flagcxGroupStart();
+      // TODO: support group semantics for heterogeneous case
+      flagcxIsHomoComm(&is_homo_);
+      if (is_homo_)
+      {
+        flagcxGroupStart();
+      }
     }
     ~AutoFlagcxGroup() noexcept(false)
     {
-      flagcxGroupEnd();
+      if (is_homo_)
+      {
+        flagcxGroupEnd();
+      }
     }
+    int is_homo_ = 1;
   };
 } // namespace c10d


### PR DESCRIPTION
- Add flagcxIsHomoComm() for communicator type verification
- Do not call group semantics for coalesced collective ops (allreduce, allgather, reducescatter) under heterogeneous circumstance, since current implementations of C2C ops require the use of stream synchronization
<img width="943" alt="截屏2025-02-13 14 30 54" src="https://github.com/user-attachments/assets/6cd0ec92-793e-475b-b20d-7d7c8567f660" />