### PR TITLE
Add mulit-stream support in torch plugin to parallelize hetero coalesced ops

### DIFF
--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -483,7 +483,6 @@ flagcxResult_t flagcxReduce(const void *sendbuff, void *recvbuff, size_t count,
           sendbuff, fwdbuff, count, datatype, op, comm->homo_inter_rank,
           comm->homo_comm, stream));
 
-      // inter-cluster sendrecv
       if (is_root_cluster && comm->homo_inter_rank != comm->homo_rank) {
         if (op == flagcxSum) {
           deviceAdaptor->deviceMemset(fwdbuff, 0,
@@ -491,6 +490,11 @@ flagcxResult_t flagcxReduce(const void *sendbuff, void *recvbuff, size_t count,
                                       flagcxMemDevice, stream);
         }
       }
+
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
+      deviceAdaptor->streamSynchronize(stream);
+
+      // inter-cluster sendrecv
       int cid = 0;
       flagcxGroupStart(comm);
       for (int i = 0; i < comm->nclusters; ++i) {
@@ -526,8 +530,7 @@ flagcxResult_t flagcxReduce(const void *sendbuff, void *recvbuff, size_t count,
       }
       flagcxGroupEnd(comm);
 
-      // sync stream to collect implicitly triggered ops by
-      // flagcxHeteroSend/Recv
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
       deviceAdaptor->streamSynchronize(stream);
 
       // intra-cluster reduce for root cluster
@@ -611,6 +614,9 @@ flagcxResult_t flagcxGather(const void *sendbuff, void *recvbuff, size_t count,
             comm->homo_comm, stream));
       }
 
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
+      deviceAdaptor->streamSynchronize(stream);
+
       // inter-cluster sendrecv
       bool fwd_root =
           comm->cluster_inter_ranks[comm->cluster_ids[root]] != root;
@@ -648,8 +654,7 @@ flagcxResult_t flagcxGather(const void *sendbuff, void *recvbuff, size_t count,
       }
       flagcxGroupEnd(comm);
 
-      // sync stream to collect implicitly triggered ops by
-      // flagcxHeteroSend/Recv
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
       deviceAdaptor->streamSynchronize(stream);
 
       // intra-cluster sendrecv if homo_inter_rank != root_rank in the root
@@ -774,6 +779,9 @@ flagcxResult_t flagcxScatter(const void *sendbuff, void *recvbuff, size_t count,
         flagcxGroupEnd(comm);
       }
 
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
+      deviceAdaptor->streamSynchronize(stream);
+
       // inter-cluster sendrecv
       flagcxGroupStart(comm);
       if (!is_root_cluster && comm->homo_inter_rank == comm->homo_rank) {
@@ -809,8 +817,7 @@ flagcxResult_t flagcxScatter(const void *sendbuff, void *recvbuff, size_t count,
       }
       flagcxGroupEnd(comm);
 
-      // sync stream to collect implicitly triggered ops by
-      // flagcxHeteroSend/Recv
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
       deviceAdaptor->streamSynchronize(stream);
 
       // intra-cluster scatter
@@ -865,6 +872,9 @@ flagcxResult_t flagcxBroadcast(const void *sendbuff, void *recvbuff,
             stream));
       }
 
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
+      deviceAdaptor->streamSynchronize(stream);
+
       // inter-cluster sendrecv
       flagcxGroupStart(comm);
       if (comm->homo_inter_rank == comm->homo_rank) {
@@ -886,8 +896,7 @@ flagcxResult_t flagcxBroadcast(const void *sendbuff, void *recvbuff,
       }
       flagcxGroupEnd(comm);
 
-      // sync stream to collect implicitly triggered ops by
-      // flagcxHeteroSend/Recv
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
       deviceAdaptor->streamSynchronize(stream);
 
       // intra-cluster bcast
@@ -1034,7 +1043,6 @@ flagcxResult_t flagcxAllReduce(const void *sendbuff, void *recvbuff,
           sendbuff, recvbuff, count, datatype, op, comm->homo_inter_rank,
           comm->homo_comm, stream));
 
-      // inter-cluster sendrecv
       if (comm->homo_inter_rank != comm->homo_rank) {
         if (op == flagcxSum) {
           deviceAdaptor->deviceMemset(recvbuff, 0,
@@ -1042,6 +1050,11 @@ flagcxResult_t flagcxAllReduce(const void *sendbuff, void *recvbuff,
                                       flagcxMemDevice, stream);
         }
       }
+
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
+      deviceAdaptor->streamSynchronize(stream);
+
+      // inter-cluster sendrecv
       int cid = 0;
       flagcxGroupStart(comm);
       for (int i = 0; i < comm->nclusters; ++i) {
@@ -1074,8 +1087,7 @@ flagcxResult_t flagcxAllReduce(const void *sendbuff, void *recvbuff,
       }
       flagcxGroupEnd(comm);
 
-      // sync stream to collect implicitly triggered ops by
-      // flagcxHeteroSend/Recv
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
       deviceAdaptor->streamSynchronize(stream);
 
       // intra-cluster allreduce
@@ -1180,13 +1192,17 @@ flagcxResult_t flagcxReduceScatter(const void *sendbuff, void *recvbuff,
           sendbuff, tmpbuff, count, datatype, op, comm->homo_inter_rank,
           comm->homo_comm, stream));
 
-      // inter-cluster sendrecv
       if (comm->homo_inter_rank != comm->homo_rank) {
         if (op == flagcxSum) {
           deviceAdaptor->deviceMemset(tmpbuff, 0, size, flagcxMemDevice,
                                       stream);
         }
       }
+
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
+      deviceAdaptor->streamSynchronize(stream);
+
+      // inter-cluster sendrecv
       int cid = 0;
       flagcxGroupStart(comm);
       for (int i = 0; i < comm->nclusters; ++i) {
@@ -1219,8 +1235,7 @@ flagcxResult_t flagcxReduceScatter(const void *sendbuff, void *recvbuff,
       }
       flagcxGroupEnd(comm);
 
-      // sync stream to collect implicitly triggered ops by
-      // flagcxHeteroSend/Recv
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
       deviceAdaptor->streamSynchronize(stream);
 
       // intra-cluster reducescatter
@@ -1364,6 +1379,9 @@ flagcxResult_t flagcxAllGather(const void *sendbuff, void *recvbuff,
                    getFlagcxDataTypeSize(datatype) * offset * sendcount),
           sendcount, datatype, comm->homo_inter_rank, comm->homo_comm, stream));
 
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
+      deviceAdaptor->streamSynchronize(stream);
+
       // inter-cluster sendrecv
       if (comm->homo_inter_rank == comm->homo_rank) {
         int offset_recv = 0;
@@ -1389,8 +1407,7 @@ flagcxResult_t flagcxAllGather(const void *sendbuff, void *recvbuff,
         flagcxGroupEnd(comm);
       }
 
-      // sync stream to collect implicitly triggered ops by
-      // flagcxHeteroSend/Recv
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
       deviceAdaptor->streamSynchronize(stream);
 
       // intra-cluster broadcast
@@ -1523,6 +1540,9 @@ flagcxResult_t flagcxAlltoAll(const void *sendbuff, void *recvbuff,
           static_cast<void *>(buffer_out + offset * size), count, datatype,
           comm->homo_comm, stream))
 
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
+      deviceAdaptor->streamSynchronize(stream);
+
       // inter-cluster sendrecv
       // TODO: use cluster_inter_rank to perform hetero sendrecv operation
       flagcxGroupStart(comm);
@@ -1538,8 +1558,7 @@ flagcxResult_t flagcxAlltoAll(const void *sendbuff, void *recvbuff,
       }
       flagcxGroupEnd(comm);
 
-      // sync stream to collect implicitly triggered ops by
-      // flagcxHeteroSend/Recv
+      // TODO: use stream wait rather than stream sync to avoid cpu blocking
       deviceAdaptor->streamSynchronize(stream);
     }
   }

--- a/plugin/torch/include/backend_flagcx.hpp
+++ b/plugin/torch/include/backend_flagcx.hpp
@@ -166,9 +166,11 @@ public:
   }
 
 protected:
+  flagcxStream_t getStreamByIndex(int streamId);
+  std::unique_ptr<flagcxEvent> &getEventByIndex(int eventId);
   void initComm(at::Device dev);
   void initComm();
-  void syncStream(at::Device device);
+  void syncStream(at::Device device, int index = 0);
   void groupStart();
   void groupEnd();
 
@@ -177,9 +179,9 @@ protected:
   int deviceId_;
   int status_; // 0: allocated, 1: initialized
   uint64_t activeGroupCounter_;
-  flagcxStream_t stream_ = nullptr;
+  std::unordered_map<int, flagcxStream_t> flagcxStreams_;
+  std::unordered_map<int, std::unique_ptr<flagcxEvent>> flagcxEvents_;
   flagcxHandlerGroup_t handler_ = nullptr;
-  std::unique_ptr<flagcxEvent> event_ = nullptr;
 
 private:
   // Helper that encapsulates work shared across all collective communication

--- a/plugin/torch/include/utils_flagcx.hpp
+++ b/plugin/torch/include/utils_flagcx.hpp
@@ -25,20 +25,11 @@ namespace c10d {
 // manages group lifetimes.
 struct flagcxGroupGuard final {
   flagcxGroupGuard(flagcxComm_t comm) {
-    // TODO: support group semantics for heterogeneous case
     comm_ = comm;
-    flagcxIsHomoComm(comm_, &isHomo_);
-    if (isHomo_) {
-      flagcxGroupStart(comm_);
-    }
+    flagcxGroupStart(comm_);
   }
-  ~flagcxGroupGuard() noexcept(false) {
-    if (isHomo_) {
-      flagcxGroupEnd(comm_);
-    }
-  }
+  ~flagcxGroupGuard() noexcept(false) { flagcxGroupEnd(comm_); }
   flagcxComm_t comm_ = nullptr;
-  int isHomo_ = 1;
 };
 
 std::string getFlagcxVersion();

--- a/plugin/torch/run.sh
+++ b/plugin/torch/run.sh
@@ -18,7 +18,8 @@ export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 # export LD_PRELOAD=/usr/local/lib/libgloo.so
 # export LD_PRELOAD=/usr/local/nccl/build/lib/libnccl.so
 export TORCH_DISTRIBUTED_DETAIL=DEBUG
-CMD='torchrun --nproc_per_node 8 --nnodes=1 --node_rank=0 --master_addr="172.24.135.58" --master_port=8281 example.py'
+#CMD='torchrun --nproc_per_node 8 --nnodes=1 --node_rank=0 --master_addr="172.24.135.58" --master_port=8281 example.py'
+CMD='torchrun --nproc_per_node 8 --nnodes=1 --node_rank=0 --master_addr="172.24.135.43" --master_port=8281 example.py'
 
 echo $CMD
 eval $CMD


### PR DESCRIPTION
- Each enqueued op for coalescing will be launched on a different stream in heterogeneous mode
- Add stream syncs at the beginning/end of flagcxHeteroSend/Recv ops to ensure correctness