### PR TITLE
support generic multi-nic C2C ReduceScatter algorithm

### DIFF
--- a/flagcx/core/c2c_algo.cc
+++ b/flagcx/core/c2c_algo.cc
@@ -1,11 +1,13 @@
 #include "c2c_algo.h"
+#include <cstdint>
 
-int getC2cCommPatternHash(int count, flagcxCommOp_t commOp,
-                          flagcxRedOp_t redOp) {
-  std::size_t h1 = std::hash<int>()(count);
-  std::size_t h2 = std::hash<int>()(commOp);
-  std::size_t h3 = std::hash<int>()(redOp);
-  return static_cast<int>(h1 ^ (h2 << 1) ^ (h3 << 2));
+size_t getC2cCommPatternHash(size_t count, flagcxCommOp_t commOp,
+                             flagcxRedOp_t redOp, flagcxComm_t comm) {
+  std::size_t h1 = std::hash<size_t>()(count);
+  std::size_t h2 = std::hash<size_t>()(commOp);
+  std::size_t h3 = std::hash<size_t>()(redOp);
+  std::size_t h4 = std::hash<size_t>()((size_t)((uintptr_t)comm));
+  return static_cast<size_t>(h1 ^ (h2 << 1) ^ (h3 << 2) ^ (h4 << 3));
 }
 
 // homoType: 0, pre; 1, homoInter; 2, post,

--- a/flagcx/core/c2c_algo.cc
+++ b/flagcx/core/c2c_algo.cc
@@ -41,23 +41,37 @@ flagcxCommOp_t getC2cHomoCommOp(flagcxCommOp_t commOp, int homoType, int mode) {
         case 2:
           switch (mode) {
             case 0:
-              return flagcxCommNonOp;
+              return flagcxCommNoOp;
             case 1:
               return flagcxCommOpAllReduce;
             case 2:
-              return flagcxCommNonOp;
+              return flagcxCommNoOp;
           }
       }
     case flagcxCommOpAllGather:
       return flagcxCommOpAllGather;
     case flagcxCommOpReduceScatter:
-      return flagcxCommOpReduceScatter;
+      switch (homoType) {
+        case 0:
+          switch (mode) {
+            case 0:
+              return flagcxCommOpReduceScatter;
+            case 1:
+              return flagcxCommOpReduce;
+            case 2:
+              return flagcxCommOpReduce;
+          }
+        case 1:
+          return flagcxCommOpAllReduce;
+        case 2:
+          return flagcxCommOpReduceScatter;
+      }
     case flagcxCommOpAlltoAll:
       return flagcxCommOpAlltoAll;
     case flagcxCommOpAlltoAllv:
       return flagcxCommOpAlltoAllv;
     default:
-      return flagcxCommNonOp;
+      return flagcxCommNoOp;
   }
 }
 
@@ -344,6 +358,9 @@ flagcxC2cRefreshFunc::~flagcxC2cRefreshFunc() {}
 
 flagcxResult_t flagcxC2cRefreshFunc::run(void *buff, flagcxDataType_t datatype,
                                          flagcxStream_t stream) {
+  TRACE_CALL("flagcxC2cRefreshFunc run: offset = %d, count = %d, "
+             "datatype = %d, redOp = %d",
+             offset_, count_, datatype, redOp_);
   if (redOp_ == flagcxSum) {
     deviceAdaptor->deviceMemset(buff, 0,
                                 offset_ * getFlagcxDataTypeSize(datatype),
@@ -728,14 +745,14 @@ flagcxResult_t flagcxC2cPlanner::findStrategy() {
     flagcxCommOp_t postHomoFuncCommOp = eachNicPerRank_
                                             ? getC2cHomoCommOp(commOp_, 2, 0)
                                             : getC2cHomoCommOp(commOp_, 2, 1);
-    postHomoFuncLoops_ = (postHomoFuncCommOp == flagcxCommNonOp) ? 0 : 1;
+    postHomoFuncLoops_ = (postHomoFuncCommOp == flagcxCommNoOp) ? 0 : 1;
     for (int i = 0; i < postHomoFuncLoops_; ++i) {
       if (postHomoFuncCommOp == flagcxCommOpAllReduce) {
         postHomoFuncList_.emplace_back(-1, 0, 0, recvCount_, 0,
                                        postHomoFuncCommOp);
       } else if (postHomoFuncCommOp == flagcxCommOpReduceScatter) {
-        postHomoFuncList_.emplace_back(-1, clusterOffset_, 0, recvCount_, 0,
-                                       postHomoFuncCommOp);
+        postHomoFuncList_.emplace_back(-1, clusterOffset_ * recvCount_, 0,
+                                       recvCount_, 0, postHomoFuncCommOp);
       }
     }
   } else {
@@ -803,11 +820,11 @@ flagcxResult_t flagcxC2cPlanner::findStrategy() {
 
     // setup postHomoFuncs
     flagcxCommOp_t postHomoFuncCommOp = getC2cHomoCommOp(commOp_, 2, 2);
-    postHomoFuncLoops_ = postHomoFuncCommOp == flagcxCommNonOp ? 0 : 1;
+    postHomoFuncLoops_ = postHomoFuncCommOp == flagcxCommNoOp ? 0 : 1;
     for (int i = 0; i < postHomoFuncLoops_; ++i) {
       if (postHomoFuncCommOp == flagcxCommOpReduceScatter) {
-        postHomoFuncList_.emplace_back(-1, clusterOffset_, 0, recvCount_, 0,
-                                       postHomoFuncCommOp);
+        postHomoFuncList_.emplace_back(-1, clusterOffset_ * recvCount_, 0,
+                                       recvCount_, 0, postHomoFuncCommOp);
       }
     }
   }
@@ -818,47 +835,63 @@ flagcxResult_t flagcxC2cPlanner::execute(const void *sendbuff, void *recvbuff,
                                          flagcxDataType_t datatype, int root,
                                          flagcxStream_t stream) {
   // redOp validation
-  if (redOp_ != flagcxRedNonOp) {
+  if (redOp_ != flagcxRedNoOp) {
     if (redOp_ != flagcxSum && redOp_ != flagcxMax && redOp_ != flagcxMin) {
       WARN("Unsupported reduction operation %d", redOp_);
       return flagcxInvalidArgument;
     }
   }
 
+  // init scratch buffer if needed
+  if (commOp_ == flagcxCommOpReduceScatter) {
+    deviceAdaptor->deviceMalloc(&scratchBuffer_,
+                                totalCount_ * getFlagcxDataTypeSize(datatype),
+                                flagcxMemDevice, stream);
+  } else {
+    scratchBuffer_ = nullptr;
+  }
+
+  void *recvTmpBuff = (scratchBuffer_ == nullptr) ? recvbuff : scratchBuffer_;
+
   // execute preHomoFuncs
   for (int i = 0; i < preHomoFuncLoops_; ++i) {
-    preHomoFuncList_[i].run(sendbuff, recvbuff, datatype, redOp_, root, comm_,
-                            stream);
+    preHomoFuncList_[i].run(sendbuff, recvTmpBuff, datatype, redOp_, root,
+                            comm_, stream);
   }
 
   for (int i = 0; i < heteroAndHomoInterFuncLoops_; ++i) {
     // execute refreshFunc
-    refreshFunc_.run(recvbuff, datatype, stream);
+    refreshFunc_.run(recvTmpBuff, datatype, stream);
 
     // TODO: use stream wait rather than stream sync to avoid cpu blocking
     // deviceAdaptor->streamSynchronize(stream);
 
     // execute heteroFuncs
-    heteroFuncList_[i].run(recvbuff, datatype, comm_, stream);
+    heteroFuncList_[i].run(recvTmpBuff, datatype, comm_, stream);
 
     // TODO: use stream wait rather than stream sync to avoid cpu blocking
     deviceAdaptor->streamSynchronize(stream);
 
     // execute homoInterFuncs
-    homoInterFuncList_[i].run(recvbuff, recvbuff, datatype, redOp_, root, comm_,
-                              stream);
+    homoInterFuncList_[i].run(recvTmpBuff, recvTmpBuff, datatype, redOp_, root,
+                              comm_, stream);
   }
 
   // execute postHomoFuns
   // we assume that there may be multiple post homo-funcs,
   // but now postHomoFuncLoops_ can only be set to 0 and 1
   for (int i = 0; i < postHomoFuncLoops_; ++i) {
-    // for single-nic mode, there is not need to call refresh func
-    if (multiNic_) {
-      refreshFunc_.run(recvbuff, datatype, stream);
-    }
-    postHomoFuncList_[i].run(recvbuff, recvbuff, datatype, redOp_, root, comm_,
-                             stream);
+    // execute refresh func
+    refreshFunc_.run(recvTmpBuff, datatype, stream);
+
+    // execute postHomoFunc
+    postHomoFuncList_[i].run(recvTmpBuff, recvbuff, datatype, redOp_, root,
+                             comm_, stream);
+  }
+
+  // free scratch buffer if needed
+  if (scratchBuffer_ != nullptr) {
+    deviceAdaptor->deviceFree(scratchBuffer_, flagcxMemDevice, stream);
   }
 
   return flagcxSuccess;

--- a/flagcx/core/c2c_algo.h
+++ b/flagcx/core/c2c_algo.h
@@ -12,8 +12,8 @@
 #include <string>
 #include <unordered_map>
 
-int getC2cCommPatternHash(int count, flagcxCommOp_t commOp,
-                          flagcxRedOp_t redOp);
+size_t getC2cCommPatternHash(size_t count, flagcxCommOp_t commOp,
+                             flagcxRedOp_t redOp, flagcxComm_t comm);
 
 template <typename Key, typename Value>
 class flagcxLRUCache {

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -1271,156 +1271,28 @@ flagcxResult_t flagcxReduceScatter(const void *sendbuff, void *recvbuff,
            timers[TIMER_COLL_FREE] / 1e6, timers[TIMER_COLL_MEM_D2H] / 1e6,
            timers[TIMER_COLL_MEM_H2D] / 1e6, timers[TIMER_COLL_COMM] / 1e6);
     } else {
-      // op validation
-      if (op != flagcxSum && op != flagcxMax && op != flagcxMin) {
-        WARN("Unsupported reduction operation %d", op);
-        return flagcxInvalidArgument;
-      }
-
-      // create a tmp buffer
-      void *tmpbuff;
-      size_t count = comm->nranks * recvcount;
-      size_t size = count * getFlagcxDataTypeSize(datatype);
-      deviceAdaptor->deviceMalloc(&tmpbuff, size, flagcxMemDevice, stream);
-
-      if (comm->support_multi_nic < 0) {
-        // intra-cluster reduce
-        FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->reduce(
-            sendbuff, tmpbuff, count, datatype, op, comm->homo_inter_rank,
-            comm->homo_comm, stream));
-
-        if (comm->homo_inter_rank != comm->homo_rank) {
-          if (op == flagcxSum) {
-            deviceAdaptor->deviceMemset(tmpbuff, 0, size, flagcxMemDevice,
-                                        stream);
-          }
-        }
-
-        // TODO: use stream wait rather than stream sync to avoid cpu blocking
-        deviceAdaptor->streamSynchronize(stream);
-
-        // inter-cluster sendrecv
-        int cid = 0;
-        flagcxGroupStart(comm);
-        for (int i = 0; i < comm->nclusters; ++i) {
-          if (comm->cluster_ids[comm->rank] == i)
-            continue;
-          // TODO: better to add an assertation ensuring that comm->ncluster <=
-          // comm->homo_ranks
-          int homo_rank_to_recv_from_cluster =
-              (comm->homo_inter_rank - cid - 1 + comm->homo_ranks) %
-              comm->homo_ranks;
-          if (comm->homo_rank == homo_rank_to_recv_from_cluster) {
-            FLAGCXCHECK(flagcxHeteroRecv(tmpbuff, count, datatype,
-                                         comm->cluster_inter_ranks[i],
-                                         comm->hetero_comm, stream));
-          }
-          int homo_rank_to_send_to_cluster =
-              (comm->globalrank2homorank[comm->cluster_inter_ranks[i]] - cid -
-               1 + comm->cluster_sizes[i]) %
-              comm->cluster_sizes[i];
-          int global_rank_to_send_to_cluster =
-              homo_rank_to_send_to_cluster -
-              comm->globalrank2homorank[comm->cluster_inter_ranks[i]] +
-              comm->cluster_inter_ranks[i];
-          if (comm->homo_inter_rank == comm->homo_rank) {
-            FLAGCXCHECK(flagcxHeteroSend(tmpbuff, count, datatype,
-                                         global_rank_to_send_to_cluster,
-                                         comm->hetero_comm, stream));
-          }
-          cid += 1;
-        }
-        flagcxGroupEnd(comm);
-
-        // TODO: use stream wait rather than stream sync to avoid cpu blocking
-        deviceAdaptor->streamSynchronize(stream);
-
-        // intra-cluster reducescatter
-        int offset = 0;
-        for (int i = 0; i < comm->cluster_ids[comm->rank]; ++i) {
-          offset += comm->cluster_sizes[i];
-        }
-        FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->reduceScatter(
-            static_cast<const void *>(static_cast<const char *>(tmpbuff) +
-                                      offset * recvcount *
-                                          getFlagcxDataTypeSize(datatype)),
-            recvbuff, recvcount, datatype, op, comm->homo_comm, stream));
+      // Experimental for multi-nic support
+      // Construct flagcxC2cPlanner and find corresponding strategy
+      flagcxC2cPlanner planner;
+      auto hashValue =
+          getC2cCommPatternHash(recvcount, flagcxCommOpReduceScatter, op);
+      if (!planCache.get(hashValue, planner)) {
+        INFO(FLAGCX_COLL,
+             "No available plan is found, create a new one with "
+             "communication pattern "
+             "(count, commOp, redOp) = (%ld, %d, %d), hashValue = %d",
+             recvcount, flagcxCommOpReduceScatter, op, hashValue);
+        planner = flagcxC2cPlanner(comm->nranks * recvcount, recvcount, comm,
+                                   flagcxCommOpReduceScatter, op);
+        FLAGCXCHECK(planner.findStrategy());
+        planCache.put(hashValue, planner);
       } else {
-        // ensure that all clusters have same sizes
-        for (int i = 0; i < comm->nclusters; ++i) {
-          assert(comm->cluster_sizes[0] == comm->cluster_sizes[i]);
-        }
-
-        size_t tmpcount = count / comm->homo_ranks;
-        size_t offset_step = tmpcount * getFlagcxDataTypeSize(datatype);
-
-        // intra-cluster reducescatter
-        FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->reduceScatter(
-            sendbuff,
-            static_cast<void *>(static_cast<char *>(tmpbuff) +
-                                offset_step * comm->homo_rank),
-            tmpcount, datatype, op, comm->homo_comm, stream));
-
-        if (op == flagcxSum) {
-          deviceAdaptor->deviceMemset(tmpbuff, 0, offset_step * comm->homo_rank,
-                                      flagcxMemDevice, stream);
-          deviceAdaptor->deviceMemset(
-              static_cast<void *>(static_cast<char *>(tmpbuff) +
-                                  offset_step * (comm->homo_rank + 1)),
-              0, offset_step * (comm->homo_ranks - comm->homo_rank - 1),
-              flagcxMemDevice, stream);
-        }
-
-        // TODO: use stream wait rather than stream sync to avoid cpu blocking
-        deviceAdaptor->streamSynchronize(stream);
-
-        // inter-cluster sendrecv
-        int cid = 0;
-        int start = 0;
-        flagcxGroupStart(comm);
-        for (int i = 0; i < comm->nclusters; ++i) {
-          if (comm->cluster_ids[comm->rank] == i) {
-            start += comm->cluster_sizes[i];
-            continue;
-          } else {
-            cid = (comm->cluster_ids[comm->rank] - i + comm->nclusters) %
-                  comm->nclusters;
-          }
-          int recv_from_cluster_homo_rank =
-              (comm->homo_rank - cid + comm->homo_ranks) % comm->homo_ranks;
-          FLAGCXCHECK(flagcxHeteroRecv(
-              static_cast<void *>(static_cast<char *>(tmpbuff) +
-                                  offset_step * recv_from_cluster_homo_rank),
-              tmpcount, datatype, recv_from_cluster_homo_rank + start,
-              comm->hetero_comm, stream));
-          int send_to_cluster_homo_rank =
-              (comm->homo_rank + cid) % comm->homo_ranks;
-          FLAGCXCHECK(flagcxHeteroSend(
-              static_cast<void *>(static_cast<char *>(tmpbuff) +
-                                  offset_step * comm->homo_rank),
-              tmpcount, datatype, send_to_cluster_homo_rank + start,
-              comm->hetero_comm, stream));
-          start += comm->cluster_sizes[i];
-        }
-        flagcxGroupEnd(comm);
-
-        // TODO: use stream wait rather than stream sync to avoid cpu blocking
-        deviceAdaptor->streamSynchronize(stream);
-
-        // intra-cluster reducescatter
-        int offset = 0;
-        for (int i = 0; i < comm->cluster_ids[comm->rank]; ++i) {
-          offset += comm->cluster_sizes[i];
-        }
-
-        FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->reduceScatter(
-            static_cast<const void *>(static_cast<const char *>(tmpbuff) +
-                                      offset * recvcount *
-                                          getFlagcxDataTypeSize(datatype)),
-            recvbuff, recvcount, datatype, op, comm->homo_comm, stream));
+        INFO(FLAGCX_COLL,
+             "Found available planwith communication pattern "
+             "(count, commOp, redOp) = (%ld, %d, %d), hashValue = %d",
+             recvcount, flagcxCommOpReduceScatter, op, hashValue);
       }
-
-      deviceAdaptor->deviceFree(tmpbuff, flagcxMemDevice, stream);
+      FLAGCXCHECK(planner.execute(sendbuff, recvbuff, datatype, -1, stream));
     }
   }
   return flagcxSuccess;

--- a/flagcx/include/flagcx.h
+++ b/flagcx/include/flagcx.h
@@ -50,7 +50,7 @@ typedef enum {
   flagcxMax = 2,
   flagcxMin = 3,
   flagcxAvg = 4,
-  flagcxRedNonOp = 5,
+  flagcxRedNoOp = 5,
   flagcxNumRedOps = 5,
   flagcxMaxRedOp = 0x7fffffff >> (32 - 8 * sizeof(flagcxRedOp_dummy_t))
 } flagcxRedOp_t;
@@ -70,7 +70,7 @@ typedef enum {
   flagcxCommOpReduceScatter = 8,
   flagcxCommOpAlltoAll = 9,
   flagcxCommOpAlltoAllv = 10,
-  flagcxCommNonOp = 11,
+  flagcxCommNoOp = 11,
   flagcxNumCommOps = 11
 } flagcxCommOp_t;
 


### PR DESCRIPTION
This PR introduces an original multi-nic C2C ReduceScatter algorithm implemented in the flagcxC2cPlanner class, handling the following cases:

multi-nic with each nic per rank (e.g. cluster 0: 8gpu-8nic; cluster 1: 8gpu-8nic)
multi-nic normal (e.g. cluster 0: 8gpu-4nic cluster 1: 8gpu-2nic)
single-nic (e.g. cluster 0: 8gpu-1nic; cluster 1: 8gpu-1nic)