### PR TITLE
support multi-nic C2C AllReduce algorithm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,11 @@ jobs:
           . venv/bin/activate
           apt update -y
           apt-get install clang-format -y
+          git fetch --all
           from_ref=${GITHUB_HEAD_REF}
           to_ref=${GITHUB_BASE_REF}
+
+          echo "From branch: $from_ref, To branch: $to_ref"
 
           pre-commit run --from-ref "origin/$from_ref" --to-ref "origin/$to_ref"
         continue-on-error: false

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -48,8 +48,11 @@ jobs:
           . venv/bin/activate
           apt update -y
           apt-get install clang-format -y
+          git fetch --all
           from_ref=${GITHUB_HEAD_REF}
           to_ref=${GITHUB_BASE_REF}
+
+          echo "From branch: $from_ref, To branch: $to_ref"
 
           pre-commit run --from-ref "origin/$from_ref" --to-ref "origin/$to_ref"
         continue-on-error: false

--- a/flagcx/core/c2c_algo.cc
+++ b/flagcx/core/c2c_algo.cc
@@ -1,5 +1,51 @@
 #include "c2c_algo.h"
 
+// homoType: 0, pre; 1, homoInter; 2, post,
+// mode: 0, multiNic+eachNicPerRank; 1, normal; 2, single-nic
+// For now, we only support AllReduce operator mapping
+flagcxCommOp_t getC2cHomoCommOp(flagcxCommOp_t commOp, int homoType, int mode) {
+  switch (commOp) {
+    case flagcxCommOpSend:
+      return flagcxCommOpSend;
+    case flagcxCommOpRecv:
+      return flagcxCommOpRecv;
+    case flagcxCommOpBroadcast:
+      return flagcxCommOpBroadcast;
+    case flagcxCommOpGather:
+      return flagcxCommOpGather;
+    case flagcxCommOpScatter:
+      return flagcxCommOpScatter;
+    case flagcxCommOpReduce:
+      return flagcxCommOpReduce;
+    case flagcxCommOpAllReduce:
+      switch (homoType) {
+        case 0:
+          switch (mode) {
+            case 0:
+              return flagcxCommOpReduceScatter;
+            case 1:
+              return flagcxCommOpReduce;
+            case 2:
+              return flagcxCommOpReduce;
+          }
+        case 1:
+          return flagcxCommOpAllReduce;
+        case 2:
+          return flagcxCommOpAllReduce;
+      }
+    case flagcxCommOpAllGather:
+      return flagcxCommOpAllGather;
+    case flagcxCommOpReduceScatter:
+      return flagcxCommOpReduceScatter;
+    case flagcxCommOpAlltoAll:
+      return flagcxCommOpAlltoAll;
+    case flagcxCommOpAlltoAllv:
+      return flagcxCommOpAlltoAllv;
+    default:
+      return flagcxCommOpAllReduce;
+  }
+}
+
 flagcxInterRankBufferInfoManager::flagcxInterRankBufferInfoManager(
     int totalCount)
     : totalCount_(totalCount) {}
@@ -120,9 +166,9 @@ flagcxInterRankBufferInfoManager::getBufferInfoList(int clusterId, int rank) {
 
 void flagcxInterRankBufferInfoManager::pushBackBufferInfo(
     int clusterId, int rank, int offset, int count, int clusterIdToSend,
-    int isRecv, int isScheduled, int peerRank) {
-  bufferInfos_[clusterId][rank].emplace_back(offset, count, clusterIdToSend,
-                                             isRecv, isScheduled, peerRank);
+    int isRecv, int isScheduled, int peerRank, int loopId) {
+  bufferInfos_[clusterId][rank].emplace_back(
+      offset, count, clusterIdToSend, isRecv, isScheduled, peerRank, loopId);
 }
 
 void flagcxInterRankBufferInfoManager::popFrontBufferInfo(int clusterId,
@@ -151,103 +197,167 @@ void flagcxInterRankBufferInfoManager::printBufferInfo(int step) {
           INFO(FLAGCX_COLL,
                "Initial InterRankBufferInfo: cluster_id = %d, rank = %d, "
                "offset = %d, count = %d, clusterIdToSend = %d, "
-               "isRecv = %d, isScheduled = %d, peerRank = %d",
+               "isRecv = %d, isScheduled = %d, peerRank = %d, loopId = %d",
                clusterIt->first, rankIt->first, bufferIt->offset_,
                bufferIt->count_, bufferIt->clusterIdToSend_, bufferIt->isRecv_,
-               bufferIt->isScheduled_, bufferIt->peerRank_);
+               bufferIt->isScheduled_, bufferIt->peerRank_, bufferIt->loopId_);
         } else if (step == 1) {
           INFO(FLAGCX_COLL,
                "Internal InterRankBufferInfo: cluster_id = %d, rank = %d, "
                "offset = %d, count = %d, clusterIdToSend = %d, "
-               "isRecv = %d, isScheduled = %d, peerRank = %d",
+               "isRecv = %d, isScheduled = %d, peerRank = %d, loopId = %d",
                clusterIt->first, rankIt->first, bufferIt->offset_,
                bufferIt->count_, bufferIt->clusterIdToSend_, bufferIt->isRecv_,
-               bufferIt->isScheduled_, bufferIt->peerRank_);
+               bufferIt->isScheduled_, bufferIt->peerRank_, bufferIt->loopId_);
         } else if (step == 2) {
           INFO(FLAGCX_COLL,
                "Final InterRankBufferInfo: cluster_id = %d, rank = %d, "
                "offset = %d, count = %d, clusterIdToSend = %d, "
-               "isRecv = %d, isScheduled = %d, peerRank = %d",
+               "isRecv = %d, isScheduled = %d, peerRank = %d, loopId = %d",
                clusterIt->first, rankIt->first, bufferIt->offset_,
                bufferIt->count_, bufferIt->clusterIdToSend_, bufferIt->isRecv_,
-               bufferIt->isScheduled_, bufferIt->peerRank_);
+               bufferIt->isScheduled_, bufferIt->peerRank_, bufferIt->loopId_);
         }
       }
     }
   }
 }
 
-flagcxC2cP2pOp::flagcxC2cP2pOp(int rank, int offset, int peerRank,
-                               int peerOffset, int count, int isRecv)
-    : rank_(rank), offset_(offset), peerRank_(peerRank),
-      peerOffset_(peerOffset), count_(count), isRecv_(isRecv) {}
+flagcxC2cP2pOp::flagcxC2cP2pOp(int rank, int peerRank, int offset, int count,
+                               int isRecv)
+    : rank_(rank), peerRank_(peerRank), offset_(offset), count_(count),
+      isRecv_(isRecv) {}
 flagcxC2cP2pOp::~flagcxC2cP2pOp() {}
 
-flagcxResult_t flagcxC2cP2pOp::run(const void *sendbuff, void *recvbuff,
-                                   flagcxDataType_t datatype, flagcxComm_t comm,
-                                   flagcxStream_t stream) {
+flagcxResult_t flagcxC2cP2pOp::run(void *buff, flagcxDataType_t datatype,
+                                   flagcxComm_t comm, flagcxStream_t stream) {
+  INFO(FLAGCX_COLL,
+       "flagcxC2cP2pOp run: rank = %d, peerRank = %d, offset = %d, count = %d, "
+       "isRecv = %d, datatype = %d",
+       comm->rank, peerRank_, offset_, count_, isRecv_, datatype);
+  void *ptr =
+      static_cast<char *>(buff) + offset_ * getFlagcxDataTypeSize(datatype);
   if (isRecv_) {
-    FLAGCXCHECK(flagcxHeteroRecv(
-        static_cast<void *>(static_cast<char *>(recvbuff) +
-                            peerOffset_ * getFlagcxDataTypeSize(datatype)),
-        count_, datatype, peerRank_, comm->hetero_comm, stream));
+    return flagcxHeteroRecv(static_cast<void *>(ptr), count_, datatype,
+                            peerRank_, comm->hetero_comm, stream);
   } else {
-    FLAGCXCHECK(
-        flagcxHeteroSend(const_cast<const void *>(static_cast<void *>(
-                             static_cast<char *>(const_cast<void *>(sendbuff)) +
-                             offset_ * getFlagcxDataTypeSize(datatype))),
-                         count_, datatype, rank_, comm->hetero_comm, stream));
+    return flagcxHeteroSend(static_cast<void *>(ptr), count_, datatype,
+                            peerRank_, comm->hetero_comm, stream);
   }
-  return flagcxSuccess;
 }
 
-flagcxC2cHomoFunc::flagcxC2cHomoFunc(int rank, int rootRank, int offset,
-                                     int count, flagcxCommOp_t commOp)
-    : rank_(rank), rootRank_(rootRank), offset_(offset), count_(count),
-      commOp_(commOp) {}
+flagcxC2cHomoFunc::flagcxC2cHomoFunc(int rootRank, int offset, int count,
+                                     int isHomoInterComm, flagcxCommOp_t commOp)
+    : rootRank_(rootRank), offset_(offset), count_(count),
+      isHomoInterComm_(isHomoInterComm), commOp_(commOp) {}
 
 flagcxC2cHomoFunc::~flagcxC2cHomoFunc() {}
 
 flagcxResult_t flagcxC2cHomoFunc::run(const void *sendbuff, void *recvbuff,
-                                      flagcxDataType_t datatype, int root,
+                                      flagcxDataType_t datatype,
+                                      flagcxRedOp_t redOp, int root,
                                       flagcxComm_t comm,
                                       flagcxStream_t stream) {
-  // case commOp_
-  // cclAdaptor[commOp_](rank, rootRank_, ...);
+  if (isHomoInterComm_ && comm->homoInterMyRank == -1) {
+    return flagcxSuccess;
+  }
+  INFO(
+      FLAGCX_COLL,
+      "flagcxC2cHomoFunc run: rank = %d, rootRank = %d, offset = %d, count = "
+      "%d, "
+      "isHomoInterComm = %d, commOp = %d, datatype = %d, redOp = %d, root = %d",
+      comm->rank, rootRank_, offset_, count_, isHomoInterComm_, commOp_,
+      datatype, redOp, root);
+  switch (commOp_) {
+    case flagcxCommOpReduce:
+      return cclAdaptors[flagcxCCLAdaptorDevice]->reduce(
+          const_cast<const void *>(static_cast<void *>(
+              static_cast<char *>(const_cast<void *>(sendbuff)) +
+              offset_ * getFlagcxDataTypeSize(datatype))),
+          static_cast<void *>(static_cast<char *>(recvbuff) +
+                              offset_ * getFlagcxDataTypeSize(datatype)),
+          count_, datatype, redOp, (rootRank_ == -1) ? root : rootRank_,
+          isHomoInterComm_ ? comm->homoInterComm : comm->homo_comm, stream);
+    case flagcxCommOpAllReduce:
+      return cclAdaptors[flagcxCCLAdaptorDevice]->allReduce(
+          const_cast<const void *>(static_cast<void *>(
+              static_cast<char *>(const_cast<void *>(sendbuff)) +
+              offset_ * getFlagcxDataTypeSize(datatype))),
+          static_cast<void *>(static_cast<char *>(recvbuff) +
+                              offset_ * getFlagcxDataTypeSize(datatype)),
+          count_, datatype, redOp,
+          isHomoInterComm_ ? comm->homoInterComm : comm->homo_comm, stream);
+    case flagcxCommOpReduceScatter:
+      return cclAdaptors[flagcxCCLAdaptorDevice]->reduceScatter(
+          const_cast<const void *>(static_cast<void *>(
+              static_cast<char *>(const_cast<void *>(sendbuff)) +
+              offset_ * getFlagcxDataTypeSize(datatype))),
+          static_cast<void *>(
+              static_cast<char *>(recvbuff) +
+              (offset_ + count_ *
+                             (isHomoInterComm_ ? comm->homoInterMyRank
+                                               : comm->homo_rank) *
+                             getFlagcxDataTypeSize(datatype))),
+          count_, datatype, redOp,
+          isHomoInterComm_ ? comm->homoInterComm : comm->homo_comm, stream);
+    default:
+      return flagcxSuccess;
+  }
   return flagcxSuccess;
 }
 
 flagcxC2cHeteroFunc::flagcxC2cHeteroFunc() {}
 flagcxC2cHeteroFunc::~flagcxC2cHeteroFunc() {}
 
-void flagcxC2cHeteroFunc::addP2pOp(int rank, int offset, int peerRank,
-                                   int peerOffset, int count, int isRecv) {
-  p2pOps_.emplace_back(rank, offset, peerRank, peerOffset, count, isRecv);
+void flagcxC2cHeteroFunc::addP2pOp(int rank, int peerRank, int offset,
+                                   int count, int isRecv) {
+  p2pOps_.emplace_back(rank, peerRank, offset, count, isRecv);
 }
 
-flagcxResult_t flagcxC2cHeteroFunc::run(const void *sendbuff, void *recvbuff,
-                                        flagcxDataType_t datatype,
+flagcxResult_t flagcxC2cHeteroFunc::run(void *buff, flagcxDataType_t datatype,
                                         flagcxComm_t comm,
                                         flagcxStream_t stream) {
   flagcxHeteroGroupStart();
   for (auto op : p2pOps_) {
-    op.run(sendbuff, recvbuff, datatype, comm, stream);
+    FLAGCXCHECK(op.run(buff, datatype, comm, stream));
   }
   flagcxHeteroGroupEnd();
   return flagcxSuccess;
 }
 
-flagcxC2cPlanner::flagcxC2cPlanner(
-    int clusterId, int rank, int homoMyRank, int homoRootRank, int homoRanks,
-    int homoInterMyRank, int homoInterRootRank, int homoInterRanks,
-    int totalCount, flagcxCommOp_t commOp, flagcxRedOp_t redOp,
-    std::vector<std::vector<int>> &clusterInterRankList)
-    : clusterId_(clusterId), rank_(rank), homoMyRank_(homoMyRank),
-      homoRootRank_(homoRootRank), homoRanks_(homoRanks),
-      homoInterMyRank_(homoInterMyRank), homoInterRootRank_(homoInterRootRank),
-      homoInterRanks_(homoInterRanks), totalCount_(totalCount), commOp_(commOp),
-      redOp_(redOp), clusterInterRankList_(clusterInterRankList),
-      interRankBufferInfoManager_(totalCount) {
+flagcxC2cRefreshFunc::flagcxC2cRefreshFunc()
+    : offset_(0), count_(0), totalCount_(0), redOp_(flagcxSum) {}
+flagcxC2cRefreshFunc::flagcxC2cRefreshFunc(int offset, int count,
+                                           int totalCount, flagcxRedOp_t redOp)
+    : offset_(offset), count_(count), totalCount_(totalCount), redOp_(redOp) {}
+flagcxC2cRefreshFunc::~flagcxC2cRefreshFunc() {}
+
+flagcxResult_t flagcxC2cRefreshFunc::run(void *buff, flagcxDataType_t datatype,
+                                         flagcxStream_t stream) {
+  if (redOp_ == flagcxSum) {
+    deviceAdaptor->deviceMemset(buff, 0,
+                                offset_ * getFlagcxDataTypeSize(datatype),
+                                flagcxMemDevice, stream);
+    deviceAdaptor->deviceMemset(
+        static_cast<void *>(static_cast<char *>(buff) +
+                            (offset_ + count_) *
+                                getFlagcxDataTypeSize(datatype)),
+        0, (totalCount_ - offset_ - count_) * getFlagcxDataTypeSize(datatype),
+        flagcxMemDevice, stream);
+  }
+  return flagcxSuccess;
+}
+
+flagcxC2cPlanner::flagcxC2cPlanner(int totalCount, flagcxComm_t comm,
+                                   flagcxCommOp_t commOp, flagcxRedOp_t redOp)
+    : totalCount_(totalCount), comm_(comm), commOp_(commOp), redOp_(redOp),
+      clusterInterRankList_(comm->clusterInterRankList),
+      interRankBufferInfoManager_(totalCount),
+      clusterId_(comm->cluster_ids[comm->rank]), rank_(comm->rank),
+      homoMyRank_(comm->homo_rank), homoRootRank_(comm->homo_root_rank),
+      homoRanks_(comm->homo_ranks), homoInterMyRank_(comm->homoInterMyRank),
+      homoInterRootRank_(comm->homoInterRootRank),
+      homoInterRanks_(comm->homoInterRanks) {
   // if inter ranks in all clusters equal to 1 （单网卡）
   multiNic_ = 0;
   for (size_t i = 0; i < clusterInterRankList_.size(); ++i) {
@@ -260,7 +370,7 @@ flagcxC2cPlanner::flagcxC2cPlanner(
   // if inter ranks in current cluster equal to homo ranks
   eachNicPerRank_ = 1;
   for (size_t i = 0; i < clusterInterRankList_.size(); ++i) {
-    if (clusterInterRankList_[i].size() != homoRanks_) {
+    if (clusterInterRankList_[i].size() != comm->cluster_sizes[i]) {
       eachNicPerRank_ = 0;
       break;
     }
@@ -283,7 +393,7 @@ flagcxResult_t flagcxC2cPlanner::refresh(int isSendRecv) {
           if (i != z) {
             interRankBufferInfoManager_.pushBackBufferInfo(
                 i, clusterInterRankList_[i][j], sendCount * j, finalCount, z, 0,
-                0, -1);
+                0, -1, -1);
           }
         }
       }
@@ -313,62 +423,154 @@ flagcxResult_t flagcxC2cPlanner::refresh(int isSendRecv) {
 
 flagcxResult_t flagcxC2cPlanner::findStrategy() {
   refresh(1);
+  // setup refreshFunc
+  if (!interRankBufferInfoManager_.getBufferInfoList(clusterId_, rank_)
+           .empty()) {
+    auto &buffer =
+        interRankBufferInfoManager_.getBufferInfoList(clusterId_, rank_)
+            .front();
+    refreshFunc_ = flagcxC2cRefreshFunc(buffer.offset_, buffer.count_,
+                                        totalCount_, redOp_);
+  } else {
+    refreshFunc_ = flagcxC2cRefreshFunc(0, 0, totalCount_, redOp_);
+  }
+
   if (multiNic_) {
     // multi-nic
+    // setup preHomoFuncs
     if (eachNicPerRank_) {
       // inter ranks equaling to homo ranks
-      preHomoFuncLoops_ = 1;
-
       // setup preHomoFuncs
+      flagcxCommOp_t preHomoFuncCommOp = getC2cHomoCommOp(commOp_, 0, 0);
+      preHomoFuncLoops_ = 1;
       for (int i = 0; i < preHomoFuncLoops_; ++i) {
-        if (commOp_ == flagcxCommOpAllReduce) {
-          // preHomoFuncList_.emplace_back(...);
-        }
-      }
-
-      // setup heteroFuncs
-      for (int i = 0; i < heteroAndPostHomoFuncLoops_; ++i) {
-        // heteroFuncList_.emplace_back();
-      }
-
-      // setup postHomoFuncs
-      for (int i = 0; i < heteroAndPostHomoFuncLoops_; ++i) {
-        if (commOp_ == flagcxCommOpAllReduce) {
-          // postHomoFuncList_.emplace_back(...);
+        auto &buffer =
+            interRankBufferInfoManager_.getBufferInfoList(clusterId_, rank_)
+                .front();
+        if (preHomoFuncCommOp == flagcxCommOpReduceScatter) {
+          preHomoFuncList_.emplace_back(-1, 0, buffer.count_, 0,
+                                        preHomoFuncCommOp);
         }
       }
     } else {
       // otherwise
-      // setup preHomoFuncs
+      flagcxCommOp_t preHomoFuncCommOp = getC2cHomoCommOp(commOp_, 0, 1);
       preHomoFuncLoops_ = clusterInterRankList_[clusterId_].size();
       for (int i = 0; i < preHomoFuncLoops_; ++i) {
-        if (commOp_ == flagcxCommOpAllReduce) {
-          // preHomoFuncList_.emplace_back(...);
+        auto &buffer = interRankBufferInfoManager_
+                           .getBufferInfoList(
+                               clusterId_, clusterInterRankList_[clusterId_][i])
+                           .front();
+        if (preHomoFuncCommOp == flagcxCommOpReduce) {
+          preHomoFuncList_.emplace_back(
+              clusterInterRankList_[clusterId_][i] - (rank_ - homoMyRank_),
+              buffer.offset_, buffer.count_, 0, preHomoFuncCommOp);
         }
       }
+    }
 
-      // determine hetero send/recv strategies
-      heteroAndPostHomoFuncLoops_ = 1;
-      for (int i = 0; i < heteroAndPostHomoFuncLoops_; ++i) {
-        for (size_t j = 0; j < clusterInterRankList_.size(); ++j) {
-          for (size_t z = j + 1; z < clusterInterRankList_.size(); ++z) {
-            // cluster j send to cluster z, cluster z recv from cluster j
-            for (size_t r1 = 0; r1 < clusterInterRankList_[j].size(); ++r1) {
-              auto &jList = interRankBufferInfoManager_.getBufferInfoList(
-                  j, clusterInterRankList_[j][r1]);
-              for (auto it = jList.begin(); it != jList.end();) {
-                int erased = 0;
-                if (!it->isScheduled_ && !it->isRecv_) {
+    // determine hetero send/recv strategies
+    heteroAndHomoInterFuncLoops_ = 1;
+    for (int i = 0; i < heteroAndHomoInterFuncLoops_; ++i) {
+      for (size_t j = 0; j < clusterInterRankList_.size(); ++j) {
+        for (size_t z = j + 1; z < clusterInterRankList_.size(); ++z) {
+          // cluster j send to cluster z, cluster z recv from cluster j
+          for (size_t r1 = 0; r1 < clusterInterRankList_[j].size(); ++r1) {
+            auto &jList = interRankBufferInfoManager_.getBufferInfoList(
+                j, clusterInterRankList_[j][r1]);
+            for (auto it = jList.begin(); it != jList.end();) {
+              int erased = 0;
+              if (!it->isScheduled_ && !it->isRecv_) {
+                for (size_t r2 = 0; r2 < clusterInterRankList_[z].size();
+                     ++r2) {
+                  if (interRankBufferInfoManager_.checkIfPossibleToPush(
+                          z, clusterInterRankList_[z][r2], it->offset_,
+                          it->count_)) {
+                    interRankBufferInfoManager_.pushBackBufferInfo(
+                        z, clusterInterRankList_[z][r2], it->offset_,
+                        it->count_, 0, 1, 1, clusterInterRankList_[j][r1], i);
+                    it->isScheduled_ = 1;
+                    it->peerRank_ = clusterInterRankList_[z][r2];
+                    it->loopId_ = i;
+                    break;
+                  }
+                }
+                if (!it->isScheduled_) {
+                  int splitCount = 0;
+                  int maxSplitCount = 0;
+                  int pushMode = 0;
+                  int finalPushMode = 0;
+                  int splitRank = clusterInterRankList_[z][0];
                   for (size_t r2 = 0; r2 < clusterInterRankList_[z].size();
                        ++r2) {
+                    if (interRankBufferInfoManager_
+                            .checkIfPossibleToSplitAndPush(
+                                z, clusterInterRankList_[z][r2], it->offset_,
+                                it->count_, &splitCount, &pushMode)) {
+                      if (maxSplitCount < splitCount) {
+                        maxSplitCount = splitCount;
+                        finalPushMode = pushMode;
+                        splitRank = clusterInterRankList_[z][r2];
+                      }
+                    }
+                  }
+                  if (maxSplitCount > 0) {
+                    if (finalPushMode == 0) {
+                      interRankBufferInfoManager_.pushBackBufferInfo(
+                          z, splitRank, it->offset_, maxSplitCount, 0, 1, 1,
+                          clusterInterRankList_[j][r1], i);
+                      interRankBufferInfoManager_.pushBackBufferInfo(
+                          j, clusterInterRankList_[j][r1], it->offset_,
+                          maxSplitCount, it->clusterIdToSend_, 0, 1, splitRank,
+                          i);
+                      interRankBufferInfoManager_.pushBackBufferInfo(
+                          j, clusterInterRankList_[j][r1],
+                          it->offset_ + maxSplitCount,
+                          it->count_ - maxSplitCount, it->clusterIdToSend_, 0,
+                          0, -1, -1);
+                    } else if (finalPushMode == 1) {
+                      interRankBufferInfoManager_.pushBackBufferInfo(
+                          z, splitRank,
+                          it->offset_ + it->count_ - maxSplitCount,
+                          maxSplitCount, 0, 1, 1, clusterInterRankList_[j][r1],
+                          i);
+                      interRankBufferInfoManager_.pushBackBufferInfo(
+                          j, clusterInterRankList_[j][r1],
+                          it->offset_ + it->count_ - maxSplitCount,
+                          maxSplitCount, it->clusterIdToSend_, 0, 1, splitRank,
+                          i);
+                      interRankBufferInfoManager_.pushBackBufferInfo(
+                          j, clusterInterRankList_[j][r1], it->offset_,
+                          it->count_ - maxSplitCount, it->clusterIdToSend_, 0,
+                          0, -1, -1);
+                    }
+                    it = jList.erase(it);
+                    erased = 1;
+                  }
+                }
+              }
+              if (!erased) {
+                it++;
+              }
+            }
+            // cluster z send to cluster j, cluster j recv from cluster z
+            for (size_t r1 = 0; r1 < clusterInterRankList_[z].size(); ++r1) {
+              auto &zList = interRankBufferInfoManager_.getBufferInfoList(
+                  z, clusterInterRankList_[z][r1]);
+              for (auto it = zList.begin(); it != zList.end();) {
+                int erased = 0;
+                if (!it->isScheduled_ && !it->isRecv_) {
+                  for (size_t r2 = 0; r2 < clusterInterRankList_[j].size();
+                       ++r2) {
                     if (interRankBufferInfoManager_.checkIfPossibleToPush(
-                            z, clusterInterRankList_[z][r2], it->offset_,
+                            j, clusterInterRankList_[j][r2], it->offset_,
                             it->count_)) {
                       interRankBufferInfoManager_.pushBackBufferInfo(
-                          z, clusterInterRankList_[z][r2], it->offset_,
-                          it->count_, 0, 1, 1, clusterInterRankList_[j][r1]);
+                          j, clusterInterRankList_[j][r2], it->offset_,
+                          it->count_, 0, 1, 1, clusterInterRankList_[z][r1], i);
                       it->isScheduled_ = 1;
-                      it->peerRank_ = clusterInterRankList_[z][r2];
+                      it->peerRank_ = clusterInterRankList_[j][r2];
+                      it->loopId_ = i;
                       break;
                     }
                   }
@@ -377,51 +579,51 @@ flagcxResult_t flagcxC2cPlanner::findStrategy() {
                     int maxSplitCount = 0;
                     int pushMode = 0;
                     int finalPushMode = 0;
-                    int splitRank = clusterInterRankList_[z][0];
-                    for (size_t r2 = 0; r2 < clusterInterRankList_[z].size();
+                    int splitRank = clusterInterRankList_[j][0];
+                    for (size_t r2 = 0; r2 < clusterInterRankList_[j].size();
                          ++r2) {
                       if (interRankBufferInfoManager_
                               .checkIfPossibleToSplitAndPush(
-                                  z, clusterInterRankList_[z][r2], it->offset_,
+                                  j, clusterInterRankList_[j][r2], it->offset_,
                                   it->count_, &splitCount, &pushMode)) {
                         if (maxSplitCount < splitCount) {
                           maxSplitCount = splitCount;
                           finalPushMode = pushMode;
-                          splitRank = clusterInterRankList_[z][r2];
+                          splitRank = clusterInterRankList_[j][r2];
                         }
                       }
                     }
                     if (maxSplitCount > 0) {
                       if (finalPushMode == 0) {
                         interRankBufferInfoManager_.pushBackBufferInfo(
-                            z, splitRank, it->offset_, maxSplitCount, 0, 1, 1,
-                            clusterInterRankList_[j][r1]);
+                            j, splitRank, it->offset_, maxSplitCount, 0, 1, 1,
+                            clusterInterRankList_[z][r1], i);
                         interRankBufferInfoManager_.pushBackBufferInfo(
-                            j, clusterInterRankList_[j][r1], it->offset_,
+                            z, clusterInterRankList_[z][r1], it->offset_,
                             maxSplitCount, it->clusterIdToSend_, 0, 1,
-                            splitRank);
+                            splitRank, i);
                         interRankBufferInfoManager_.pushBackBufferInfo(
-                            j, clusterInterRankList_[j][r1],
+                            z, clusterInterRankList_[z][r1],
                             it->offset_ + maxSplitCount,
                             it->count_ - maxSplitCount, it->clusterIdToSend_, 0,
-                            0, -1);
+                            0, -1, -1);
                       } else if (finalPushMode == 1) {
                         interRankBufferInfoManager_.pushBackBufferInfo(
-                            z, splitRank,
+                            j, splitRank,
                             it->offset_ + it->count_ - maxSplitCount,
                             maxSplitCount, 0, 1, 1,
-                            clusterInterRankList_[j][r1]);
+                            clusterInterRankList_[z][r1], i);
                         interRankBufferInfoManager_.pushBackBufferInfo(
-                            j, clusterInterRankList_[j][r1],
+                            z, clusterInterRankList_[z][r1],
                             it->offset_ + it->count_ - maxSplitCount,
                             maxSplitCount, it->clusterIdToSend_, 0, 1,
-                            splitRank);
+                            splitRank, i);
                         interRankBufferInfoManager_.pushBackBufferInfo(
-                            j, clusterInterRankList_[j][r1], it->offset_,
+                            z, clusterInterRankList_[z][r1], it->offset_,
                             it->count_ - maxSplitCount, it->clusterIdToSend_, 0,
-                            0, -1);
+                            0, -1, -1);
                       }
-                      it = jList.erase(it);
+                      it = zList.erase(it);
                       erased = 1;
                     }
                   }
@@ -430,143 +632,142 @@ flagcxResult_t flagcxC2cPlanner::findStrategy() {
                   it++;
                 }
               }
-              // cluster z send to cluster j, cluster j recv from cluster z
-              for (size_t r1 = 0; r1 < clusterInterRankList_[z].size(); ++r1) {
-                auto &zList = interRankBufferInfoManager_.getBufferInfoList(
-                    z, clusterInterRankList_[z][r1]);
-                for (auto it = zList.begin(); it != zList.end();) {
-                  int erased = 0;
-                  if (!it->isScheduled_ && !it->isRecv_) {
-                    for (size_t r2 = 0; r2 < clusterInterRankList_[j].size();
-                         ++r2) {
-                      if (interRankBufferInfoManager_.checkIfPossibleToPush(
-                              j, clusterInterRankList_[j][r2], it->offset_,
-                              it->count_)) {
-                        interRankBufferInfoManager_.pushBackBufferInfo(
-                            j, clusterInterRankList_[j][r2], it->offset_,
-                            it->count_, 0, 1, 1, clusterInterRankList_[z][r1]);
-                        it->isScheduled_ = 1;
-                        it->peerRank_ = clusterInterRankList_[j][r2];
-                        break;
-                      }
-                    }
-                    if (!it->isScheduled_) {
-                      int splitCount = 0;
-                      int maxSplitCount = 0;
-                      int pushMode = 0;
-                      int finalPushMode = 0;
-                      int splitRank = clusterInterRankList_[j][0];
-                      for (size_t r2 = 0; r2 < clusterInterRankList_[j].size();
-                           ++r2) {
-                        if (interRankBufferInfoManager_
-                                .checkIfPossibleToSplitAndPush(
-                                    j, clusterInterRankList_[j][r2],
-                                    it->offset_, it->count_, &splitCount,
-                                    &pushMode)) {
-                          if (maxSplitCount < splitCount) {
-                            maxSplitCount = splitCount;
-                            finalPushMode = pushMode;
-                            splitRank = clusterInterRankList_[j][r2];
-                          }
-                        }
-                      }
-                      if (maxSplitCount > 0) {
-                        if (finalPushMode == 0) {
-                          interRankBufferInfoManager_.pushBackBufferInfo(
-                              j, splitRank, it->offset_, maxSplitCount, 0, 1, 1,
-                              clusterInterRankList_[z][r1]);
-                          interRankBufferInfoManager_.pushBackBufferInfo(
-                              z, clusterInterRankList_[z][r1], it->offset_,
-                              maxSplitCount, it->clusterIdToSend_, 0, 1,
-                              splitRank);
-                          interRankBufferInfoManager_.pushBackBufferInfo(
-                              z, clusterInterRankList_[z][r1],
-                              it->offset_ + maxSplitCount,
-                              it->count_ - maxSplitCount, it->clusterIdToSend_,
-                              0, 0, -1);
-                        } else if (finalPushMode == 1) {
-                          interRankBufferInfoManager_.pushBackBufferInfo(
-                              j, splitRank,
-                              it->offset_ + it->count_ - maxSplitCount,
-                              maxSplitCount, 0, 1, 1,
-                              clusterInterRankList_[z][r1]);
-                          interRankBufferInfoManager_.pushBackBufferInfo(
-                              z, clusterInterRankList_[z][r1],
-                              it->offset_ + it->count_ - maxSplitCount,
-                              maxSplitCount, it->clusterIdToSend_, 0, 1,
-                              splitRank);
-                          interRankBufferInfoManager_.pushBackBufferInfo(
-                              z, clusterInterRankList_[z][r1], it->offset_,
-                              it->count_ - maxSplitCount, it->clusterIdToSend_,
-                              0, 0, -1);
-                        }
-                        it = zList.erase(it);
-                        erased = 1;
-                      }
-                    }
-                  }
-                  if (!erased) {
-                    it++;
-                  }
-                }
+            }
+          }
+        }
+      }
+
+      int scheduleCompleted = 1;
+      for (size_t j = 0; j < clusterInterRankList_.size(); ++j) {
+        for (size_t z = 0; z < clusterInterRankList_[j].size(); ++z) {
+          if (!interRankBufferInfoManager_.checkIsScheduled(
+                  j, clusterInterRankList_[j][z])) {
+            scheduleCompleted = 0;
+            break;
+          }
+        }
+        if (!scheduleCompleted) {
+          break;
+        }
+      }
+
+      if (!scheduleCompleted) {
+        refresh(0);
+        heteroAndHomoInterFuncLoops_ += 1;
+      }
+    }
+    interRankBufferInfoManager_.printBufferInfo(2);
+
+    // setup heteroFuncs
+    for (int i = 0; i < heteroAndHomoInterFuncLoops_; ++i) {
+      flagcxC2cHeteroFunc heteroFunc = flagcxC2cHeteroFunc();
+      for (size_t j = 0; j < clusterInterRankList_.size(); ++j) {
+        for (size_t z = 0; z < clusterInterRankList_[j].size(); ++z) {
+          if (rank_ == clusterInterRankList_[j][z]) {
+            auto &rankList =
+                interRankBufferInfoManager_.getBufferInfoList(j, rank_);
+            for (auto it = rankList.begin(); it != rankList.end(); ++it) {
+              if (it->loopId_ == i) {
+                heteroFunc.addP2pOp(rank_, it->peerRank_, it->offset_,
+                                    it->count_, it->isRecv_);
               }
             }
           }
         }
-
-        int scheduleCompleted = 1;
-        for (size_t j = 0; j < clusterInterRankList_.size(); ++j) {
-          for (size_t z = 0; z < clusterInterRankList_[j].size(); ++z) {
-            if (!interRankBufferInfoManager_.checkIsScheduled(
-                    j, clusterInterRankList_[j][z])) {
-              scheduleCompleted = 0;
-              break;
-            }
-          }
-          if (!scheduleCompleted) {
-            break;
-          }
-        }
-
-        if (!scheduleCompleted) {
-          refresh(0);
-          heteroAndPostHomoFuncLoops_ += 1;
-        }
       }
-      interRankBufferInfoManager_.printBufferInfo(2);
+      heteroFuncList_.push_back(std::move(heteroFunc));
+    }
 
-      // setup heteroFuncs
-      for (int i = 0; i < heteroAndPostHomoFuncLoops_; ++i) {
-        // heteroFuncList_.emplace_back();
+    // setup homoInterFuncs
+    flagcxCommOp_t homoInterFuncCommOp = getC2cHomoCommOp(commOp_, 1, 1);
+    for (int i = 0; i < heteroAndHomoInterFuncLoops_; ++i) {
+      if (homoInterFuncCommOp == flagcxCommOpAllReduce) {
+        homoInterFuncList_.emplace_back(-1, 0, totalCount_, 1,
+                                        homoInterFuncCommOp);
       }
+    }
 
-      // setup postHomoFuncs
-      for (int i = 0; i < heteroAndPostHomoFuncLoops_; ++i) {
-        if (commOp_ == flagcxCommOpAllReduce) {
-          // postHomoFuncList_.emplace_back(...);
-        }
+    // setup postHomoFuncs
+    flagcxCommOp_t postHomoFuncCommOp = getC2cHomoCommOp(commOp_, 2, 1);
+    if (eachNicPerRank_) {
+      postHomoFuncLoops_ = 0;
+    } else {
+      postHomoFuncLoops_ = 1;
+    }
+    for (int i = 0; i < postHomoFuncLoops_; ++i) {
+      if (postHomoFuncCommOp == flagcxCommOpAllReduce) {
+        postHomoFuncList_.emplace_back(-1, 0, totalCount_, 0,
+                                       postHomoFuncCommOp);
       }
     }
   } else {
     // single-nic
-    preHomoFuncLoops_ = 1;
-
     // setup preHomoFuncs
+    flagcxCommOp_t preHomoFuncCommOp = getC2cHomoCommOp(commOp_, 0, 2);
+    preHomoFuncLoops_ = 1;
     for (int i = 0; i < preHomoFuncLoops_; ++i) {
-      if (commOp_ == flagcxCommOpAllReduce) {
-        // preHomoFuncList_.emplace_back(...);
+      auto &buffer = interRankBufferInfoManager_
+                         .getBufferInfoList(
+                             clusterId_, clusterInterRankList_[clusterId_][i])
+                         .front();
+      if (preHomoFuncCommOp == flagcxCommOpReduce) {
+        preHomoFuncList_.emplace_back(
+            clusterInterRankList_[clusterId_][i] - (rank_ - homoMyRank_),
+            buffer.offset_, buffer.count_, 0, preHomoFuncCommOp);
       }
     }
 
     // setup heteroFuncs
-    for (int i = 0; i < heteroAndPostHomoFuncLoops_; ++i) {
-      // heteroFuncList_.emplace_back();
+    heteroAndHomoInterFuncLoops_ = 1;
+    for (int i = 0; i < heteroAndHomoInterFuncLoops_; ++i) {
+      flagcxC2cHeteroFunc heteroFunc = flagcxC2cHeteroFunc();
+      int cid = 0;
+      for (size_t j = 0; j < clusterInterRankList_.size(); ++j) {
+        if (clusterId_ == j) {
+          continue;
+        }
+        int homoRankToRecvFromCluster =
+            (comm_->globalrank2homorank[clusterInterRankList_[clusterId_][0]] -
+             cid - 1 + homoRanks_) %
+            homoRanks_;
+        if (homoMyRank_ == homoRankToRecvFromCluster) {
+          heteroFunc.addP2pOp(rank_, clusterInterRankList_[j][0], 0,
+                              totalCount_, 1);
+        }
+        int homoRankToSendToCluster =
+            (comm_->globalrank2homorank[clusterInterRankList_[j][0]] - cid - 1 +
+             comm_->cluster_sizes[j]) %
+            comm_->cluster_sizes[j];
+        int globalRankToSendToCluster =
+            homoRankToSendToCluster -
+            comm_->globalrank2homorank[clusterInterRankList_[j][0]] +
+            clusterInterRankList_[j][0];
+        if (homoMyRank_ ==
+            comm_->globalrank2homorank[clusterInterRankList_[clusterId_][0]]) {
+          heteroFunc.addP2pOp(rank_, globalRankToSendToCluster, 0, totalCount_,
+                              0);
+        }
+        cid += 1;
+      }
+      heteroFuncList_.push_back(std::move(heteroFunc));
+    }
+
+    // setup homoInterFuncs
+    flagcxCommOp_t homoInterFuncCommOp = getC2cHomoCommOp(commOp_, 1, 2);
+    for (int i = 0; i < heteroAndHomoInterFuncLoops_; ++i) {
+      if (homoInterFuncCommOp == flagcxCommOpAllReduce) {
+        homoInterFuncList_.emplace_back(-1, 0, totalCount_, 1,
+                                        homoInterFuncCommOp);
+      }
     }
 
     // setup postHomoFuncs
-    for (int i = 0; i < heteroAndPostHomoFuncLoops_; ++i) {
-      if (commOp_ == flagcxCommOpAllReduce) {
-        // postHomoFuncList_.emplace_back(...);
+    flagcxCommOp_t postHomoFuncCommOp = getC2cHomoCommOp(commOp_, 2, 2);
+    postHomoFuncLoops_ = 1;
+    for (int i = 0; i < postHomoFuncLoops_; ++i) {
+      if (postHomoFuncCommOp == flagcxCommOpAllReduce) {
+        postHomoFuncList_.emplace_back(-1, 0, totalCount_, 0,
+                                       postHomoFuncCommOp);
       }
     }
   }
@@ -575,7 +776,42 @@ flagcxResult_t flagcxC2cPlanner::findStrategy() {
 
 flagcxResult_t flagcxC2cPlanner::execute(const void *sendbuff, void *recvbuff,
                                          flagcxDataType_t datatype, int root,
-                                         flagcxComm_t comm,
                                          flagcxStream_t stream) {
+  // execute preHomoFuncs
+  for (int i = 0; i < preHomoFuncLoops_; ++i) {
+    preHomoFuncList_[i].run(sendbuff, recvbuff, datatype, redOp_, root, comm_,
+                            stream);
+  }
+
+  for (int i = 0; i < heteroAndHomoInterFuncLoops_; ++i) {
+    // execute refreshFunc
+    refreshFunc_.run(recvbuff, datatype, stream);
+
+    // TODO: use stream wait rather than stream sync to avoid cpu blocking
+    // deviceAdaptor->streamSynchronize(stream);
+
+    // execute heteroFuncs
+    heteroFuncList_[i].run(recvbuff, datatype, comm_, stream);
+
+    // TODO: use stream wait rather than stream sync to avoid cpu blocking
+    deviceAdaptor->streamSynchronize(stream);
+
+    // execute homoInterFuncs
+    homoInterFuncList_[i].run(recvbuff, recvbuff, datatype, redOp_, root, comm_,
+                              stream);
+  }
+
+  // execute postHomoFuns
+  // we assume that there may be multiple post homo-funcs,
+  // but now postHomoFuncLoops_ can only be set to 0 and 1
+  for (int i = 0; i < postHomoFuncLoops_; ++i) {
+    // for single-nic mode, there is not need to call refresh func
+    if (multiNic_) {
+      refreshFunc_.run(recvbuff, datatype, stream);
+    }
+    postHomoFuncList_[i].run(recvbuff, recvbuff, datatype, redOp_, root, comm_,
+                             stream);
+  }
+
   return flagcxSuccess;
 }

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -1140,144 +1140,17 @@ flagcxResult_t flagcxAllReduce(const void *sendbuff, void *recvbuff,
            timers[TIMER_COLL_FREE] / 1e6, timers[TIMER_COLL_MEM_D2H] / 1e6,
            timers[TIMER_COLL_MEM_H2D] / 1e6, timers[TIMER_COLL_COMM] / 1e6);
     } else {
-      // Experimental for multi-nic support
-      // Construct flagcxC2cPlanner and find corresponding strategy
-      flagcxC2cPlanner planner(
-          comm->cluster_ids[comm->rank], comm->rank, comm->homo_rank,
-          comm->homo_root_rank, comm->homo_ranks, comm->homoInterMyRank,
-          comm->homoInterRootRank, comm->homoInterRanks, count,
-          flagcxCommOpAllReduce, op, comm->clusterInterRankList);
-      planner.findStrategy();
-
       // op validation
       if (op != flagcxSum && op != flagcxMax && op != flagcxMin) {
         WARN("Unsupported reduction operation %d", op);
         return flagcxInvalidArgument;
       }
 
-      if (comm->support_multi_nic < 0) {
-        // intra-cluster reduce
-        FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->reduce(
-            sendbuff, recvbuff, count, datatype, op, comm->homo_inter_rank,
-            comm->homo_comm, stream));
-
-        if (comm->homo_inter_rank != comm->homo_rank) {
-          if (op == flagcxSum) {
-            deviceAdaptor->deviceMemset(recvbuff, 0,
-                                        count * getFlagcxDataTypeSize(datatype),
-                                        flagcxMemDevice, stream);
-          }
-        }
-
-        // TODO: use stream wait rather than stream sync to avoid cpu blocking
-        deviceAdaptor->streamSynchronize(stream);
-
-        // inter-cluster sendrecv
-        int cid = 0;
-        flagcxGroupStart(comm);
-        for (int i = 0; i < comm->nclusters; ++i) {
-          if (comm->cluster_ids[comm->rank] == i)
-            continue;
-          // TODO: better to add an assertation ensuring that comm->ncluster <=
-          // comm->homo_ranks
-          int homo_rank_to_recv_from_cluster =
-              (comm->homo_inter_rank - cid - 1 + comm->homo_ranks) %
-              comm->homo_ranks;
-          if (comm->homo_rank == homo_rank_to_recv_from_cluster) {
-            FLAGCXCHECK(flagcxHeteroRecv(recvbuff, count, datatype,
-                                         comm->cluster_inter_ranks[i],
-                                         comm->hetero_comm, stream));
-          }
-          int homo_rank_to_send_to_cluster =
-              (comm->globalrank2homorank[comm->cluster_inter_ranks[i]] - cid -
-               1 + comm->cluster_sizes[i]) %
-              comm->cluster_sizes[i];
-          int global_rank_to_send_to_cluster =
-              homo_rank_to_send_to_cluster -
-              comm->globalrank2homorank[comm->cluster_inter_ranks[i]] +
-              comm->cluster_inter_ranks[i];
-          if (comm->homo_inter_rank == comm->homo_rank) {
-            FLAGCXCHECK(flagcxHeteroSend(recvbuff, count, datatype,
-                                         global_rank_to_send_to_cluster,
-                                         comm->hetero_comm, stream));
-          }
-          cid += 1;
-        }
-        flagcxGroupEnd(comm);
-
-        // TODO: use stream wait rather than stream sync to avoid cpu blocking
-        deviceAdaptor->streamSynchronize(stream);
-
-        // intra-cluster allreduce
-        FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->allReduce(
-            recvbuff, recvbuff, count, datatype, op, comm->homo_comm, stream));
-      } else {
-        // ensure that all clusters have same sizes
-        for (int i = 0; i < comm->nclusters; ++i) {
-          assert(comm->cluster_sizes[0] == comm->cluster_sizes[i]);
-        }
-
-        size_t recvcount = count / comm->homo_ranks;
-        size_t offset_step = recvcount * getFlagcxDataTypeSize(datatype);
-
-        // intra-cluster reducescatter
-        FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->reduceScatter(
-            sendbuff,
-            static_cast<void *>(static_cast<char *>(recvbuff) +
-                                offset_step * comm->homo_rank),
-            recvcount, datatype, op, comm->homo_comm, stream));
-
-        if (op == flagcxSum) {
-          deviceAdaptor->deviceMemset(recvbuff, 0,
-                                      offset_step * comm->homo_rank,
-                                      flagcxMemDevice, stream);
-          deviceAdaptor->deviceMemset(
-              static_cast<void *>(static_cast<char *>(recvbuff) +
-                                  offset_step * (comm->homo_rank + 1)),
-              0, offset_step * (comm->homo_ranks - comm->homo_rank - 1),
-              flagcxMemDevice, stream);
-        }
-
-        // TODO: use stream wait rather than stream sync to avoid cpu blocking
-        deviceAdaptor->streamSynchronize(stream);
-
-        // inter-cluster sendrecv
-        int cid = 0;
-        int start = 0;
-        flagcxGroupStart(comm);
-        for (int i = 0; i < comm->nclusters; ++i) {
-          if (comm->cluster_ids[comm->rank] == i) {
-            start += comm->cluster_sizes[i];
-            continue;
-          } else {
-            cid = (comm->cluster_ids[comm->rank] - i + comm->nclusters) %
-                  comm->nclusters;
-          }
-          int recv_from_cluster_homo_rank =
-              (comm->homo_rank - cid + comm->homo_ranks) % comm->homo_ranks;
-          FLAGCXCHECK(flagcxHeteroRecv(
-              static_cast<void *>(static_cast<char *>(recvbuff) +
-                                  offset_step * recv_from_cluster_homo_rank),
-              recvcount, datatype, recv_from_cluster_homo_rank + start,
-              comm->hetero_comm, stream));
-          int send_to_cluster_homo_rank =
-              (comm->homo_rank + cid) % comm->homo_ranks;
-          FLAGCXCHECK(flagcxHeteroSend(
-              static_cast<void *>(static_cast<char *>(recvbuff) +
-                                  offset_step * comm->homo_rank),
-              recvcount, datatype, send_to_cluster_homo_rank + start,
-              comm->hetero_comm, stream));
-          start += comm->cluster_sizes[i];
-        }
-        flagcxGroupEnd(comm);
-
-        // TODO: use stream wait rather than stream sync to avoid cpu blocking
-        deviceAdaptor->streamSynchronize(stream);
-
-        // intra-cluster allreduce
-        FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->allReduce(
-            recvbuff, recvbuff, count, datatype, op, comm->homo_comm, stream));
-      }
+      // Experimental for multi-nic support
+      // Construct flagcxC2cPlanner and find corresponding strategy
+      flagcxC2cPlanner planner(count, comm, flagcxCommOpAllReduce, op);
+      planner.findStrategy();
+      planner.execute(sendbuff, recvbuff, datatype, -1, stream);
     }
   }
   return flagcxSuccess;


### PR DESCRIPTION
This PR introduces an original multi-nic C2C AllReduce algorithm implemented in class flagcxC2cPlanner, handling the following cases:
1. multi-nic with each nic per rank (e.g. cluster 0: 8gpu-8nic; cluster 1: 8gpu-8nic)
2. multi-nic normal (e.g. cluster 0: 8gpu-4nic cluster 1: 8gpu-2nic)
3. single-nic (e.g. cluster 0: 8gpu-1nic; cluster 1: 8gpu-1nic)