### PR TITLE
remove gdrSupported field from flagcxDevProps to avoid compilation error

### DIFF
--- a/flagcx/adaptor/cuda_adaptor.cc
+++ b/flagcx/adaptor/cuda_adaptor.cc
@@ -191,7 +191,9 @@ flagcxResult_t cudaAdaptorGetDeviceProperties(struct flagcxDevProps *props,
   props->pciBusId = devProp.pciBusID;
   props->pciDeviceId = devProp.pciDeviceID;
   props->pciDomainId = devProp.pciDomainID;
-  props->gdrSupported = devProp.gpuDirectRDMASupported;
+  // TODO: see if there's another way to get this info. In some cuda versions,
+  // cudaDeviceProp does not have `gpuDirectRDMASupported` field
+  // props->gdrSupported = devProp.gpuDirectRDMASupported;
 
   return flagcxSuccess;
 }

--- a/flagcx/adaptor/ixcuda_adaptor.cc
+++ b/flagcx/adaptor/ixcuda_adaptor.cc
@@ -191,9 +191,9 @@ flagcxResult_t ixcudaAdaptorGetDeviceProperties(struct flagcxDevProps *props,
   props->pciBusId = devProp.pciBusID;
   props->pciDeviceId = devProp.pciDeviceID;
   props->pciDomainId = devProp.pciDomainID;
-  // TODO: check if ix cudaDeviceProp has the same field
+  // TODO: see if there's another way to get this info. In some cuda versions,
+  // cudaDeviceProp does not have `gpuDirectRDMASupported` field
   // props->gdrSupported = devProp.gpuDirectRDMASupported;
-  props->gdrSupported = 1;
 
   return flagcxSuccess;
 }

--- a/flagcx/core/topo.h
+++ b/flagcx/core/topo.h
@@ -175,7 +175,8 @@ struct flagcxDevProps {
   int pciBusId;
   int pciDeviceId;
   int pciDomainId;
-  int gdrSupported;
+  // remove unused field for now
+  // int gdrSupported;
 };
 
 flagcxResult_t flagcxTopoGetNode(struct flagcxTopoSystem *system,


### PR DESCRIPTION
- removed `gdrSupported` from flagcxDevProps to avoid compilation error cuased by different definitions of `cudaDeviceProp` in different cuda versions