### PR TITLE
Support cluster split functionality

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -80,7 +80,4 @@ jobs:
       - name: Run unit tests with mpirun
         run: |
           cd /__w/FlagCX/FlagCX/test/unittest
-          source ../script/_gpu_check.sh
-          wait_for_gpu
           mpirun -np 8 ./build/bin/main
-

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -80,5 +80,7 @@ jobs:
       - name: Run unit tests with mpirun
         run: |
           cd /__w/FlagCX/FlagCX/test/unittest
+          source ../script/_gpu_check.sh
+          wait_for_gpu
           mpirun -np 8 ./build/bin/main
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [<img src="flagopen.png">](https://flagopen.baai.ac.cn/)
 
 ## Latest News
-- **[2025/04]** Released [v0.1](https://github.com/FlagOpen/FlagCX/tree/release/v0.1): 
+- **[2025/04]** Released [v0.1](https://github.com/FlagOpen/FlagCX/tree/release/v0.1):
   - Supports five native communications libraries with automatic topology detection.
   - Delivers 11 heterogeneous collective communication algorithms, including both P2P and collective ops.
   - Provides a full-stack open-source solution, FlagScale + FlagCX, for efficient heterogeneous training.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ FlagCX leverages native collective communications libraries to provide the full 
 | Mode          | Homo | Homo   | Homo | Homo | Homo | Homo  | Hetero    | Hetero  | Hetero     |
 | send          | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓          |
 | recv          | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓          |
-| broadcast     | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✘          | ✘       | ✓          |
-| gather        | ✓    | ✓      | ✓    | ✓    | ✘    | ✓     |✘          | ✘       | ✓          |
-| scatter       | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✘          | ✘       | ✓          |
+| broadcast     | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✘       | ✓          |
+| gather        | ✓    | ✓      | ✓    | ✓    | ✘    | ✓     |✓          | ✘       | ✓          |
+| scatter       | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✘       | ✓          |
 | reduce        | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✘       | ✓          |
 | allreduce     | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓          |
 | allgather     | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓          |

--- a/flagcx/core/cluster.h
+++ b/flagcx/core/cluster.h
@@ -4,8 +4,14 @@
 #include "adaptor.h"
 #include "flagcx.h"
 #include "param.h"
+#include <iostream>
 #include <map>
+#include <sstream>
 #include <string>
+#include <vector>
+
+flagcxResult_t parseClusterSplitList(const char *input,
+                                     std::vector<int> &output);
 
 flagcxResult_t flagcxCollectClusterInfos(const flagcxVendor *allData,
                                          flagcxCommunicatorType_t *type,

--- a/test/script/_gpu_check.sh
+++ b/test/script/_gpu_check.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+wait_for_gpu() {
+    gpu_count=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+
+    memory_usage_max=30000
+
+    while true; do
+
+    IFS=$'\n' read -d '' -r -a memory_usage_array <<< "$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits)"
+    IFS=$'\n' read -d '' -r -a memory_total_array <<< "$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits)"
+
+    need_wait=false
+
+    for ((i=0; i<$gpu_count; i++)); do
+
+        memory_usage_i=$((${memory_usage_array[$i]}))
+        memory_total_i=$((${memory_total_array[$i]}))
+        memory_remin_i=$(($memory_total_i-$memory_usage_i))
+
+        if [ $memory_remin_i -lt $memory_usage_max ]; then
+        need_wait=true
+        fi
+
+    done
+
+    if [ "$need_wait" = false ]; then
+            break
+    fi
+
+    echo "wait for gpu free"
+    sleep 1m
+
+    unset memory_usage_array
+    unset memory_total_array
+
+    done
+
+    echo "All gpu is free"
+}

--- a/test/script/auto_script.sh
+++ b/test/script/auto_script.sh
@@ -19,6 +19,8 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+source ../script/_gpu_check.sh
+wait_for_gpu
 
 mpirun -np 8   ./test_alltoall -b 128M -e 1G -f 2 -p 1
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
This PR introduces support for splitting a homogeneous cluster into multiple sub-clusters. For instance, given two clusters c1 and c2 with 8 and 16 homo-ranks respectively, setting:


`FLAGCX_CLUSTER_SPLIT_LIST=2,4`

will split:
- c1 into two sub-clusters (c1-1, c1-2) with 4 homo-ranks each
- c2 into four sub-clusters (c2-1, c2-2, c2-3, c2-4) with 4 homo-ranks each

This enables more flexible groupings of ranks for communication planning and facilitates heterogeneous communication scenarios even on a single machine.