### PR TITLE
Add caching mechanism for C2C plan search

### DIFF
--- a/flagcx/core/c2c_algo.cc
+++ b/flagcx/core/c2c_algo.cc
@@ -1,5 +1,13 @@
 #include "c2c_algo.h"
 
+int getC2cCommPatternHash(int count, flagcxCommOp_t commOp,
+                          flagcxRedOp_t redOp) {
+  std::size_t h1 = std::hash<int>()(count);
+  std::size_t h2 = std::hash<int>()(commOp);
+  std::size_t h3 = std::hash<int>()(redOp);
+  return static_cast<int>(h1 ^ (h2 << 1) ^ (h3 << 2));
+}
+
 // homoType: 0, pre; 1, homoInter; 2, post,
 // mode: 0, multiNic+eachNicPerRank; 1, normal; 2, single-nic
 // For now, we only support AllReduce operator mapping

--- a/flagcx/core/c2c_algo.cc
+++ b/flagcx/core/c2c_algo.cc
@@ -810,6 +810,14 @@ flagcxResult_t flagcxC2cPlanner::findStrategy() {
 flagcxResult_t flagcxC2cPlanner::execute(const void *sendbuff, void *recvbuff,
                                          flagcxDataType_t datatype, int root,
                                          flagcxStream_t stream) {
+  // redOp validation
+  if (redOp_ < flagcxNumRedOps) {
+    if (redOp_ != flagcxSum && redOp_ != flagcxMax && redOp_ != flagcxMin) {
+      WARN("Unsupported reduction operation %d", redOp_);
+      return flagcxInvalidArgument;
+    }
+  }
+
   // execute preHomoFuncs
   for (int i = 0; i < preHomoFuncLoops_; ++i) {
     preHomoFuncList_[i].run(sendbuff, recvbuff, datatype, redOp_, root, comm_,

--- a/flagcx/core/c2c_algo.cc
+++ b/flagcx/core/c2c_algo.cc
@@ -39,7 +39,14 @@ flagcxCommOp_t getC2cHomoCommOp(flagcxCommOp_t commOp, int homoType, int mode) {
         case 1:
           return flagcxCommOpAllReduce;
         case 2:
-          return flagcxCommOpAllReduce;
+          switch (mode) {
+            case 0:
+              return flagcxCommNonOp;
+            case 1:
+              return flagcxCommOpAllReduce;
+            case 2:
+              return flagcxCommNonOp;
+          }
       }
     case flagcxCommOpAllGather:
       return flagcxCommOpAllGather;
@@ -50,7 +57,7 @@ flagcxCommOp_t getC2cHomoCommOp(flagcxCommOp_t commOp, int homoType, int mode) {
     case flagcxCommOpAlltoAllv:
       return flagcxCommOpAlltoAllv;
     default:
-      return flagcxCommOpAllReduce;
+      return flagcxCommNonOp;
   }
 }
 
@@ -300,18 +307,13 @@ flagcxResult_t flagcxC2cHomoFunc::run(const void *sendbuff, void *recvbuff,
           const_cast<const void *>(static_cast<void *>(
               static_cast<char *>(const_cast<void *>(sendbuff)) +
               sendOffset_ * getFlagcxDataTypeSize(datatype))),
-          static_cast<void *>(
-              static_cast<char *>(recvbuff) +
-              (recvOffset_ + count_ *
-                                 (isHomoInterComm_ ? comm->homoInterMyRank
-                                                   : comm->homo_rank) *
-                                 getFlagcxDataTypeSize(datatype))),
+          static_cast<void *>(static_cast<char *>(recvbuff) +
+                              recvOffset_ * getFlagcxDataTypeSize(datatype)),
           count_, datatype, redOp,
           isHomoInterComm_ ? comm->homoInterComm : comm->homo_comm, stream);
     default:
       return flagcxSuccess;
   }
-  return flagcxSuccess;
 }
 
 flagcxC2cHeteroFunc::flagcxC2cHeteroFunc() {}
@@ -368,6 +370,12 @@ flagcxC2cPlanner::flagcxC2cPlanner(int totalCount, int recvCount,
       homoRanks_(comm->homo_ranks), homoInterMyRank_(comm->homoInterMyRank),
       homoInterRootRank_(comm->homoInterRootRank),
       homoInterRanks_(comm->homoInterRanks) {
+  // calculate clusterOffset_
+  clusterOffset_ = 0;
+  for (int i = 0; i < clusterId_; ++i) {
+    clusterOffset_ += comm_->cluster_sizes[i];
+  }
+
   // if inter ranks in all clusters equal to 1 （single-nic）
   multiNic_ = 0;
   for (size_t i = 0; i < clusterInterRankList_.size(); ++i) {
@@ -393,14 +401,9 @@ flagcxC2cPlanner::flagcxC2cPlanner(int totalCount, int recvCount,
       break;
     }
   }
-
-  // TODO: init scratch buffer
-  scratchBuffer_ = nullptr;
 }
 
-flagcxC2cPlanner::~flagcxC2cPlanner() {
-  // TODO: destroy scratch buffer
-}
+flagcxC2cPlanner::~flagcxC2cPlanner() {}
 
 flagcxResult_t flagcxC2cPlanner::refresh(int isSendRecv) {
   if (isSendRecv) {
@@ -641,8 +644,8 @@ flagcxResult_t flagcxC2cPlanner::findStrategy() {
             interRankBufferInfoManager_.getBufferInfoList(clusterId_, rank_)
                 .front();
         if (preHomoFuncCommOp == flagcxCommOpReduceScatter) {
-          preHomoFuncList_.emplace_back(-1, 0, 0, buffer.count_, 0,
-                                        preHomoFuncCommOp);
+          preHomoFuncList_.emplace_back(-1, 0, homoMyRank_ * buffer.count_,
+                                        buffer.count_, 0, preHomoFuncCommOp);
         }
       }
     } else {
@@ -711,24 +714,27 @@ flagcxResult_t flagcxC2cPlanner::findStrategy() {
     }
 
     // setup homoInterFuncs
-    flagcxCommOp_t homoInterFuncCommOp = getC2cHomoCommOp(commOp_, 1, 1);
+    flagcxCommOp_t homoInterFuncCommOp = eachNicPerRank_
+                                             ? getC2cHomoCommOp(commOp_, 1, 0)
+                                             : getC2cHomoCommOp(commOp_, 1, 1);
     for (int i = 0; i < heteroAndHomoInterFuncLoops_; ++i) {
       if (homoInterFuncCommOp == flagcxCommOpAllReduce) {
-        homoInterFuncList_.emplace_back(-1, 0, 0, recvCount_, 1,
+        homoInterFuncList_.emplace_back(-1, 0, 0, totalCount_, 1,
                                         homoInterFuncCommOp);
       }
     }
 
     // setup postHomoFuncs
-    flagcxCommOp_t postHomoFuncCommOp = getC2cHomoCommOp(commOp_, 2, 1);
-    if (eachNicPerRank_) {
-      postHomoFuncLoops_ = 0;
-    } else {
-      postHomoFuncLoops_ = 1;
-    }
+    flagcxCommOp_t postHomoFuncCommOp = eachNicPerRank_
+                                            ? getC2cHomoCommOp(commOp_, 2, 0)
+                                            : getC2cHomoCommOp(commOp_, 2, 1);
+    postHomoFuncLoops_ = (postHomoFuncCommOp == flagcxCommNonOp) ? 0 : 1;
     for (int i = 0; i < postHomoFuncLoops_; ++i) {
       if (postHomoFuncCommOp == flagcxCommOpAllReduce) {
         postHomoFuncList_.emplace_back(-1, 0, 0, recvCount_, 0,
+                                       postHomoFuncCommOp);
+      } else if (postHomoFuncCommOp == flagcxCommOpReduceScatter) {
+        postHomoFuncList_.emplace_back(-1, clusterOffset_, 0, recvCount_, 0,
                                        postHomoFuncCommOp);
       }
     }
@@ -789,17 +795,18 @@ flagcxResult_t flagcxC2cPlanner::findStrategy() {
     flagcxCommOp_t homoInterFuncCommOp = getC2cHomoCommOp(commOp_, 1, 2);
     for (int i = 0; i < heteroAndHomoInterFuncLoops_; ++i) {
       if (homoInterFuncCommOp == flagcxCommOpAllReduce) {
-        homoInterFuncList_.emplace_back(-1, 0, 0, recvCount_, 1,
+        homoInterFuncList_.emplace_back(-1, 0, 0, totalCount_,
+                                        0, // use homo comm instead
                                         homoInterFuncCommOp);
       }
     }
 
     // setup postHomoFuncs
     flagcxCommOp_t postHomoFuncCommOp = getC2cHomoCommOp(commOp_, 2, 2);
-    postHomoFuncLoops_ = 1;
+    postHomoFuncLoops_ = postHomoFuncCommOp == flagcxCommNonOp ? 0 : 1;
     for (int i = 0; i < postHomoFuncLoops_; ++i) {
-      if (postHomoFuncCommOp == flagcxCommOpAllReduce) {
-        postHomoFuncList_.emplace_back(-1, 0, 0, recvCount_, 0,
+      if (postHomoFuncCommOp == flagcxCommOpReduceScatter) {
+        postHomoFuncList_.emplace_back(-1, clusterOffset_, 0, recvCount_, 0,
                                        postHomoFuncCommOp);
       }
     }
@@ -811,7 +818,7 @@ flagcxResult_t flagcxC2cPlanner::execute(const void *sendbuff, void *recvbuff,
                                          flagcxDataType_t datatype, int root,
                                          flagcxStream_t stream) {
   // redOp validation
-  if (redOp_ < flagcxNumRedOps) {
+  if (redOp_ != flagcxRedNonOp) {
     if (redOp_ != flagcxSum && redOp_ != flagcxMax && redOp_ != flagcxMin) {
       WARN("Unsupported reduction operation %d", redOp_);
       return flagcxInvalidArgument;

--- a/flagcx/core/c2c_algo.h
+++ b/flagcx/core/c2c_algo.h
@@ -202,6 +202,7 @@ private:
   int homoInterMyRank_;
   int homoInterRootRank_;
   int homoInterRanks_;
+  int clusterOffset_;
   int multiNic_;
   int eachNicPerRank_;
   int preHomoFuncLoops_;            // number of loops for preHomoFunc

--- a/flagcx/core/c2c_algo.h
+++ b/flagcx/core/c2c_algo.h
@@ -6,9 +6,56 @@
 #include "flagcx.h"
 #include "group.h"
 #include "param.h"
+#include <iostream>
 #include <list>
 #include <map>
 #include <string>
+#include <unordered_map>
+
+int getC2cCommPatternHash(int count, flagcxCommOp_t commOp,
+                          flagcxRedOp_t redOp);
+
+template <typename Key, typename Value>
+class flagcxLRUCache {
+public:
+  flagcxLRUCache(size_t capacity) : capacity_(capacity) {}
+
+  bool get(const Key &key, Value &value) {
+    auto it = cacheMap_.find(key);
+    if (it == cacheMap_.end())
+      return false;
+
+    // Move the accessed item to the front of the list
+    cacheItems_.splice(cacheItems_.begin(), cacheItems_, it->second);
+    value = it->second->second;
+    return true;
+  }
+
+  void put(const Key &key, const Value &value) {
+    auto it = cacheMap_.find(key);
+    if (it != cacheMap_.end()) {
+      // Update and move to front
+      it->second->second = value;
+      cacheItems_.splice(cacheItems_.begin(), cacheItems_, it->second);
+    } else {
+      // Insert new element
+      if (cacheItems_.size() == capacity_) {
+        // Remove least recently used item
+        auto lru = cacheItems_.back();
+        cacheMap_.erase(lru.first);
+        cacheItems_.pop_back();
+      }
+      cacheItems_.emplace_front(key, value);
+      cacheMap_[key] = cacheItems_.begin();
+    }
+  }
+
+private:
+  size_t capacity_;
+  std::list<std::pair<Key, Value>> cacheItems_;
+  std::unordered_map<Key, typename std::list<std::pair<Key, Value>>::iterator>
+      cacheMap_;
+};
 
 // homoType: 0, pre; 1, homoInter; 2, post,
 // mode: 0, multiNic+eachNicPerRank; 1, normal; 2, single-nic
@@ -36,6 +83,9 @@ class flagcxInterRankBufferInfoManager {
 public:
   flagcxInterRankBufferInfoManager(int totalCount);
   ~flagcxInterRankBufferInfoManager();
+  flagcxInterRankBufferInfoManager() = default;
+  flagcxInterRankBufferInfoManager(const flagcxInterRankBufferInfoManager &) =
+      default;
 
   bool checkIfPossibleToPush(int clusterId, int rank, int offset, int count);
   bool checkIfPossibleToSplitAndPush(int clusterId, int rank, int offset,
@@ -123,6 +173,9 @@ public:
   flagcxC2cPlanner(int totalCount, int recvCount, flagcxComm_t comm,
                    flagcxCommOp_t commOp, flagcxRedOp_t redOp);
   ~flagcxC2cPlanner();
+  flagcxC2cPlanner() = default;
+  flagcxC2cPlanner(const flagcxC2cPlanner &) = default;
+  flagcxC2cPlanner &operator=(const flagcxC2cPlanner &) = default;
 
   flagcxResult_t refresh(
       int isSendRecv); // 0: refresh recv info only; 1: refresh send+recv info
@@ -139,16 +192,16 @@ private:
   flagcxComm_t comm_;
   flagcxCommOp_t commOp_;
   flagcxRedOp_t redOp_;
-  std::vector<std::vector<int>> &clusterInterRankList_;
+  std::vector<std::vector<int>> clusterInterRankList_;
   flagcxInterRankBufferInfoManager interRankBufferInfoManager_;
-  int &clusterId_;
-  int &rank_; // global rank
-  int &homoMyRank_;
-  int &homoRootRank_;
-  int &homoRanks_;
-  int &homoInterMyRank_;
-  int &homoInterRootRank_;
-  int &homoInterRanks_;
+  int clusterId_;
+  int rank_; // global rank
+  int homoMyRank_;
+  int homoRootRank_;
+  int homoRanks_;
+  int homoInterMyRank_;
+  int homoInterRootRank_;
+  int homoInterRanks_;
   int multiNic_;
   int eachNicPerRank_;
   int preHomoFuncLoops_;            // number of loops for preHomoFunc

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -1172,12 +1172,6 @@ flagcxResult_t flagcxAllReduce(const void *sendbuff, void *recvbuff,
            timers[TIMER_COLL_FREE] / 1e6, timers[TIMER_COLL_MEM_D2H] / 1e6,
            timers[TIMER_COLL_MEM_H2D] / 1e6, timers[TIMER_COLL_COMM] / 1e6);
     } else {
-      // op validation
-      if (op != flagcxSum && op != flagcxMax && op != flagcxMin) {
-        WARN("Unsupported reduction operation %d", op);
-        return flagcxInvalidArgument;
-      }
-
       // Experimental for multi-nic support
       // Construct flagcxC2cPlanner and find corresponding strategy
       flagcxC2cPlanner planner;
@@ -1190,7 +1184,7 @@ flagcxResult_t flagcxAllReduce(const void *sendbuff, void *recvbuff,
              count, flagcxCommOpAllReduce, op, hashValue);
         planner =
             flagcxC2cPlanner(count, count, comm, flagcxCommOpAllReduce, op);
-        planner.findStrategy();
+        FLAGCXCHECK(planner.findStrategy());
         planCache.put(hashValue, planner);
       } else {
         INFO(FLAGCX_COLL,
@@ -1198,7 +1192,7 @@ flagcxResult_t flagcxAllReduce(const void *sendbuff, void *recvbuff,
              "(count, commOp, redOp) = (%ld, %d, %d), hashValue = %d",
              count, flagcxCommOpAllReduce, op, hashValue);
       }
-      planner.execute(sendbuff, recvbuff, datatype, -1, stream);
+      FLAGCXCHECK(planner.execute(sendbuff, recvbuff, datatype, -1, stream));
     }
   }
   return flagcxSuccess;

--- a/flagcx/include/flagcx.h
+++ b/flagcx/include/flagcx.h
@@ -50,6 +50,7 @@ typedef enum {
   flagcxMax = 2,
   flagcxMin = 3,
   flagcxAvg = 4,
+  flagcxRedNonOp = 5,
   flagcxNumRedOps = 5,
   flagcxMaxRedOp = 0x7fffffff >> (32 - 8 * sizeof(flagcxRedOp_dummy_t))
 } flagcxRedOp_t;
@@ -69,6 +70,7 @@ typedef enum {
   flagcxCommOpReduceScatter = 8,
   flagcxCommOpAlltoAll = 9,
   flagcxCommOpAlltoAllv = 10,
+  flagcxCommNonOp = 11,
   flagcxNumCommOps = 11
 } flagcxCommOp_t;
 


### PR DESCRIPTION
This PR introduces a caching mechanism to eliminate redundant search workloads generated by the flagcxC2cPlanner class for a given communication pattern defined by (count, commOp, redOp)