### PR TITLE
Align XCCL uniqueId header with uint64_t prefix for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Tests for FlagCX are maintained in `test/perf`.
 ```sh
 cd test/perf
 make [USE_NVIDIA/USE_ILUVATAR_COREX/USE_CAMBRICON/USE_METAX/USE_KUNLUNXIN/USE_DU]=1
-./test_allreduce -b 128M -e 8G -f 2
+mpirun --allow-run-as-root -np 8 ./test_allreduce -b 128K -e 4G -f 2
 ```
 Note that the default MPI install path is set to `/usr/local/mpi`, you may specify the MPI path with:
 ```sh

--- a/flagcx/core/c2c_algo.cc
+++ b/flagcx/core/c2c_algo.cc
@@ -1667,7 +1667,8 @@ flagcxResult_t flagcxC2cPlanner::execute(const void *sendbuff, void *recvbuff,
       commOp_ == flagcxCommOpReduceScatter) {
     int clusterCountValid_ = 1;
     for (int i = 0; i < comm_->nclusters; ++i) {
-      if (comm_->nclusters > int(clusterInterRankList_[i].size())) {
+      if (comm_->nclusters > int(clusterInterRankList_[i].size()) &&
+          comm_->nclusters > 2) {
         clusterCountValid_ = 0;
         break;
       }


### PR DESCRIPTION
This PR updates aligns the XCCL uniqueId with other uniqueId structures across the codebase, by offseting the uniqueId pointer by sizeof(int) before passing it to bkcl_get_unique_id and bkcl_init_rank. 

Note that when performing heterogeneous communication between Kunlunxin and other devices, XCCL must be used to generate the unique ID.