### PR TITLE
feat: Add MPI adaptor support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,13 @@ USE_BOOTSTRAP ?= 0
 USE_METAX ?= 0
 USE_KUNLUNXIN ?=0
 USE_DU ?= 0
+USE_MPI ?= 0
 
 # set to empty if not provided
 DEVICE_HOME ?=
 CCL_HOME ?=
 HOST_CCL_HOME ?=
+MPI_HOME ?=
 
 ifeq ($(strip $(DEVICE_HOME)),)
 	ifeq ($(USE_NVIDIA), 1)
@@ -56,8 +58,16 @@ endif
 ifeq ($(strip $(HOST_CCL_HOME)),)
 	ifeq ($(USE_GLOO), 1)
 		HOST_CCL_HOME = /usr/local
+	else ifeq ($(USE_MPI), 1)
+		HOST_CCL_HOME = $(MPI_HOME)
 	else
 		HOST_CCL_HOME = 
+	endif
+endif
+
+ifeq ($(strip $(MPI_HOME)),)
+	ifeq ($(USE_MPI), 1)
+		MPI_HOME = /usr/local
 	endif
 endif
 
@@ -134,6 +144,11 @@ ifeq ($(USE_GLOO), 1)
 	HOST_CCL_INCLUDE = $(HOST_CCL_HOME)/include
 	HOST_CCL_LINK = -lgloo
 	HOST_CCL_ADAPTOR_FLAG = -DUSE_GLOO_ADAPTOR
+else ifeq ($(USE_MPI), 1)
+	HOST_CCL_LIB = $(MPI_HOME)/lib
+	HOST_CCL_INCLUDE = $(MPI_HOME)/include
+	HOST_CCL_LINK = -lmpi
+	HOST_CCL_ADAPTOR_FLAG = -DUSE_MPI_ADAPTOR
 else ifeq ($(USE_BOOTSTRAP), 1)
 	HOST_CCL_LIB = /usr/local/lib
 	HOST_CCL_INCLUDE = /usr/local/include
@@ -171,11 +186,13 @@ print_var:
 	@echo "DEVICE_HOME: $(DEVICE_HOME)"
 	@echo "CCL_HOME: $(CCL_HOME)"
 	@echo "HOST_CCL_HOME: $(HOST_CCL_HOME)"
+	@echo "MPI_HOME: $(MPI_HOME)"
 	@echo "USE_NVIDIA: $(USE_NVIDIA)"
 	@echo "USE_ILUVATAR_COREX: $(USE_ILUVATAR_COREX)"
 	@echo "USE_CAMBRICON: $(USE_CAMBRICON)"
 	@echo "USE_KUNLUNXIN: $(USE_KUNLUNXIN)"
 	@echo "USE_GLOO: $(USE_GLOO)"
+	@echo "USE_MPI: $(USE_MPI)"
 	@echo "USE_DU: $(USE_DU)"
 	@echo "DEVICE_LIB: $(DEVICE_LIB)"
 	@echo "DEVICE_INCLUDE: $(DEVICE_INCLUDE)"

--- a/README.md
+++ b/README.md
@@ -17,22 +17,21 @@
 FlagCX is also a part of [FlagAI-Open](https://flagopen.baai.ac.cn/), an open-source initiative by BAAI that aims to foster an open-source ecosystem for AI technologies. It serves as a platform where developers, researchers, and AI enthusiasts can collaborate on various AI projects, contribute to the development of cutting-edge AI solutions, and share their work with the global community.
 
 FlagCX leverages native collective communications libraries to provide the full support of single-chip communications on different platforms. In addition to its native x-CCL support, FlagCX provides an original device-buffer RDMA design to offer advanced support for cross-chip high-performance sendrecev operations (`CORE` module), which can also be integrated with native x-CCL backends to enable optimized cross-chip collective communications. A comprehensive list of currently supported communication backends and their different capabilities are listed as follows:
-
-| Backend       | NCCL | IXCCL  | CNCL | MCCL | XCCL | DUCCL | BOOTSTRAP | GLOO    | CORE+x-CCL |
-|:--------------|:-----|:-------|:-----|:-----|:-----|:------|:----------|:--------|:-----------|
-| Mode          | Homo | Homo   | Homo | Homo | Homo | Homo  | Hetero    | Hetero  | Hetero     |
-| send          | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓          |
-| recv          | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓          |
-| broadcast     | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓          |
-| gather        | ✓    | ✓      | ✓    | ✓    | ✘    | ✓     |✓          | ✓       | ✓          |
-| scatter       | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓          |
-| reduce        | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓          |
-| allreduce     | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓          |
-| allgather     | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓          |
-| reducescatter | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✘       | ✓          |
-| alltoall      | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓          |
-| alltoallv     | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓          |
-| group ops     | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✘          | ✘       | ✘          |
+| Backend       | NCCL | IXCCL  | CNCL | MCCL | XCCL | DUCCL | BOOTSTRAP | GLOO    | MPI     | CORE+x-CCL |
+|:--------------|:-----|:-------|:-----|:-----|:-----|:------|:----------|:--------|:--------|:-----------|
+| Mode          | Homo | Homo   | Homo | Homo | Homo | Homo  | Hetero    | Hetero  | Hetero  | Hetero     |
+| send          | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓       | ✓          |
+| recv          | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓       | ✓          |
+| broadcast     | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓       | ✓          |
+| gather        | ✓    | ✓      | ✓    | ✓    | ✘    | ✓     |✓          | ✓       | ✓       | ✓          |
+| scatter       | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓       | ✓          |
+| reduce        | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓       | ✓          |
+| allreduce     | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓       | ✓          |
+| allgather     | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓       | ✓          |
+| reducescatter | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✘       | ✓       | ✓          |
+| alltoall      | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓       | ✓          |
+| alltoallv     | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✓          | ✓       | ✓       | ✓          |
+| group ops     | ✓    | ✓      | ✓    | ✓    | ✓    | ✓     |✘          | ✘       | ✘       | ✘          |
 
 Note that `Homo` and `Hetero` modes refer to communications among homogeneous and heterogeneous clusters. Except for `BOOTSTRAP` (which is constructed by FlagCX `bootstrap` component), all other native collective communications libraries can be referenced through the links below:
 
@@ -43,6 +42,7 @@ Note that `Homo` and `Hetero` modes refer to communications among homogeneous an
 - [XCCL](WIP), XPU Collective Communications Library.
 - [DUCCL](https://developer.sourcefind.cn), DU Collective Communications Library.
 - [GLOO](https://github.com/facebookincubator/gloo), Gloo Collective Communications Library.
+- [MPI](https://www.mpich.org), Message Passing Interface (MPI) standard.
 
 FlagCX also integrates with upper-layer applications such as PyTorch and PaddlePaddle based on its unified APIs. The table below presents all supported frameworks by FlagCX and their related communication operations, where the `batch_XXX` and `XXX_coalesced` ops refer to the usage of group primitives.
 
@@ -76,10 +76,16 @@ FlagCX also integrates with upper-layer applications such as PyTorch and PaddleP
 2. Build the library with different flags targeting to different platforms:
     ```sh
     cd FlagCX
-    make [USE_NVIDIA/USE_ILUVATAR_COREX/USE_CAMBRICON/USE_GLOO/USE_METAX/USE_KUNLUNXIN/USE_DU]=1
+    make [USE_NVIDIA/USE_ILUVATAR_COREX/USE_CAMBRICON/USE_GLOO/USE_MPI/USE_METAX/USE_KUNLUNXIN/USE_DU]=1
 
     # If the compilation variable "make USE_KUNLUNXIN=1" is used, the following environment variables need to be enabled:
     export XPU_FORCE_SHARED_DEVICE_CONTEXT=1
+    ```
+    If `USE_MPI=1` is set, you need to install MPICH first. You can do so with the following commands:
+    ```sh
+    wget https://www.mpich.org/static/downloads/4.2.3/mpich-4.2.3.tar.gz
+    tar xzvf mpich-4.2.3.tar.gz
+    cd mpich-4.2.3 && ./configure --prefix="$PWD/build" --with-device=ch3 --disable-fortran && make -j64 && make install
     ```
     The default install path is set to `build/`, you can manually set `BUILDDIR` to specify the build path. You may also define `DEVICE_HOME` and `CCL_HOME` to indicate the install paths of device runtime and communication libraries.
 
@@ -95,6 +101,14 @@ Note that the default MPI install path is set to `/usr/local/mpi`, you may speci
 ```sh
 make MPI_HOME=<path to mpi install>
 ```
+If you have installed MPICH (e.g., via `mpich-4.2.3`), you should use `mpirun` to launch tests across multiple nodes:
+```sh
+/workspace/mpich-4.2.3/build/bin/mpirun -np 16 -hosts 10.1.15.237:8,10.1.15.141:8 \
+  -genv PATH=/workspace/mpich-4.2.3/build/bin:/opt/maca/bin:$PATH \
+  -genv LD_LIBRARY_PATH=/workspace/mpich-4.2.3/build/lib:/opt/maca/lib:$LD_LIBRARY_PATH \
+  ./test_allreduce -b 128M -e 8G -f 2
+```
+⚠️ Note: If you built the project with a custom MPICH (e.g., mpich-4.2.3), you must also use the same MPICH's mpirun for testing to ensure compatibility.
 
 All tests support the same set of arguments:
 

--- a/README.md
+++ b/README.md
@@ -81,12 +81,6 @@ FlagCX also integrates with upper-layer applications such as PyTorch and PaddleP
     # If the compilation variable "make USE_KUNLUNXIN=1" is used, the following environment variables need to be enabled:
     export XPU_FORCE_SHARED_DEVICE_CONTEXT=1
     ```
-    If `USE_MPI=1` is set, you need to install MPICH first. You can do so with the following commands:
-    ```sh
-    wget https://www.mpich.org/static/downloads/4.2.3/mpich-4.2.3.tar.gz
-    tar xzvf mpich-4.2.3.tar.gz
-    cd mpich-4.2.3 && ./configure --prefix="$PWD/build" --with-device=ch3 --disable-fortran && make -j64 && make install
-    ```
     The default install path is set to `build/`, you can manually set `BUILDDIR` to specify the build path. You may also define `DEVICE_HOME` and `CCL_HOME` to indicate the install paths of device runtime and communication libraries.
 
 ### Tests
@@ -101,14 +95,6 @@ Note that the default MPI install path is set to `/usr/local/mpi`, you may speci
 ```sh
 make MPI_HOME=<path to mpi install>
 ```
-If you have installed MPICH (e.g., via `mpich-4.2.3`), you should use `mpirun` to launch tests across multiple nodes:
-```sh
-/workspace/mpich-4.2.3/build/bin/mpirun -np 16 -hosts 10.1.15.237:8,10.1.15.141:8 \
-  -genv PATH=/workspace/mpich-4.2.3/build/bin:/opt/maca/bin:$PATH \
-  -genv LD_LIBRARY_PATH=/workspace/mpich-4.2.3/build/lib:/opt/maca/lib:$LD_LIBRARY_PATH \
-  ./test_allreduce -b 128M -e 8G -f 2
-```
-⚠️ Note: If you built the project with a custom MPICH (e.g., mpich-4.2.3), you must also use the same MPICH's mpirun for testing to ensure compatibility.
 
 All tests support the same set of arguments:
 

--- a/flagcx/adaptor/adaptor.cc
+++ b/flagcx/adaptor/adaptor.cc
@@ -12,6 +12,9 @@ struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&bootstrapAdaptor,
 #elif USE_GLOO_ADAPTOR
 struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&glooAdaptor,
                                                       &ncclAdaptor};
+#elif USE_MPI_ADAPTOR
+struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&mpiAdaptor,
+                                                      &ncclAdaptor};
 #endif
 struct flagcxDeviceAdaptor *deviceAdaptor = &cudaAdaptor;
 #elif USE_ILUVATAR_COREX_ADAPTOR
@@ -20,6 +23,9 @@ struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&bootstrapAdaptor,
                                                       &ixncclAdaptor};
 #elif USE_GLOO_ADAPTOR
 struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&glooAdaptor,
+                                                      &ixncclAdaptor};
+#elif USE_MPI_ADAPTOR
+struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&mpiAdaptor,
                                                       &ixncclAdaptor};
 #endif
 struct flagcxDeviceAdaptor *deviceAdaptor = &ixcudaAdaptor;
@@ -30,6 +36,9 @@ struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&bootstrapAdaptor,
 #elif USE_GLOO_ADAPTOR
 struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&glooAdaptor,
                                                       &cnclAdaptor};
+#elif USE_MPI_ADAPTOR
+struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&mpiAdaptor,
+                                                      &cnclAdaptor};
 #endif
 struct flagcxDeviceAdaptor *deviceAdaptor = &mluAdaptor;
 #elif USE_METAX_ADAPTOR
@@ -38,6 +47,9 @@ struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&bootstrapAdaptor,
                                                       &mcclAdaptor};
 #elif USE_GLOO_ADAPTOR
 struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&glooAdaptor,
+                                                      &mcclAdaptor};
+#elif USE_MPI_ADAPTOR
+struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&mpiAdaptor,
                                                       &mcclAdaptor};
 #endif
 struct flagcxDeviceAdaptor *deviceAdaptor = &macaAdaptor;
@@ -48,6 +60,9 @@ struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&bootstrapAdaptor,
 #elif USE_GLOO_ADAPTOR
 struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&glooAdaptor,
                                                       &xcclAdaptor};
+#elif USE_MPI_ADAPTOR
+struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&mpiAdaptor,
+                                                      &xcclAdaptor};
 #endif
 struct flagcxDeviceAdaptor *deviceAdaptor = &kunlunAdaptor;
 #elif USE_DU_ADAPTOR
@@ -56,6 +71,9 @@ struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&bootstrapAdaptor,
                                                       &duncclAdaptor};
 #elif USE_GLOO_ADAPTOR
 struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&glooAdaptor,
+                                                      &duncclAdaptor};
+#elif USE_MPI_ADAPTOR
+struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&mpiAdaptor,
                                                       &duncclAdaptor};
 #endif
 struct flagcxDeviceAdaptor *deviceAdaptor = &ducudaAdaptor;

--- a/flagcx/adaptor/adaptor.h
+++ b/flagcx/adaptor/adaptor.h
@@ -27,6 +27,7 @@ extern struct flagcxCCLAdaptor cnclAdaptor;
 extern struct flagcxCCLAdaptor mcclAdaptor;
 extern struct flagcxCCLAdaptor xcclAdaptor;
 extern struct flagcxCCLAdaptor duncclAdaptor;
+extern struct flagcxCCLAdaptor mpiAdaptor;
 extern struct flagcxCCLAdaptor *cclAdaptors[];
 
 extern struct flagcxDeviceAdaptor cudaAdaptor;

--- a/flagcx/adaptor/mpi_adaptor.cc
+++ b/flagcx/adaptor/mpi_adaptor.cc
@@ -1,0 +1,318 @@
+#include "mpi_adaptor.h"
+#include <functional>
+
+#ifdef USE_MPI_ADAPTOR
+
+static flagcxResult_t validateComm(flagcxInnerComm_t comm) {
+    if (!comm || !comm->base) {
+        return flagcxInvalidArgument;
+    }
+    
+    if (!comm->base->isValidContext()) {
+        printf("Error: Invalid MPI context: %s\n", comm->base->getLastError().c_str());
+        return flagcxInternalError;
+    }
+    
+    return flagcxSuccess;
+}
+
+flagcxResult_t mpiAdaptorGetVersion(int *version) {
+    int subversion;
+    int result = MPI_Get_version(version, &subversion);
+    return (result == MPI_SUCCESS) ? flagcxSuccess : flagcxInternalError;
+}
+
+flagcxResult_t mpiAdaptorGetUniqueId(flagcxUniqueId_t *uniqueId) {
+    return flagcxSuccess;
+}
+
+const char *mpiAdaptorGetErrorString(flagcxResult_t result) {
+    switch (result) {
+        case flagcxSuccess: return "MPI Success";
+        case flagcxInternalError: return "MPI Internal Error";
+        default: return "MPI Unknown Error";
+    }
+}
+
+const char *mpiAdaptorGetLastError(flagcxInnerComm_t comm) {
+
+    return "MPI: No Error";
+}
+
+flagcxResult_t mpiAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                                      flagcxUniqueId_t /*commId*/, int rank,
+                                      bootstrapState *bootstrap) {
+    int initialized;
+    MPI_Initialized(&initialized);
+    
+    if (!initialized) {
+        int provided;
+        int result = MPI_Init_thread(NULL, NULL, MPI_THREAD_MULTIPLE, &provided);
+        if (result != MPI_SUCCESS) {
+            return flagcxInternalError;
+        }
+        
+        if (provided < MPI_THREAD_SERIALIZED) {
+            printf("Warning: MPI does not support required thread level\n");
+        }
+    }
+    
+    int mpi_rank, mpi_size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
+    
+    // validate parameters if bootstrap is provided
+    if (bootstrap != nullptr) {
+        if (rank != mpi_rank || nranks != mpi_size) {
+            printf("Warning: Expected rank/size (%d/%d) differs from MPI (%d/%d), using MPI values\n", 
+                   rank, nranks, mpi_rank, mpi_size);
+        }
+    }
+    
+    if (*comm == NULL) {
+        FLAGCXCHECK(flagcxCalloc(comm, 1));
+    }
+    
+    // use actual MPI rank and size to create context
+    (*comm)->base = std::make_shared<flagcxMpiContext>(mpi_rank, mpi_size, bootstrap);
+    
+    // check if context is created successfully
+    if (!(*comm)->base || !(*comm)->base->isValidContext()) {
+        printf("Error: Failed to create MPI context: %s\n", 
+               (*comm)->base ? (*comm)->base->getLastError().c_str() : "Unknown error");
+        return flagcxInternalError;
+    }    
+    return flagcxSuccess;
+}
+
+flagcxResult_t mpiAdaptorCommFinalize(flagcxInnerComm_t comm) {
+    comm->base.reset();
+    return flagcxSuccess;
+}
+
+flagcxResult_t mpiAdaptorCommDestroy(flagcxInnerComm_t comm) {
+    comm->base.reset();
+    return flagcxSuccess;
+}
+
+flagcxResult_t mpiAdaptorCommAbort(flagcxInnerComm_t comm) {
+    MPI_Abort(comm->base->getMpiComm(), 1);
+    return flagcxSuccess;
+}
+
+flagcxResult_t mpiAdaptorCommResume(flagcxInnerComm_t comm) {
+    return flagcxNotSupported;
+}
+
+flagcxResult_t mpiAdaptorCommSuspend(flagcxInnerComm_t comm) {
+    return flagcxNotSupported;
+}
+
+flagcxResult_t mpiAdaptorCommCount(const flagcxInnerComm_t comm, int *count) {
+    *count = comm->base->getSize();
+    return flagcxSuccess;
+}
+
+flagcxResult_t mpiAdaptorCommCuDevice(const flagcxInnerComm_t comm, int *device) {
+    *device = -1;
+    return flagcxSuccess;
+}
+
+flagcxResult_t mpiAdaptorCommUserRank(const flagcxInnerComm_t comm, int *rank) {
+    *rank = comm->base->getRank();
+    return flagcxSuccess;
+}
+
+flagcxResult_t mpiAdaptorCommGetAsyncError(flagcxInnerComm_t comm,
+                                           flagcxResult_t asyncError) {
+    return flagcxNotSupported;
+}
+
+flagcxResult_t mpiAdaptorReduce(const void *sendbuff, void *recvbuff,
+                                size_t count, flagcxDataType_t datatype,
+                                flagcxRedOp_t op, int root,
+                                flagcxInnerComm_t comm,
+                                flagcxStream_t /*stream*/) {
+    int result;
+    MPI_Op mpiOp = getFlagcxToMpiOp(op);
+    CALL_MPI_REDUCE(datatype, sendbuff, recvbuff, count, mpiOp, root, 
+                    comm->base->getMpiComm(), &result);
+    return (result == MPI_SUCCESS) ? flagcxSuccess : flagcxInternalError;
+}
+
+flagcxResult_t mpiAdaptorBroadcast(const void *sendbuff, void *recvbuff,
+                                   size_t count, flagcxDataType_t datatype,
+                                   int root, flagcxInnerComm_t comm,
+                                   flagcxStream_t /*stream*/) {
+    int result;
+    void *buffer = (comm->base->getRank() == root) ? 
+                   const_cast<void*>(sendbuff) : recvbuff;
+    
+    CALL_MPI_BCAST(datatype, buffer, count, root, comm->base->getMpiComm(), &result);
+    return (result == MPI_SUCCESS) ? flagcxSuccess : flagcxInternalError;
+}
+
+flagcxResult_t mpiAdaptorAllReduce(const void *sendbuff, void *recvbuff,
+                                   size_t count, flagcxDataType_t datatype,
+                                   flagcxRedOp_t op, flagcxInnerComm_t comm,
+                                   flagcxStream_t /*stream*/) {
+    FLAGCXCHECK(validateComm(comm));
+    
+    int result;
+    MPI_Op mpiOp = getFlagcxToMpiOp(op);
+    CALL_MPI_ALLREDUCE(datatype, sendbuff, recvbuff, count, mpiOp, 
+                       comm->base->getMpiComm(), &result);
+    return (result == MPI_SUCCESS) ? flagcxSuccess : flagcxInternalError;
+}
+
+flagcxResult_t mpiAdaptorGather(const void *sendbuff, void *recvbuff,
+                                size_t count, flagcxDataType_t datatype,
+                                int root, flagcxInnerComm_t comm,
+                                flagcxStream_t /*stream*/) {
+    int result;
+    CALL_MPI_GATHER(datatype, sendbuff, count, recvbuff, count, root, 
+                    comm->base->getMpiComm(), &result);
+    return (result == MPI_SUCCESS) ? flagcxSuccess : flagcxInternalError;
+}
+
+flagcxResult_t mpiAdaptorScatter(const void *sendbuff, void *recvbuff,
+                                 size_t count, flagcxDataType_t datatype,
+                                 int root, flagcxInnerComm_t comm,
+                                 flagcxStream_t /*stream*/) {
+    int result;
+    CALL_MPI_SCATTER(datatype, sendbuff, count, recvbuff, count, root,
+                     comm->base->getMpiComm(), &result);
+    return (result == MPI_SUCCESS) ? flagcxSuccess : flagcxInternalError;
+}
+
+flagcxResult_t mpiAdaptorReduceScatter(const void *sendbuff, void *recvbuff, size_t recvcount,
+                                       flagcxDataType_t datatype, flagcxRedOp_t op,
+                                       flagcxInnerComm_t comm, flagcxStream_t /*stream*/) {
+    int result;
+    MPI_Op mpiOp = getFlagcxToMpiOp(op);
+    CALL_MPI_REDUCE_SCATTER(datatype, sendbuff, recvbuff, recvcount, mpiOp,
+                            comm->base->getMpiComm(), &result);
+    return (result == MPI_SUCCESS) ? flagcxSuccess : flagcxInternalError;
+}
+
+flagcxResult_t mpiAdaptorAllGather(const void *sendbuff, void *recvbuff,
+                                   size_t sendcount, flagcxDataType_t datatype,
+                                   flagcxInnerComm_t comm, flagcxStream_t /*stream*/) {
+    int result;
+    CALL_MPI_ALLGATHER(datatype, sendbuff, sendcount, recvbuff, sendcount,
+                       comm->base->getMpiComm(), &result);
+    return (result == MPI_SUCCESS) ? flagcxSuccess : flagcxInternalError;
+}
+
+flagcxResult_t mpiAdaptorAlltoAll(const void *sendbuff, void *recvbuff,
+                                  size_t count, flagcxDataType_t datatype,
+                                  flagcxInnerComm_t comm, flagcxStream_t /*stream*/) {
+    int result;
+    CALL_MPI_ALLTOALL(datatype, sendbuff, count, recvbuff, count,
+                      comm->base->getMpiComm(), &result);
+    return (result == MPI_SUCCESS) ? flagcxSuccess : flagcxInternalError;
+}
+
+flagcxResult_t mpiAdaptorAlltoAllv(const void *sendbuff, size_t *sendcounts,
+                                   size_t *sdispls, void *recvbuff,
+                                   size_t *recvcounts, size_t *rdispls,
+                                   flagcxDataType_t datatype,
+                                   flagcxInnerComm_t comm, flagcxStream_t /*stream*/) {
+    FLAGCXCHECK(validateComm(comm));
+    
+    // validate parameters
+    if (!sendcounts || !sdispls || !recvcounts || !rdispls) {
+        printf("Error: AlltoAllv requires non-null count and displacement arrays\n");
+        return flagcxInvalidArgument;
+    }
+    
+    int size = comm->base->getSize();
+    MPI_Datatype mpi_datatype = getFlagcxToMpiDataType(datatype);
+    
+    std::vector<int> mpi_sendcounts(size), mpi_recvcounts(size);
+    std::vector<int> mpi_sdispls(size), mpi_rdispls(size);
+    
+    for (int i = 0; i < size; i++) {
+        mpi_sendcounts[i] = static_cast<int>(sendcounts[i]);
+        mpi_recvcounts[i] = static_cast<int>(recvcounts[i]);
+        mpi_sdispls[i] = static_cast<int>(sdispls[i]);
+        mpi_rdispls[i] = static_cast<int>(rdispls[i]);
+    }
+    
+    int result = MPI_Alltoallv(sendbuff, mpi_sendcounts.data(), mpi_sdispls.data(), 
+                               mpi_datatype, recvbuff, mpi_recvcounts.data(), 
+                               mpi_rdispls.data(), mpi_datatype, comm->base->getMpiComm());
+    
+    return (result == MPI_SUCCESS) ? flagcxSuccess : flagcxInternalError;
+}
+
+flagcxResult_t mpiAdaptorSend(const void *sendbuff, size_t count,
+                              flagcxDataType_t datatype, int peer,
+                              flagcxInnerComm_t comm, flagcxStream_t /*stream*/) {
+    FLAGCXCHECK(validateComm(comm));
+    
+    // validate peer range
+    if (peer < 0 || peer >= comm->base->getSize()) {
+        printf("Error: Invalid peer %d, must be in range [0, %d)\n", peer, comm->base->getSize());
+        return flagcxInvalidArgument;
+    }
+    
+    MPI_Datatype mpi_datatype = getFlagcxToMpiDataType(datatype);
+    int tag = 0;
+    
+    int result = MPI_Send(sendbuff, static_cast<int>(count), mpi_datatype, peer, tag, 
+                          comm->base->getMpiComm());
+    
+    return (result == MPI_SUCCESS) ? flagcxSuccess : flagcxInternalError;
+}
+
+flagcxResult_t mpiAdaptorRecv(void *recvbuff, size_t count,
+                              flagcxDataType_t datatype, int peer,
+                              flagcxInnerComm_t comm, flagcxStream_t /*stream*/) {
+    FLAGCXCHECK(validateComm(comm));
+    
+    // validate peer range (allow MPI_ANY_SOURCE)
+    if (peer != MPI_ANY_SOURCE && (peer < 0 || peer >= comm->base->getSize())) {
+        printf("Error: Invalid peer %d, must be in range [0, %d) or MPI_ANY_SOURCE\n", 
+               peer, comm->base->getSize());
+        return flagcxInvalidArgument;
+    }
+    
+    MPI_Datatype mpi_datatype = getFlagcxToMpiDataType(datatype);
+    int tag = 0;
+    MPI_Status status;
+    
+    int result = MPI_Recv(recvbuff, static_cast<int>(count), mpi_datatype, peer, tag, 
+                          comm->base->getMpiComm(), &status);
+    
+    return (result == MPI_SUCCESS) ? flagcxSuccess : flagcxInternalError;
+}
+
+flagcxResult_t mpiAdaptorGroupStart() {
+    return flagcxSuccess;
+}
+
+flagcxResult_t mpiAdaptorGroupEnd() {
+    return flagcxSuccess;
+}
+
+struct flagcxCCLAdaptor mpiAdaptor = {
+    "MPI",
+    // Basic functions
+    mpiAdaptorGetVersion,     mpiAdaptorGetUniqueId,
+    mpiAdaptorGetErrorString, mpiAdaptorGetLastError,
+    // Communicator functions  
+    mpiAdaptorCommInitRank, mpiAdaptorCommFinalize, mpiAdaptorCommDestroy,
+    mpiAdaptorCommAbort,    mpiAdaptorCommResume,   mpiAdaptorCommSuspend,
+    mpiAdaptorCommCount,    mpiAdaptorCommCuDevice, mpiAdaptorCommUserRank,
+    mpiAdaptorCommGetAsyncError,
+    // Communication functions
+    mpiAdaptorReduce,    mpiAdaptorGather,    mpiAdaptorScatter,
+    mpiAdaptorBroadcast, mpiAdaptorAllReduce, mpiAdaptorReduceScatter,
+    mpiAdaptorAllGather, mpiAdaptorAlltoAll,  mpiAdaptorAlltoAllv,
+    mpiAdaptorSend,      mpiAdaptorRecv,
+    // Group semantics
+    mpiAdaptorGroupStart, mpiAdaptorGroupEnd
+};
+
+#endif // USE_MPI_ADAPTOR

--- a/flagcx/adaptor/mpi_adaptor.h
+++ b/flagcx/adaptor/mpi_adaptor.h
@@ -1,0 +1,262 @@
+#ifdef USE_MPI_ADAPTOR
+
+#include "comm.h"
+#include "utils.h"
+#include "alloc.h"
+#include "check.h"
+#include "flagcx.h"
+#include "adaptor.h"
+
+#include <mpi.h>
+#include <map>
+#include <vector>
+#include <memory>
+#include <string>
+#include <cstring>
+
+#define GENERATE_MPI_TYPES(type, func, args...)  \
+  switch (type) {                                \
+    case flagcxChar:                             \
+      func<char, MPI_CHAR>(args);                \
+      break;                                     \
+    case flagcxUint8:                            \
+      func<uint8_t, MPI_UNSIGNED_CHAR>(args);    \
+      break;                                     \
+    case flagcxInt:                              \
+      func<int, MPI_INT>(args);                  \
+      break;                                     \
+    case flagcxUint32:                           \
+      func<uint32_t, MPI_UNSIGNED>(args);        \
+      break;                                     \
+    case flagcxInt64:                            \
+      func<int64_t, MPI_LONG_LONG>(args);        \
+      break;                                     \
+    case flagcxUint64:                           \
+      func<uint64_t, MPI_UNSIGNED_LONG_LONG>(args); \
+      break;                                     \
+    case flagcxFloat:                            \
+      func<float, MPI_FLOAT>(args);              \
+      break;                                     \
+    case flagcxDouble:                           \
+      func<double, MPI_DOUBLE>(args);            \
+      break;                                     \
+    case flagcxHalf:                             \
+      func<uint16_t, MPI_UINT16_T>(args);        \
+      break;                                     \
+    case flagcxBfloat16:                         \
+      printf("Invalid data type");               \
+      break;                                     \
+    default:                                     \
+      printf("Invalid data type");               \
+      break;                                     \
+  }
+
+#define GENERATE_MPI_REDUCTION_OPS(op, func, args...)  \
+  switch (op) {                              \
+    case flagcxSum:                          \
+      func<MPI_SUM>(args);                   \
+      break;                                 \
+    case flagcxProd:                         \
+      func<MPI_PROD>(args);                  \
+      break;                                 \
+    case flagcxMax:                          \
+      func<MPI_MAX>(args);                   \
+      break;                                 \
+    case flagcxMin:                          \
+      func<MPI_MIN>(args);                   \
+      break;                                 \
+    case flagcxAvg:                          \
+      printf("MPI backend does not support flagcxAvg\n"); \
+      break;                                 \
+    default:                                 \
+      break;                                 \
+  }
+
+template <typename T, MPI_Datatype mpi_type>
+void getMpiDataType(MPI_Datatype& result) {
+    result = mpi_type;
+}
+
+template <MPI_Op mpi_op>
+void getMpiOp(MPI_Op& result) {
+    result = mpi_op;
+}
+
+inline MPI_Datatype getFlagcxToMpiDataType(flagcxDataType_t datatype) {
+    MPI_Datatype result = MPI_DATATYPE_NULL;
+    GENERATE_MPI_TYPES(datatype, getMpiDataType, result);
+    return result;
+}
+
+inline MPI_Op getFlagcxToMpiOp(flagcxRedOp_t op) {
+    MPI_Op result = MPI_OP_NULL;
+    GENERATE_MPI_REDUCTION_OPS(op, getMpiOp, result);
+    return result;
+}
+
+template <typename T, MPI_Datatype mpi_type>
+void callMpiFunction(int func_type, const void *sendbuf, void *recvbuf, 
+                     size_t count, MPI_Op op, int root, MPI_Comm comm, int *result) {
+    switch (func_type) {
+        case 0: // ALLREDUCE
+            *result = MPI_Allreduce(sendbuf, recvbuf, count, mpi_type, op, comm);
+            break;
+        case 1: // REDUCE
+            *result = MPI_Reduce(sendbuf, recvbuf, count, mpi_type, op, root, comm);
+            break;
+        case 2: // BCAST
+            *result = MPI_Bcast(recvbuf, count, mpi_type, root, comm);
+            break;
+        case 3: // GATHER
+            *result = MPI_Gather(sendbuf, count, mpi_type, recvbuf, count, mpi_type, root, comm);
+            break;
+        case 4: // SCATTER
+            *result = MPI_Scatter(sendbuf, count, mpi_type, recvbuf, count, mpi_type, root, comm);
+            break;
+        case 5: // ALLGATHER
+            *result = MPI_Allgather(sendbuf, count, mpi_type, recvbuf, count, mpi_type, comm);
+            break;
+        case 6: // ALLTOALL
+            *result = MPI_Alltoall(sendbuf, count, mpi_type, recvbuf, count, mpi_type, comm);
+            break;
+        case 7: // REDUCE_SCATTER
+            {
+                int size;
+                MPI_Comm_size(comm, &size);
+                std::vector<int> recvcounts(size, count);
+                *result = MPI_Reduce_scatter(sendbuf, recvbuf, recvcounts.data(), mpi_type, op, comm);
+            }
+            break;
+    }
+}
+
+template <typename... Args>
+void callMpi(int func_type, flagcxDataType_t datatype, Args... args) {
+    GENERATE_MPI_TYPES(datatype, callMpiFunction, func_type, args...);
+}
+
+#define CALL_MPI_ALLREDUCE(datatype, sendbuf, recvbuf, count, op, comm, result) \
+    callMpi(0, datatype, sendbuf, recvbuf, count, op, 0, comm, result)
+
+#define CALL_MPI_REDUCE(datatype, sendbuf, recvbuf, count, op, root, comm, result) \
+    callMpi(1, datatype, sendbuf, recvbuf, count, op, root, comm, result)
+
+#define CALL_MPI_BCAST(datatype, buffer, count, root, comm, result) \
+    callMpi(2, datatype, nullptr, buffer, count, MPI_OP_NULL, root, comm, result)
+
+#define CALL_MPI_GATHER(datatype, sendbuf, sendcount, recvbuf, recvcount, root, comm, result) \
+    callMpi(3, datatype, sendbuf, recvbuf, sendcount, MPI_OP_NULL, root, comm, result)
+
+#define CALL_MPI_SCATTER(datatype, sendbuf, sendcount, recvbuf, recvcount, root, comm, result) \
+    callMpi(4, datatype, sendbuf, recvbuf, sendcount, MPI_OP_NULL, root, comm, result)
+
+#define CALL_MPI_ALLGATHER(datatype, sendbuf, sendcount, recvbuf, recvcount, comm, result) \
+    callMpi(5, datatype, sendbuf, recvbuf, sendcount, MPI_OP_NULL, 0, comm, result)
+
+#define CALL_MPI_ALLTOALL(datatype, sendbuf, sendcount, recvbuf, recvcount, comm, result) \
+    callMpi(6, datatype, sendbuf, recvbuf, sendcount, MPI_OP_NULL, 0, comm, result)
+
+#define CALL_MPI_REDUCE_SCATTER(datatype, sendbuf, recvbuf, recvcount, op, comm, result) \
+    callMpi(7, datatype, sendbuf, recvbuf, recvcount, op, 0, comm, result)
+
+class flagcxMpiContext {
+public:
+    flagcxMpiContext(int rank, int nranks, bootstrapState *bootstrap);
+    ~flagcxMpiContext();
+    
+    // Getters
+    MPI_Comm getMpiComm() const { return mpiComm_; }
+    int getRank() const { return rank_; }
+    int getSize() const { return size_; }
+    bootstrapState* getBootstrap() const { return bootstrap_; }
+    bool isValidContext() const { return isValid_; }
+    const std::string& getLastError() const { return lastError_; }
+    
+    // Operations
+    bool createCustomComm(MPI_Comm baseComm = MPI_COMM_WORLD);
+    void setComm(MPI_Comm comm) { mpiComm_ = comm; }
+
+private:
+    MPI_Comm mpiComm_;
+    int rank_;
+    int size_;
+    bootstrapState *bootstrap_;
+    bool isValid_;
+    bool ownsComm_;
+    std::string lastError_;
+    
+    // Helper methods
+    void setError(const std::string& error) { lastError_ = error; isValid_ = false; }
+    bool validateMpiEnvironment();
+};
+
+inline flagcxMpiContext::flagcxMpiContext(int rank, int nranks, bootstrapState *bootstrap) 
+    : mpiComm_(MPI_COMM_NULL), rank_(rank), size_(nranks), bootstrap_(bootstrap),
+      isValid_(false), ownsComm_(false) {
+
+    if (!validateMpiEnvironment()) {
+        return;
+    }
+    
+    mpiComm_ = MPI_COMM_WORLD;
+    ownsComm_ = false;
+    
+    int mpi_rank, mpi_size;
+    MPI_Comm_rank(mpiComm_, &mpi_rank);
+    MPI_Comm_size(mpiComm_, &mpi_size);
+    
+    if (rank_ != mpi_rank || size_ != mpi_size) {
+        printf("Warning: Context parameters (%d/%d) differ from MPI (%d/%d), using MPI values\n", 
+               rank_, size_, mpi_rank, mpi_size);
+        rank_ = mpi_rank;
+        size_ = mpi_size;
+    }
+    isValid_ = true;
+}
+
+inline flagcxMpiContext::~flagcxMpiContext() {
+    // if comm is not MPI_COMM_WORLD, free it
+    if (ownsComm_ && mpiComm_ != MPI_COMM_WORLD && mpiComm_ != MPI_COMM_NULL) {
+        MPI_Comm_free(&mpiComm_);
+    }
+}
+
+inline bool flagcxMpiContext::createCustomComm(MPI_Comm baseComm) {
+    if (ownsComm_ && mpiComm_ != MPI_COMM_WORLD && mpiComm_ != MPI_COMM_NULL) {
+        MPI_Comm_free(&mpiComm_);
+    }
+    
+    int result = MPI_Comm_dup(baseComm, &mpiComm_);
+    if (result != MPI_SUCCESS) {
+        setError("Failed to duplicate MPI communicator");
+        return false;
+    }
+    ownsComm_ = true;
+    // update rank and size
+    MPI_Comm_rank(mpiComm_, &rank_);
+    MPI_Comm_size(mpiComm_, &size_);
+    
+    return true;
+}
+
+inline bool flagcxMpiContext::validateMpiEnvironment() {
+    int initialized;
+    if (MPI_Initialized(&initialized) != MPI_SUCCESS) {
+        setError("Failed to check MPI initialization status");
+        return false;
+    }
+    
+    if (!initialized) {
+        setError("MPI is not initialized");
+        return false;
+    }
+    
+    return true;
+}
+
+struct flagcxInnerComm {
+    std::shared_ptr<flagcxMpiContext> base;
+};
+
+
+#endif // USE_MPI_ADAPTOR


### PR DESCRIPTION
- Implemented MPI adaptor (mpi_adaptor.cc/h)
- Integrated MPI adaptor into adaptor system (adaptor.cc/h)
- Updated Makefile to support MPI build options
- Enabled a complete MPI adaptor to support heterogeneous backend communication across vendors
new mpi adaptor test results：[Flagcx mpi vs bootstrap transport test data.pdf](https://github.com/user-attachments/files/20865613/Flagcx.mpi.vs.bootstrap.transport.test.data.pdf)