### PR TITLE
change GetNicDistance logic to avoid APUs sharing a nic

### DIFF
--- a/flagcx/core/topo.cc
+++ b/flagcx/core/topo.cc
@@ -521,7 +521,8 @@ flagcxResult_t flagcxGetLocalNetFromGpu(int apu, int *dev,
 }
 
 flagcxResult_t flagcxGetNicDistance(struct flagcxTopoServer *topoServer,
-                                    int rank, int *nicDistance) {
+                                    int rank,
+                                    struct flagcxNicDistance *distInfo) {
   int netDev;
   FLAGCXCHECK(flagcxTopoGetLocalNet(topoServer, rank, &netDev));
   int apuIdx;
@@ -530,7 +531,8 @@ flagcxResult_t flagcxGetNicDistance(struct flagcxTopoServer *topoServer,
       topoServer->nodes[APU].nodes[apuIdx].paths[NET];
   for (int i = 0; i < topoServer->nodes[NET].count; i++) {
     if (topoServer->nodes[NET].nodes[i].net.dev == netDev) {
-      *nicDistance = paths[i].type; // distance represented by path type
+      distInfo->distance = paths[i].type;
+      distInfo->netDev = netDev;
       return flagcxSuccess;
     }
   }

--- a/flagcx/core/topo.h
+++ b/flagcx/core/topo.h
@@ -270,6 +270,11 @@ struct flatTopoServer {
   struct flatTopoNodeSet nodes[FLAGCX_TOPO_NODE_TYPES];
 };
 
+struct flagcxNicDistance {
+  int distance;
+  int netDev;
+};
+
 flagcxResult_t flagcxTopoGetNode(struct flagcxTopoServer *topoServer,
                                  struct flagcxTopoNode **node, int type,
                                  uint64_t id);
@@ -320,7 +325,8 @@ flagcxResult_t flagcxTopoGetCompCap(struct flagcxTopoServer *topoServer,
                                     int *ccMin, int *ccMax);
 
 flagcxResult_t flagcxGetNicDistance(struct flagcxTopoServer *topoServer,
-                                    int rank, int *nicDistance);
+                                    int rank,
+                                    struct flagcxNicDistance *distInfo);
 
 // static flagcxResult_t flagcxTopoIdToIndex(struct flagcxTopoServer*
 // serverTopo, int type, int64_t id, int* index) {


### PR DESCRIPTION
- modified logic for getting nic distance for each rank, avoiding the scenario in which multiple gpus share the same nic