### PR TITLE
add inter-rank collecting mechanism to initialize the homo inter comm

### DIFF
--- a/flagcx/core/global_comm.h
+++ b/flagcx/core/global_comm.h
@@ -4,6 +4,8 @@
 #include "bootstrap.h"
 #include "flagcx.h"
 
+#include <vector>
+
 /* Opaque handle to flagcxInnerComm */
 typedef struct flagcxInnerComm *flagcxInnerComm_t;
 
@@ -17,6 +19,7 @@ typedef enum {
 } flagcxCommunicatorType_t;
 
 struct flagcxComm {
+  // TODO: adjust code format
   int rank;
   int nranks;
   int nclusters;
@@ -31,12 +34,18 @@ struct flagcxComm {
   volatile uint32_t *abortFlag;
   int *cluster_sizes;
   int *cluster_ids;
-  int *cluster_inter_ranks;
   int *globalrank2homorank;
+  int *cluster_inter_ranks;
   bootstrapState *bootstrap;
   flagcxInnerComm_t host_comm;
   flagcxInnerComm_t homo_comm;
   flagcxHeteroComm_t hetero_comm;
+  // experimental for multi-nic support
+  int homoInterRootRank;
+  int homoInterMyRank;
+  int homoInterRanks;
+  std::vector<std::vector<int>> clusterInterRankList;
+  flagcxInnerComm_t homoInterComm;
 };
 
 #endif // end include guard

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -11,6 +11,7 @@
 #include <cassert>
 #include <stdio.h>
 #include <string.h>
+#include <unordered_map>
 
 size_t getFlagcxDataTypeSize(flagcxDataType_t dtype) {
   switch (dtype) {
@@ -201,6 +202,10 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
   (*comm)->cluster_inter_ranks = NULL;
   (*comm)->globalrank2homorank = NULL;
   (*comm)->comm_type = flagcxCommunicatorUnknown;
+  (*comm)->homoInterRootRank = -1;
+  (*comm)->homoInterMyRank = -1;
+  (*comm)->homoInterRanks = -1;
+  (*comm)->homoInterComm = NULL;
 
   struct bootstrapState *state = NULL;
   FLAGCXCHECK(flagcxCalloc(&state, 1));
@@ -306,17 +311,56 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
     (*comm)->support_multi_nic = std::stoi(enableMultiNicSupport);
   }
 
+  // Experimental for multi-nic support
+  // Collect nic distance to ranks
+  (*comm)->clusterInterRankList.resize((*comm)->nclusters);
+  int *nicDistanceData;
+  FLAGCXCHECK(flagcxCalloc(&nicDistanceData, nranks));
+  // flagcxGetNicDistance(nicDistanceData + rank);
+  nicDistanceData[rank] = rank % 2 + 1;
+  FLAGCXCHECK(bootstrapAllGather(state, (void *)nicDistanceData, sizeof(int)));
+  FLAGCXCHECK(bootstrapBarrier(state, rank, nranks, 0));
+  for (int i = 0; i < (*comm)->nclusters; ++i) {
+    int minDistance = INT_MAX;
+    std::unordered_map<int, std::vector<int>> nicDistanceToRanks;
+    for (int j = 0; j < nranks; ++j) {
+      if (clusterIdData[j] != i) {
+        continue;
+      }
+      int val = nicDistanceData[j];
+      nicDistanceToRanks[val].push_back(j);
+      minDistance = std::min(minDistance, val);
+    }
+    (*comm)->clusterInterRankList[i] =
+        std::move(nicDistanceToRanks[minDistance]);
+  }
+  // Set homoInterMyRank, homoInterRootRank and homoInterRanks
+  auto &myClusterInterRanks =
+      (*comm)->clusterInterRankList[clusterIdData[rank]];
+  for (size_t i = 0; i < myClusterInterRanks.size(); ++i) {
+    if (rank == myClusterInterRanks[i]) {
+      (*comm)->homoInterMyRank = i;
+    }
+  }
+  if ((*comm)->homoInterMyRank != -1) {
+    (*comm)->homoInterRootRank = myClusterInterRanks[0];
+    (*comm)->homoInterRanks = myClusterInterRanks.size();
+  }
+
   INFO(FLAGCX_INIT,
        "rank = %d, nranks = %d, nclusters = %d, cluster_id = %d, cluster_size "
-       "= %d, cluster_inter_rank = %d, homo_rank = %d, homo_root_rank = %d, "
-       "homo_inter_rank = %d, homo_ranks = %d, has_single_rank_homo_comm = %d, "
-       "support_multi_nic = %d",
+       "= %d, "
+       "cluster_inter_rank = %d, homo_rank = %d, homo_root_rank = %d, "
+       "homo_inter_rank = %d, homo_ranks = %d, "
+       "has_single_rank_homo_comm = %d, support_multi_nic = %d, "
+       "homoInterRootRank = %d, homoInterMyRank = %d, homoInterRanks = %d",
        rank, nranks, (*comm)->nclusters, (*comm)->cluster_ids[rank],
        (*comm)->cluster_sizes[(*comm)->cluster_ids[rank]],
        (*comm)->cluster_inter_ranks[(*comm)->cluster_ids[rank]],
        (*comm)->homo_rank, (*comm)->homo_root_rank, (*comm)->homo_inter_rank,
        (*comm)->homo_ranks, (*comm)->has_single_rank_homo_comm,
-       (*comm)->support_multi_nic);
+       (*comm)->homo_ranks, (*comm)->homoInterRootRank,
+       (*comm)->homoInterMyRank, (*comm)->homoInterRanks);
 
   // Reset commId and homo root rank calls underlying GetUniqueId function for
   // initialization of homo communicator
@@ -363,9 +407,34 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
     }
   }
 
+  // Experimental for multi-nic support
+  // Reset commId and homo inter root rank calls underlying GetUniqueId function
+  // for initialization of homo inter communicator
+  memset((void *)commId, 0, sizeof(flagcxUniqueId));
+  memset((void *)uniqueIdData, 0, nranks * sizeof(flagcxUniqueId));
+  // Let homoInterRootRank call underlying GetUniqueId function
+  // for initialization of homo inter communicator
+  if (rank == (*comm)->homoInterRootRank) {
+    cclAdaptors[flagcxCCLAdaptorDevice]->getUniqueId(&commId);
+    memcpy((void *)&uniqueIdData[rank], (void *)commId, sizeof(flagcxUniqueId));
+  }
+  // Collect uniqueIdData globally
+  FLAGCXCHECK(
+      bootstrapAllGather(state, (void *)uniqueIdData, sizeof(flagcxUniqueId)));
+  FLAGCXCHECK(bootstrapBarrier(state, rank, nranks, 0));
+  // Call cclAdaptor->commInitRank
+  if ((*comm)->homoInterRootRank != -1) {
+    memcpy((void *)commId, (void *)&uniqueIdData[(*comm)->homoInterRootRank],
+           sizeof(flagcxUniqueId));
+    FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->commInitRank(
+        &(*comm)->homoInterComm, (*comm)->homoInterRanks, commId,
+        (*comm)->homoInterMyRank, NULL));
+  }
+
   free(clusterInterRankData);
   free(uniqueIdData);
   free(vendorData);
+  free(nicDistanceData);
 
   return flagcxSuccess;
 }
@@ -523,9 +592,9 @@ flagcxResult_t flagcxReduce(const void *sendbuff, void *recvbuff, size_t count,
 
       // step 4: memcpy h2d
       timers[TIMER_COLL_MEM_H2D] = clockNano();
-      if(comm->rank == root) {
+      if (comm->rank == root) {
         deviceAdaptor->deviceMemcpy(recvbuff, buff_out, size,
-                                  flagcxMemcpyHostToDevice, NULL, NULL);
+                                    flagcxMemcpyHostToDevice, NULL, NULL);
       }
       timers[TIMER_COLL_MEM_H2D] = clockNano() - timers[TIMER_COLL_MEM_H2D];
 

--- a/test/perf/Makefile
+++ b/test/perf/Makefile
@@ -80,7 +80,7 @@ run-sendrecv:
 	@mpirun --allow-run-as-root -np 8 -x UCX_POSIX_USE_PROC_LINK=n -x ${DEV}_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 -x FLAGCX_DEBUG=INFO -x FLAGCX_DEBUG_SUBSYS=ALL ./test_sendrecv
 
 run-allreduce:
-	@mpirun --allow-run-as-root -np 8 -x UCX_POSIX_USE_PROC_LINK=n -x ${DEV}_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 -x FLAGCX_DEBUG=TRACE -x FLAGCX_DEBUG_SUBSYS=ALL ./test_allreduce
+	@mpirun --allow-run-as-root -np 8 -x UCX_POSIX_USE_PROC_LINK=n -x ${DEV}_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 -x FLAGCX_DEBUG=INFO -x FLAGCX_DEBUG_SUBSYS=ALL ./test_allreduce
 
 run-allgather:
 	@mpirun --allow-run-as-root -np 8 -x UCX_POSIX_USE_PROC_LINK=n -x ${DEV}_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 -x FLAGCX_DEBUG=INFO -x FLAGCX_DEBUG_SUBSYS=ALL ./test_allgather


### PR DESCRIPTION
This PR introduces an inter-rank collection mechanism to initialize the homogeneous inter-communicator, composed of a subset of ranks within the homogeneous ranks that are closest to available NICs. This communicator will be used for inter-cluster send/receive operations.