### PR TITLE
Move AlltoAll/v ops into the flagcxPlanner workflow

### DIFF
--- a/flagcx/core/c2c_algo.h
+++ b/flagcx/core/c2c_algo.h
@@ -132,7 +132,9 @@ public:
 
   flagcxResult_t run(const void *sendbuff, void *recvbuff,
                      flagcxDataType_t datatype, flagcxRedOp_t redOp, int root,
-                     flagcxComm_t comm, flagcxStream_t stream);
+                     flagcxComm_t comm, flagcxStream_t stream,
+                     size_t *sendCounts = nullptr, size_t *sDispls = nullptr,
+                     size_t *recvCounts = nullptr, size_t *rDispls = nullptr);
 
   int rootRank_;
   int sendOffset_;
@@ -149,8 +151,8 @@ public:
   ~flagcxC2cHeteroFunc();
 
   void addP2pOp(int rank, int peerRank, int offset, int count, int isRecv);
-  flagcxResult_t run(void *buff, flagcxDataType_t datatype, flagcxComm_t comm,
-                     flagcxStream_t stream);
+  flagcxResult_t run(void *sendbuff, void *recvbuff, flagcxDataType_t datatype,
+                     flagcxComm_t comm, flagcxStream_t stream);
 
 private:
   std::vector<flagcxC2cP2pOp> p2pOps_;
@@ -188,10 +190,12 @@ public:
   flagcxResult_t searchHeteroSendRecvOps(int searchMethod,
                                          int loopId); // 0: DFS; 1: BFS
   flagcxResult_t findStrategy();
-  flagcxResult_t findStrategyBroadcast(int root);
   flagcxResult_t execute(const void *sendbuff, void *recvbuff,
                          flagcxDataType_t datatype, int root,
-                         flagcxStream_t stream);
+                         flagcxStream_t stream, size_t *sendCounts = nullptr,
+                         size_t *sDispls = nullptr,
+                         size_t *recvCounts = nullptr,
+                         size_t *rDispls = nullptr);
 
 private:
   int sendCount_;
@@ -200,6 +204,10 @@ private:
   flagcxComm_t comm_;
   flagcxCommOp_t commOp_;
   flagcxRedOp_t redOp_;
+  size_t *sendCounts_; // used for alltoallv, etc.
+  size_t *sDispls_;
+  size_t *recvCounts_;
+  size_t *rDispls_;
   std::vector<std::vector<int>> clusterInterRankList_;
   int clusterId_;
   int rank_; // global rank
@@ -219,6 +227,7 @@ private:
   int heteroAndHomoInterFuncLoops_; // number of loops for heteroFunc and
                                     // homoInterFunc
   int postHomoFuncLoops_;           // number of loops for postHomoFunc
+  int strategyFound_;
   flagcxInterRankBufferInfoManager interRankBufferInfoManager_;
   flagcxC2cRefreshFunc refreshFunc_;
   std::vector<flagcxC2cHomoFunc> preHomoFuncList_;

--- a/test/perf/test_allgather.cpp
+++ b/test/perf/test_allgather.cpp
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
     devHandle->deviceMemcpy(sendbuff, hello, size / totalProcs,
                             flagcxMemcpyHostToDevice, NULL);
 
-    if ((proc == 0 || proc == totalProcs - 1) == 0 && print_buffer) {
+    if ((proc == 0 || proc == totalProcs - 1) && print_buffer) {
       printf("sendbuff = ");
       printf("%f\n", ((float *)hello)[0]);
     }

--- a/test/perf/test_alltoall.cpp
+++ b/test/perf/test_alltoall.cpp
@@ -1,114 +1,121 @@
-#include "mpi.h"
 #include "flagcx.h"
+#include "mpi.h"
 #include "tools.h"
-#include <iostream>
 #include <cstring>
+#include <iostream>
 
 #define DATATYPE flagcxFloat
 
-int main(int argc, char *argv[]){
-    parser args(argc, argv);
-    size_t min_bytes = args.getMinBytes();
-    size_t max_bytes = args.getMaxBytes();
-    int step_factor = args.getStepFactor();
-    int num_warmup_iters = args.getWarmupIters();
-    int num_iters = args.getTestIters();
-    int print_buffer = args.isPrintBuffer();
+int main(int argc, char *argv[]) {
+  parser args(argc, argv);
+  size_t min_bytes = args.getMinBytes();
+  size_t max_bytes = args.getMaxBytes();
+  int step_factor = args.getStepFactor();
+  int num_warmup_iters = args.getWarmupIters();
+  int num_iters = args.getTestIters();
+  int print_buffer = args.isPrintBuffer();
 
-    int totalProcs, proc; 
-    MPI_Init(&argc, &argv);
-    MPI_Comm_size(MPI_COMM_WORLD, &totalProcs);
-    MPI_Comm_rank(MPI_COMM_WORLD, &proc);
-    printf("I am %d of %d\n", proc, totalProcs);
-    
-    flagcxHandlerGroup_t handler;
-    flagcxHandleInit(&handler);
-    flagcxUniqueId_t& uniqueId = handler->uniqueId;
-    flagcxComm_t& comm = handler->comm;
-    flagcxDeviceHandle_t& devHandle = handler->devHandle;
+  int totalProcs, proc;
+  MPI_Init(&argc, &argv);
+  MPI_Comm_size(MPI_COMM_WORLD, &totalProcs);
+  MPI_Comm_rank(MPI_COMM_WORLD, &proc);
+  printf("I am %d of %d\n", proc, totalProcs);
 
-    int nGpu;
-    devHandle->getDeviceCount(&nGpu);
-    devHandle->setDevice(proc % nGpu);
+  flagcxHandlerGroup_t handler;
+  flagcxHandleInit(&handler);
+  flagcxUniqueId_t &uniqueId = handler->uniqueId;
+  flagcxComm_t &comm = handler->comm;
+  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
-    if (proc == 0)
-        flagcxGetUniqueId(&uniqueId);
-    MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, MPI_COMM_WORLD);
-    MPI_Barrier(MPI_COMM_WORLD);
-    
-    flagcxCommInitRank(&comm, totalProcs, uniqueId, proc);
+  int nGpu;
+  devHandle->getDeviceCount(&nGpu);
+  devHandle->setDevice(proc % nGpu);
 
-    flagcxStream_t stream;
-    devHandle->streamCreate(&stream);
+  if (proc == 0)
+    flagcxGetUniqueId(&uniqueId);
+  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
+            MPI_COMM_WORLD);
+  MPI_Barrier(MPI_COMM_WORLD);
 
-    void *sendbuff, *recvbuff, *hello;
-    size_t count;
-    timer tim;
-    
-    for (size_t size = min_bytes; size <= max_bytes; size *= step_factor) {
-        count = size / sizeof(float);
-        devHandle->deviceMalloc(&sendbuff, size, flagcxMemDevice, NULL);
-        devHandle->deviceMalloc(&recvbuff, size, flagcxMemDevice, NULL);
-        devHandle->deviceMalloc(&hello, size, flagcxMemHost, NULL);
-        devHandle->deviceMemset(hello, 0, size, flagcxMemHost, NULL);
+  flagcxCommInitRank(&comm, totalProcs, uniqueId, proc);
 
-        for (int i = 0; i < totalProcs; i++) {
-	     ((float *)hello)[i * (count / totalProcs)] = 10 * proc + i;
-        }
+  flagcxStream_t stream;
+  devHandle->streamCreate(&stream);
 
-        devHandle->deviceMemcpy(sendbuff, hello, size, flagcxMemcpyHostToDevice, NULL);
-    
-        if (proc == 0 && print_buffer) {
-            printf("sendbuff = ");
-        	for (int i = 0; i < totalProcs; i++) {
-                printf("%f ", ((float *)hello)[i * (count / totalProcs)]);
-            }
-            printf("\n");
-        }
+  void *sendbuff, *recvbuff, *hello;
+  size_t count;
+  timer tim;
 
-        for(int i=0;i<num_warmup_iters;i++){
-            flagcxAlltoAll(sendbuff, recvbuff, count / totalProcs, DATATYPE, comm, stream);
-        }
-        devHandle->streamSynchronize(stream);
+  for (size_t size = min_bytes; size <= max_bytes; size *= step_factor) {
+    count = size / sizeof(float);
+    devHandle->deviceMalloc(&sendbuff, size, flagcxMemDevice, NULL);
+    devHandle->deviceMalloc(&recvbuff, size, flagcxMemDevice, NULL);
+    devHandle->deviceMalloc(&hello, size, flagcxMemHost, NULL);
+    devHandle->deviceMemset(hello, 0, size, flagcxMemHost, NULL);
 
-        MPI_Barrier(MPI_COMM_WORLD);
-
-        tim.reset();
-        for(int i=0;i<num_iters;i++){
-            flagcxAlltoAll(sendbuff, recvbuff, count / totalProcs, DATATYPE, comm, stream);
-        }
-        devHandle->streamSynchronize(stream);
-
-        double elapsed_time = tim.elapsed() / num_iters;
-        double base_bw = (double)(size) / 1.0E9 / elapsed_time;
-        double alg_bw = base_bw;
-        double factor = ((double)(totalProcs - 1))/((double)(totalProcs));
-        double bus_bw = base_bw * factor;
-        if (proc == 0) {
-            printf("Comm size: %zu bytes; Elapsed time: %lf sec; Algo bandwidth: %lf GB/s; Bus bandwidth: %lf GB/s\n", size, elapsed_time, alg_bw, bus_bw);
-        }
-
-        MPI_Barrier(MPI_COMM_WORLD);
-
-        devHandle->deviceMemset(hello, 0, size, flagcxMemHost, NULL);
-        devHandle->deviceMemcpy(hello, recvbuff, size, flagcxMemcpyDeviceToHost, NULL);
-        if (proc == 0 && print_buffer) {
-            printf("recvbuff = ");
-        	for (int i = 0; i < totalProcs; i++) {
-                printf("%f ", ((float *)hello)[i * (count / totalProcs)]);
-            }
-            printf("\n");
-        }
-
-        devHandle->deviceFree(sendbuff, flagcxMemDevice, NULL);
-        devHandle->deviceFree(recvbuff, flagcxMemDevice, NULL);
-        devHandle->deviceFree(hello, flagcxMemHost, NULL);
+    for (int i = 0; i < totalProcs; i++) {
+      ((float *)hello)[i * (count / totalProcs)] = 10 * proc + i;
     }
 
-    devHandle->streamDestroy(stream);
-    flagcxCommDestroy(comm);
-    flagcxHandleFree(handler);
+    devHandle->deviceMemcpy(sendbuff, hello, size, flagcxMemcpyHostToDevice,
+                            NULL);
 
-    MPI_Finalize();
-    return 0;
-} 
+    if ((proc == 0 || proc == totalProcs - 1) && print_buffer) {
+      printf("sendbuff = ");
+      for (int i = 0; i < totalProcs; i++) {
+        printf("%f ", ((float *)hello)[i * (count / totalProcs)]);
+      }
+      printf("\n");
+    }
+
+    for (int i = 0; i < num_warmup_iters; i++) {
+      flagcxAlltoAll(sendbuff, recvbuff, count / totalProcs, DATATYPE, comm,
+                     stream);
+    }
+    devHandle->streamSynchronize(stream);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    tim.reset();
+    for (int i = 0; i < num_iters; i++) {
+      flagcxAlltoAll(sendbuff, recvbuff, count / totalProcs, DATATYPE, comm,
+                     stream);
+    }
+    devHandle->streamSynchronize(stream);
+
+    double elapsed_time = tim.elapsed() / num_iters;
+    double base_bw = (double)(size) / 1.0E9 / elapsed_time;
+    double alg_bw = base_bw;
+    double factor = ((double)(totalProcs - 1)) / ((double)(totalProcs));
+    double bus_bw = base_bw * factor;
+    if (proc == 0) {
+      printf("Comm size: %zu bytes; Elapsed time: %lf sec; Algo bandwidth: %lf "
+             "GB/s; Bus bandwidth: %lf GB/s\n",
+             size, elapsed_time, alg_bw, bus_bw);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    devHandle->deviceMemset(hello, 0, size, flagcxMemHost, NULL);
+    devHandle->deviceMemcpy(hello, recvbuff, size, flagcxMemcpyDeviceToHost,
+                            NULL);
+    if ((proc == 0 || proc == totalProcs - 1) && print_buffer) {
+      printf("recvbuff = ");
+      for (int i = 0; i < totalProcs; i++) {
+        printf("%f ", ((float *)hello)[i * (count / totalProcs)]);
+      }
+      printf("\n");
+    }
+
+    devHandle->deviceFree(sendbuff, flagcxMemDevice, NULL);
+    devHandle->deviceFree(recvbuff, flagcxMemDevice, NULL);
+    devHandle->deviceFree(hello, flagcxMemHost, NULL);
+  }
+
+  devHandle->streamDestroy(stream);
+  flagcxCommDestroy(comm);
+  flagcxHandleFree(handler);
+
+  MPI_Finalize();
+  return 0;
+}

--- a/test/perf/test_alltoallv.cpp
+++ b/test/perf/test_alltoallv.cpp
@@ -72,7 +72,7 @@ int main(int argc, char *argv[]) {
     devHandle->deviceMemcpy(sendbuff, hello, size, flagcxMemcpyHostToDevice,
                             NULL);
 
-    if (proc == 0 && print_buffer) {
+    if ((proc == 0 || proc == totalProcs - 1) && print_buffer) {
       printf("sendbuff = ");
       for (int i = 0; i < totalProcs; i++) {
         printf("%f ", ((float *)hello)[i * count]);
@@ -120,7 +120,7 @@ int main(int argc, char *argv[]) {
       }
     }
 
-    if (proc == 0 && print_buffer) {
+    if ((proc == 0 || proc == totalProcs - 1) && print_buffer) {
       printf("h_sendcounts = ");
       for (int i = 0; i < totalProcs; i++) {
         printf("%ld ", h_sendcounts[i]);
@@ -174,7 +174,7 @@ int main(int argc, char *argv[]) {
     devHandle->deviceMemset(hello, 0, size, flagcxMemHost, NULL);
     devHandle->deviceMemcpy(hello, recvbuff, size, flagcxMemcpyDeviceToHost,
                             NULL);
-    if (proc == 0 && print_buffer) {
+    if ((proc == 0 || proc == totalProcs - 1) && print_buffer) {
       printf("recvbuff = ");
       for (int i = 0; i < totalProcs; i++) {
         printf("%f ", ((float *)hello)[i * count]);


### PR DESCRIPTION
This PR integrates AlltoAll and AlltoAllv operations into the flagcxPlanner workflow. Instead of using the searchHeteroSendRecvOps function, each rank is treated as an inter-rank to construct customized hetero send/recv strategies. Note that this approach is functional but may not be the most optimized solution for AlltoAll/v operations.