### PR TITLE
Refactor workflow for pipeline optimization

### DIFF
--- a/flagcx/core/c2c_algo.h
+++ b/flagcx/core/c2c_algo.h
@@ -120,21 +120,24 @@ public:
 
 class flagcxC2cHomoFunc {
 public:
-  flagcxC2cHomoFunc(int rootRank, int sendOffset, int recvOffset, int count,
-                    int homoType, flagcxCommOp_t commOp);
+  flagcxC2cHomoFunc(int rootRank, int sendType, int recvType, int sendOffset,
+                    int recvOffset, int count, int homoType,
+                    flagcxCommOp_t commOp);
   flagcxC2cHomoFunc(
-      int rootRank, int sendOffset, int recvOffset, int count, int homoType,
-      flagcxCommOp_t commOp,
+      int rootRank, int sendType, int recvType, int sendOffset, int recvOffset,
+      int count, int homoType, flagcxCommOp_t commOp,
       flagcxInterRankBufferInfoManager interRankBufferInfoManager);
   ~flagcxC2cHomoFunc();
 
-  flagcxResult_t run(const void *sendbuff, void *recvbuff,
+  flagcxResult_t run(const void *sendbuff, void *recvbuff, void *scratchbuff,
                      flagcxDataType_t datatype, flagcxRedOp_t redOp, int root,
                      flagcxComm_t comm, flagcxStream_t stream,
                      size_t *sendCounts = nullptr, size_t *sDispls = nullptr,
                      size_t *recvCounts = nullptr, size_t *rDispls = nullptr);
 
   int rootRank_;
+  int sendType_;
+  int recvType_;
   int sendOffset_;
   int recvOffset_;
   int count_;
@@ -198,6 +201,11 @@ public:
                          size_t *rDispls = nullptr);
 
 private:
+  int nSeqPreSteps_;
+  int nPipePreSteps_;
+  int nSeqInterSteps_;
+  int nPipePostSteps_;
+  int nSeqPostSteps_;
   int sendCount_;
   int recvCount_;
   int rootRank_; // used for gather, scatter
@@ -224,17 +232,13 @@ private:
   int clusterOffset_;
   int multiNic_;
   int eachNicPerRank_;
-  int preHomoFuncLoops_;            // number of loops for preHomoFunc
-  int heteroAndHomoInterFuncLoops_; // number of loops for heteroFunc and
-                                    // homoInterFunc
-  int postHomoFuncLoops_;           // number of loops for postHomoFunc
   int strategyFound_;
   flagcxInterRankBufferInfoManager interRankBufferInfoManager_;
   flagcxC2cRefreshFunc refreshFunc_;
-  std::vector<flagcxC2cHomoFunc> preHomoFuncList_;
-  std::vector<flagcxC2cHeteroFunc> heteroFuncList_;
-  std::vector<flagcxC2cHomoFunc> homoInterFuncList_;
-  std::vector<flagcxC2cHomoFunc> postHomoFuncList_;
+  std::vector<std::vector<flagcxC2cHomoFunc>> preHomoFuncSteps_;
+  std::vector<std::vector<flagcxC2cHeteroFunc>> heteroFuncSteps_;
+  std::vector<std::vector<flagcxC2cHomoFunc>> homoInterFuncSteps_;
+  std::vector<std::vector<flagcxC2cHomoFunc>> postHomoFuncSteps_;
   void *scratchBuffer_; // used for intermediate processing
 };
 

--- a/flagcx/core/cost_model.cc
+++ b/flagcx/core/cost_model.cc
@@ -27,7 +27,7 @@ flagcxResult_t flagcxAlgoTimeEstimator::getAlgoTime(float *time) {
 flagcxResult_t flagcxAlgoTimeEstimator::getPreHomoAlgoTime(float *time) {
   flagcxComm_t comm = planner_.comm_;
   auto &preHomoFuncs =
-      planner_.preHomoFuncList_; // all clusters perform the same algo
+      planner_.preHomoFuncSteps_[0]; // all clusters perform the same algo
   float totalPreHomoTime = 0.0;
   // compute the execution time for all clusters
   // use the max time for all clusters
@@ -50,7 +50,7 @@ flagcxResult_t flagcxAlgoTimeEstimator::getPreHomoAlgoTime(float *time) {
 
 flagcxResult_t flagcxAlgoTimeEstimator::getPostHomoAlgoTime(float *time) {
   flagcxComm_t comm = planner_.comm_;
-  auto &postHomoFuncs = planner_.postHomoFuncList_;
+  auto &postHomoFuncs = planner_.postHomoFuncSteps_[0];
   float totalPostHomoTime = 0.0;
   // compute the execution time for all clusters
   // use the max time for all clusters
@@ -81,7 +81,7 @@ flagcxResult_t flagcxAlgoTimeEstimator::getHomoAlgoTime(
 flagcxResult_t flagcxAlgoTimeEstimator::getHomoInterAlgoTime(int loop,
                                                              float *time) {
   flagcxComm_t comm = planner_.comm_;
-  auto &homoFunc = planner_.homoInterFuncList_[loop];
+  auto &homoFunc = planner_.homoInterFuncSteps_[0][loop];
   // getHomoAlgoTime
   float totalHomoInterTime = 0.0;
   // compute the execution time for all clusters
@@ -107,7 +107,8 @@ flagcxResult_t flagcxAlgoTimeEstimator::getHeteroAlgoTime(float *time) {
   flagcxHeteroComm_t heteroComm = comm->hetero_comm;
   // filter out hetero funcs for each rank
   std::unordered_map<int, std::vector<flagcxC2cHeteroFunc>> heteroFuncMap;
-  int heteroFuncLoops = planner_.heteroAndHomoInterFuncLoops_;
+  int heteroFuncLoops = planner_.nPipePreSteps_ + planner_.nSeqInterSteps_ +
+                        planner_.nPipePostSteps_;
   auto &clusterInterRankList = planner_.clusterInterRankList_;
   // get all interRanks
   std::vector<int> interRanks;


### PR DESCRIPTION
Change the old 3-stage C2C workflow into a 5-stage pipelined workflow:

1. Sequentially execute preHomoFuncs that cannot be overlapped with inter-cluster data transfers.
2. Pipelined preHomoFuncSteps and heteroFuncs.
3. Sequentially execute heteroFuncs + homoInterFuncs that cannot be pipelined.
4. Pipelined heteroFuncs and postHomoFuncs.
5. Sequentially execute postHomoFuncSteps that cannot be pipelined.

The old workflow implementations are migrated to the new workflow as steps 1, 3, and 5.