### PR TITLE
Support heterogeneous communicaition on Kunlunxin via device func mechanism

### DIFF
--- a/flagcx/adaptor/kunlunxin_adaptor.cc
+++ b/flagcx/adaptor/kunlunxin_adaptor.cc
@@ -262,6 +262,15 @@ flagcxResult_t kunlunAdaptorLaunchHostFunc(flagcxStream_t stream,
   return flagcxSuccess;
 }
 
+flagcxResult_t kunlunAdaptorLaunchDeviceFunc(flagcxStream_t stream,
+                                             flagcxLaunchFunc_t fn,
+                                             void *args) {
+  if (stream != NULL) {
+    fn(stream, args);
+  }
+  return flagcxSuccess;
+}
+
 flagcxResult_t kunlunAdaptorGetDeviceProperties(struct flagcxDevProps *props,
                                                 int dev) {
   if (props == NULL) {
@@ -300,57 +309,67 @@ flagcxResult_t kunlunAdaptorGetDeviceByPciBusId(int *dev,
   return flagcxSuccess;
 }
 
-struct flagcxDeviceAdaptor kunlunAdaptor {
-  "KUNLUN",
-      // Basic functions
-      kunlunAdaptorDeviceSynchronize, kunlunAdaptorDeviceMemcpy,
-      kunlunAdaptorDeviceMemset, kunlunAdaptorDeviceMalloc,
-      kunlunAdaptorDeviceFree, kunlunAdaptorSetDevice, kunlunAdaptorGetDevice,
-      kunlunAdaptorGetDeviceCount, kunlunAdaptorGetVendor,
-      // GDR functions
-      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-      kunlunAdaptorGdrMemAlloc, kunlunAdaptorGdrMemFree,
-      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-            // *memHandle);
-      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-      kunlunAdaptorGdrPtrMmap,   // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr,
-                                 // void *devptr, size_t sz);
-      kunlunAdaptorGdrPtrMunmap, // flagcxResult_t (*gdrPtrMummap)(void *cpuptr,
-                                 // size_t sz);
-      // Stream functions
-      kunlunAdaptorStreamCreate, kunlunAdaptorStreamDestroy,
-      kunlunAdaptorStreamCopy, kunlunAdaptorStreamFree,
-      kunlunAdaptorStreamSynchronize, kunlunAdaptorStreamQuery,
-      kunlunAdaptorStreamWaitEvent,
-      // Event functions
-      kunlunAdaptorEventCreate, kunlunAdaptorEventDestroy,
-      kunlunAdaptorEventRecord, kunlunAdaptorEventSynchronize,
-      kunlunAdaptorEventQuery,
-      // Kernel launch
-      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-            // share_mem, void *stream, void *memHandle);
-      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-      NULL, // flagcxResult_t// (*launchDeviceFunc)(flagcxStream_t stream,
-            // void *args);
-      // Others
-      kunlunAdaptorGetDeviceProperties, // flagcxResult_t
-                                        // (*getDeviceProperties)(struct
-                                        // flagcxDevProps *props, int dev);
-      kunlunAdaptorGetDevicePciBusId,   // flagcxResult_t
-                                        // (*getDevicePciBusId)(char *pciBusId,
-                                        // int len, int dev);
-      kunlunAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                        // (*getDeviceByPciBusId)(int
-                                        // *dev, const char *pciBusId);
-      kunlunAdaptorLaunchHostFunc,
-      // DMA buffer
-      NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-            // void *buffer, size_t size, unsigned long long flags);
+struct flagcxDeviceAdaptor kunlunAdaptor{
+    "KUNLUN",
+    // Basic functions
+    kunlunAdaptorDeviceSynchronize,
+    kunlunAdaptorDeviceMemcpy,
+    kunlunAdaptorDeviceMemset,
+    kunlunAdaptorDeviceMalloc,
+    kunlunAdaptorDeviceFree,
+    kunlunAdaptorSetDevice,
+    kunlunAdaptorGetDevice,
+    kunlunAdaptorGetDeviceCount,
+    kunlunAdaptorGetVendor,
+    // GDR functions
+    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+    kunlunAdaptorGdrMemAlloc,
+    kunlunAdaptorGdrMemFree,
+    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+          // *memHandle);
+    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+    kunlunAdaptorGdrPtrMmap,   // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr,
+                               // void *devptr, size_t sz);
+    kunlunAdaptorGdrPtrMunmap, // flagcxResult_t (*gdrPtrMummap)(void *cpuptr,
+                               // size_t sz);
+    // Stream functions
+    kunlunAdaptorStreamCreate,
+    kunlunAdaptorStreamDestroy,
+    kunlunAdaptorStreamCopy,
+    kunlunAdaptorStreamFree,
+    kunlunAdaptorStreamSynchronize,
+    kunlunAdaptorStreamQuery,
+    kunlunAdaptorStreamWaitEvent,
+    // Event functions
+    kunlunAdaptorEventCreate,
+    kunlunAdaptorEventDestroy,
+    kunlunAdaptorEventRecord,
+    kunlunAdaptorEventSynchronize,
+    kunlunAdaptorEventQuery,
+    // Kernel launch
+    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+          // share_mem, void *stream, void *memHandle);
+    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+    kunlunAdaptorLaunchDeviceFunc,
+    // Others
+    kunlunAdaptorGetDeviceProperties, // flagcxResult_t
+                                      // (*getDeviceProperties)(struct
+                                      // flagcxDevProps *props, int dev);
+    kunlunAdaptorGetDevicePciBusId,   // flagcxResult_t
+                                      // (*getDevicePciBusId)(char *pciBusId,
+                                      // int len, int dev);
+    kunlunAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                      // (*getDeviceByPciBusId)(int
+                                      // *dev, const char *pciBusId);
+    kunlunAdaptorLaunchHostFunc,
+    // DMA buffer
+    NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
+    NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
+          // void *buffer, size_t size, unsigned long long flags);
 };
 
 #endif // USE_KUNLUNXIN_ADAPTOR

--- a/flagcx/core/global_comm.h
+++ b/flagcx/core/global_comm.h
@@ -28,7 +28,6 @@ struct flagcxComm {
   int homo_inter_rank;
   int homo_ranks;
   int has_single_rank_homo_comm;
-  int support_multi_nic;
   flagcxCommunicatorType_t comm_type;
   uint64_t magic;
   volatile uint32_t *abortFlag;

--- a/flagcx/core/group.cc
+++ b/flagcx/core/group.cc
@@ -182,7 +182,7 @@ static flagcxResult_t groupLaunch(struct flagcxAsyncJob *job_) {
                 (void *)&op->args.hEventReady, (void *)op->args.dEventReady,
                 sizeof(bool), flagcxMemcpyDeviceToHost, op->stream, NULL));
             argList = {(void *)&op->args.eventRecorded,
-                       (void *)&op->args.hlArgs, op->args.dlArgs};
+                       (void *)&op->args.hlArgs, (void *)op->args.dlArgs};
             funcQueue.push({op->stream, op->event, argList.data()});
           } else {
             FLAGCXCHECK(deviceAdaptor->launchHostFunc(
@@ -229,7 +229,7 @@ static flagcxResult_t groupLaunch(struct flagcxAsyncJob *job_) {
                 (void *)&op->args.hEventReady, (void *)op->args.dEventReady,
                 sizeof(bool), flagcxMemcpyDeviceToHost, op->stream, NULL));
             argList = {(void *)&op->args.eventRecorded,
-                       (void *)&op->args.hlArgs, op->args.dlArgs};
+                       (void *)&op->args.hlArgs, (void *)op->args.dlArgs};
             funcQueue.push({op->stream, op->event, argList.data()});
           } else {
             FLAGCXCHECK(deviceAdaptor->launchHostFunc(
@@ -250,7 +250,7 @@ static flagcxResult_t groupLaunch(struct flagcxAsyncJob *job_) {
 
   while (!funcQueue.empty()) {
     // get corresponding func args
-    struct flagcxFuncArgs args = funcQueue.front();
+    flagcxFuncArgs args = funcQueue.front();
 
     // launch host or device func
     if (deviceAsyncLoad && deviceAsyncStore) {

--- a/flagcx/core/group.cc
+++ b/flagcx/core/group.cc
@@ -31,14 +31,12 @@ __thread struct flagcxIntruQueue<struct flagcxAsyncJob, &flagcxAsyncJob::next>
 flagcxResult_t flagcxHeteroGroupStart() {
   flagcxResult_t ret = flagcxSuccess;
   FLAGCXCHECK(flagcxGroupStartInternal());
-  TRACE_CALL("flagcxGroupStart()");
   return ret;
 }
 
 flagcxResult_t flagcxHeteroGroupEnd() {
   flagcxResult_t ret = flagcxSuccess;
   FLAGCXCHECKGOTO(flagcxGroupEndInternal(), ret, exit);
-  TRACE_CALL("flagcxGroupEnd()");
 exit:
   return ret;
 }
@@ -89,6 +87,22 @@ static flagcxResult_t groupLaunch(struct flagcxAsyncJob *job_) {
   // volatile bool *groupAbortFlag = gjob->abortFlagPtr;
 
   std::queue<flagcxFuncArgs> funcQueue;
+  // host func: {eventRecorded, hlArgs, NULL};
+  // device func: {eventRecorded, hlArgs, dlArgs};
+  std::queue<std::vector<void *>> argsQueue;
+
+  // When relaxed ordering is enabled, the H2D copy is issued on cpStream
+  // Otherwise, it shares commStream with the device function to guarantee
+  // execution order
+  int deviceFuncRelaxedOrdering = 0;
+  const char *dfroStr = std::getenv("FLAGCX_DEVICE_FUNC_RELAXED_ORDERING");
+  if (dfroStr) {
+    if (std::stoi(dfroStr) == 1) {
+      deviceFuncRelaxedOrdering = 1;
+    } else {
+      deviceFuncRelaxedOrdering = 0;
+    }
+  }
 
   if (groupCommPreconnectHeadMain != nullptr) {
     struct flagcxHeteroComm *comm = groupCommPreconnectHeadMain;
@@ -151,8 +165,10 @@ static flagcxResult_t groupLaunch(struct flagcxAsyncJob *job_) {
           op->args.chunkSize = CHUNKSIZE;
           op->args.chunkSteps = (p2p->bytes + CHUNKSIZE - 1) / (CHUNKSIZE);
           op->args.sendStepMask = MAXSTEPS - 1;
+          op->args.deviceFuncRelaxedOrdering = deviceFuncRelaxedOrdering;
           op->stream = p2p->stream;
           FLAGCXCHECK(deviceAdaptor->eventCreate(&op->event));
+          std::vector<void *> argList;
           if (deviceAsyncLoad && deviceAsyncStore) {
             FLAGCXCHECK(deviceAdaptor->deviceMalloc(
                 (void **)&op->args.dlArgs, sizeof(bool), flagcxMemDevice,
@@ -162,14 +178,20 @@ static flagcxResult_t groupLaunch(struct flagcxAsyncJob *job_) {
                 op->stream));
             FLAGCXCHECK(deviceAdaptor->launchDeviceFunc(
                 op->stream, deviceAsyncStore, op->args.dEventReady));
-            funcQueue.push({op->stream, op->event, &op->args.eventRecorded,
-                            op->args.dlArgs});
+            FLAGCXCHECK(deviceAdaptor->deviceMemcpy(
+                (void *)&op->args.hEventReady, (void *)op->args.dEventReady,
+                sizeof(bool), flagcxMemcpyDeviceToHost, op->stream, NULL));
+            argList = {(void *)&op->args.eventRecorded,
+                       (void *)&op->args.hlArgs, op->args.dlArgs};
+            funcQueue.push({op->stream, op->event, argList.data()});
           } else {
             FLAGCXCHECK(deviceAdaptor->launchHostFunc(
                 op->stream, cpuAsyncStore, (void *)&op->args.hEventReady));
-            funcQueue.push({op->stream, op->event, &op->args.eventRecorded,
-                            (void *)&op->args.hlArgs});
+            argList = {(void *)&op->args.eventRecorded,
+                       (void *)&op->args.hlArgs, NULL};
+            funcQueue.push({op->stream, op->event, argList.data()});
           }
+          argsQueue.push(std::move(argList));
           FLAGCXCHECK(flagcxProxySaveOp(comm, op));
           free(p2p);
         }
@@ -190,8 +212,10 @@ static flagcxResult_t groupLaunch(struct flagcxAsyncJob *job_) {
           op->args.chunkSize = CHUNKSIZE;
           op->args.chunkSteps = (p2p->bytes + CHUNKSIZE - 1) / (CHUNKSIZE);
           op->args.sendStepMask = MAXSTEPS - 1;
+          op->args.deviceFuncRelaxedOrdering = deviceFuncRelaxedOrdering;
           op->stream = p2p->stream;
           FLAGCXCHECK(deviceAdaptor->eventCreate(&op->event));
+          std::vector<void *> argList;
           if (deviceAsyncLoad && deviceAsyncStore) {
             FLAGCXCHECK(deviceAdaptor->deviceMalloc(
                 (void **)&op->args.dlArgs, sizeof(bool), flagcxMemDevice,
@@ -201,14 +225,20 @@ static flagcxResult_t groupLaunch(struct flagcxAsyncJob *job_) {
                 op->stream));
             FLAGCXCHECK(deviceAdaptor->launchDeviceFunc(
                 op->stream, deviceAsyncStore, op->args.dEventReady));
-            funcQueue.push({op->stream, op->event, &op->args.eventRecorded,
-                            op->args.dlArgs});
+            FLAGCXCHECK(deviceAdaptor->deviceMemcpy(
+                (void *)&op->args.hEventReady, (void *)op->args.dEventReady,
+                sizeof(bool), flagcxMemcpyDeviceToHost, op->stream, NULL));
+            argList = {(void *)&op->args.eventRecorded,
+                       (void *)&op->args.hlArgs, op->args.dlArgs};
+            funcQueue.push({op->stream, op->event, argList.data()});
           } else {
             FLAGCXCHECK(deviceAdaptor->launchHostFunc(
                 op->stream, cpuAsyncStore, (void *)&op->args.hEventReady));
-            funcQueue.push({op->stream, op->event, &op->args.eventRecorded,
-                            (void *)&op->args.hlArgs});
+            argList = {(void *)&op->args.eventRecorded,
+                       (void *)&op->args.hlArgs, NULL};
+            funcQueue.push({op->stream, op->event, argList.data()});
           }
+          argsQueue.push(std::move(argList));
           FLAGCXCHECK(flagcxProxySaveOp(comm, op));
           free(p2p);
         }
@@ -221,20 +251,31 @@ static flagcxResult_t groupLaunch(struct flagcxAsyncJob *job_) {
   while (!funcQueue.empty()) {
     // get corresponding func args
     struct flagcxFuncArgs args = funcQueue.front();
-    funcQueue.pop();
 
     // launch host or device func
     if (deviceAsyncLoad && deviceAsyncStore) {
+      if (deviceFuncRelaxedOrdering == 0) {
+        bool *volatile hlArgs = (bool *)args.argList[1];
+        while (!__atomic_load_n(hlArgs, __ATOMIC_RELAXED)) {
+        }
+        FLAGCXCHECK(deviceAdaptor->deviceMemcpy(
+            args.argList[2], args.argList[1], sizeof(bool),
+            flagcxMemcpyHostToDevice, args.stream, NULL));
+      }
       FLAGCXCHECK(deviceAdaptor->launchDeviceFunc(args.stream, deviceAsyncLoad,
-                                                  args.value));
+                                                  args.argList[2]));
     } else {
-      FLAGCXCHECK(
-          deviceAdaptor->launchHostFunc(args.stream, cpuAsyncLoad, args.value));
+      FLAGCXCHECK(deviceAdaptor->launchHostFunc(args.stream, cpuAsyncLoad,
+                                                args.argList[1]));
     }
 
     // record func op
     FLAGCXCHECK(deviceAdaptor->eventRecord(args.event, args.stream));
-    *args.recorded = true;
+    bool *volatile recorded = (bool *)args.argList[0];
+    __atomic_store_n(recorded, 1, __ATOMIC_RELAXED);
+
+    funcQueue.pop();
+    argsQueue.pop();
   }
 
   while (!flagcxIntruQueueEmpty(asyncJobsMain)) {

--- a/flagcx/core/ibvwrap.cc
+++ b/flagcx/core/ibvwrap.cc
@@ -203,18 +203,9 @@ flagcxResult_t wrap_ibv_dealloc_pd(
 
 flagcxResult_t wrap_ibv_reg_mr(struct ibv_mr **ret, struct ibv_pd *pd,
                                void *addr, size_t length, int access) {
-  if (deviceAdaptor->gdrPtrMmap && deviceAdaptor->gdrPtrMummap) {
-    void *cpuptr;
-    deviceAdaptor->gdrPtrMmap(&cpuptr, addr, length);
-    IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_reg_mr,
-                        ibv_internal_reg_mr(pd, cpuptr, length, access), *ret,
-                        NULL, "ibv_reg_mr");
-    deviceAdaptor->gdrPtrMummap(cpuptr, length);
-  } else {
-    IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_reg_mr,
-                        ibv_internal_reg_mr(pd, addr, length, access), *ret,
-                        NULL, "ibv_reg_mr");
-  }
+  IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_reg_mr,
+                      ibv_internal_reg_mr(pd, addr, length, access), *ret, NULL,
+                      "ibv_reg_mr");
 }
 
 struct ibv_mr *wrap_direct_ibv_reg_mr(struct ibv_pd *pd, void *addr,
@@ -235,20 +226,9 @@ flagcxResult_t wrap_ibv_reg_mr_iova2(struct ibv_mr **ret, struct ibv_pd *pd,
   if (ret == NULL) {
     return flagcxSuccess;
   } // Assume dummy call
-  if (deviceAdaptor->gdrPtrMmap && deviceAdaptor->gdrPtrMummap) {
-    void *cpuptr;
-    deviceAdaptor->gdrPtrMmap(&cpuptr, addr, length);
-    IBV_PTR_CHECK_ERRNO(
-        ibvSymbols, ibv_internal_reg_mr_iova2,
-        ibv_internal_reg_mr_iova2(pd, cpuptr, length, iova, access), *ret, NULL,
-        "ibv_reg_mr_iova2");
-    deviceAdaptor->gdrPtrMummap(cpuptr, length);
-  } else {
-    IBV_PTR_CHECK_ERRNO(
-        ibvSymbols, ibv_internal_reg_mr_iova2,
-        ibv_internal_reg_mr_iova2(pd, addr, length, iova, access), *ret, NULL,
-        "ibv_reg_mr_iova2");
-  }
+  IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_reg_mr_iova2,
+                      ibv_internal_reg_mr_iova2(pd, addr, length, iova, access),
+                      *ret, NULL, "ibv_reg_mr_iova2");
 }
 
 /* DMA-BUF support */

--- a/flagcx/core/launch_kernel.cc
+++ b/flagcx/core/launch_kernel.cc
@@ -25,13 +25,13 @@ flagcxResult_t loadKernelSymbol(const char *path, const char *name,
   return flagcxSuccess;
 }
 
-void cpuAsyncStore(void *_args) {
-  bool *volatile args = (bool *)_args;
-  __atomic_store_n(args, 1, __ATOMIC_RELAXED);
+void cpuAsyncStore(void *args) {
+  bool *volatile value = (bool *)args;
+  __atomic_store_n(value, 1, __ATOMIC_RELAXED);
 }
 
-void cpuAsyncLoad(void *_args) {
-  bool *volatile args = (bool *)_args;
-  while (!__atomic_load_n(args, __ATOMIC_RELAXED))
-    ;
+void cpuAsyncLoad(void *args) {
+  bool *volatile value = (bool *)args;
+  while (!__atomic_load_n(value, __ATOMIC_RELAXED)) {
+  }
 }

--- a/flagcx/core/launch_kernel.h
+++ b/flagcx/core/launch_kernel.h
@@ -29,17 +29,10 @@ flagcxResult_t loadKernelSymbol(const char *path, const char *name,
 }
 #endif
 
-struct flagcxFuncArgs {
-  flagcxStream_t stream;
-  flagcxEvent_t event;
-  bool *recorded; // Indicates if the op has been recorded by the event
-  void *value;    // May point to either hlArgs or dlArgs
-};
-
 extern flagcxLaunchFunc_t deviceAsyncStore;
 extern flagcxLaunchFunc_t deviceAsyncLoad;
 
-void cpuAsyncStore(void *_args);
-void cpuAsyncLoad(void *_args);
+void cpuAsyncStore(void *args);
+void cpuAsyncLoad(void *args);
 
 #endif

--- a/flagcx/core/launch_kernel.h
+++ b/flagcx/core/launch_kernel.h
@@ -1,10 +1,10 @@
 #ifndef FLAGCX_LAUNCH_KERNEL_H_
-typedef void (*flagcxLaunchFunc_t)(flagcxStream_t, void *);
 #define FLAGCX_LAUNCH_KERNEL_H_
 #pragma once
+#include "flagcx.h"
+typedef void (*flagcxLaunchFunc_t)(flagcxStream_t, void *);
 #include "adaptor.h"
 #include "debug.h"
-#include "flagcx.h"
 #include "param.h"
 #include "topo.h"
 #include "utils.h"

--- a/flagcx/core/launch_kernel.h
+++ b/flagcx/core/launch_kernel.h
@@ -1,5 +1,4 @@
 #ifndef FLAGCX_LAUNCH_KERNEL_H_
-typedef struct flagcxStream *flagcxStream_t;
 typedef void (*flagcxLaunchFunc_t)(flagcxStream_t, void *);
 #define FLAGCX_LAUNCH_KERNEL_H_
 #pragma once
@@ -33,8 +32,8 @@ flagcxResult_t loadKernelSymbol(const char *path, const char *name,
 struct flagcxFuncArgs {
   flagcxStream_t stream;
   flagcxEvent_t event;
-  bool *recorded;
-  void *value;
+  bool *recorded; // Indicates if the op has been recorded by the event
+  void *value;    // May point to either hlArgs or dlArgs
 };
 
 extern flagcxLaunchFunc_t deviceAsyncStore;
@@ -42,32 +41,5 @@ extern flagcxLaunchFunc_t deviceAsyncLoad;
 
 void cpuAsyncStore(void *_args);
 void cpuAsyncLoad(void *_args);
-
-/*
-Reference CUDA implementation for async kernel launch (for future adaptor
-implementations)
-1.1 deviceAsyncStore, set value to true
-__global__ void deviceAsyncStore(bool* __restrict__ value) {
-  *value = 1;
-  // __threadfence_system();  // Ensure that the write is visible to the CPU.
-}
-
-1.2 host launcher for deviceAsyncStore
-extern "C" flagcxResult_t launchDeviceAsyncStore(flagcxStream_t stream, void
-*args) { bool* value = static_cast<bool*>(args); deviceAsyncStore<<<1, 1, 0,
-*(cudaStream_t*)stream>>>(value); return flagcxSuccess;
-}
-
-2.1 deviceAsyncLoad, wait until value becomes true
-__global__ void deviceAsyncLoad(const volatile bool* __restrict__ value) {
-  while (!(*value)) { // no-op; }
-}
-
-2.2 host launcher for deviceAsyncLoad
-extern "C" flagcxResult_t launchDeviceAsyncLoad(flagcxStream_t stream, void
-*args) { bool* value = static_cast<bool*>(args); deviceAsyncLoad<<<1, 1, 0,
-*(cudaStream_t*)stream>>>(value); return flagcxSuccess;
-}
-*/
 
 #endif

--- a/flagcx/core/net_ib.cc
+++ b/flagcx/core/net_ib.cc
@@ -1623,16 +1623,27 @@ flagcxResult_t flagcxIbRegMrDmaBufInternal(flagcxIbNetCommDevBase *base,
                                                flags),
                         res, returning);
       } else {
+        void *cpuptr = NULL;
+        if (deviceAdaptor->gdrPtrMmap && deviceAdaptor->gdrPtrMummap) {
+          deviceAdaptor->gdrPtrMmap(&cpuptr, (void *)addr, pages * pageSize);
+        }
         if (flagcxIbRelaxedOrderingEnabled) {
           // Use IBVERBS_1.8 API - needed for IBV_ACCESS_RELAXED_ORDERING
           // support
-          FLAGCXCHECKGOTO(wrap_ibv_reg_mr_iova2(&mr, base->pd, (void *)addr,
-                                                pages * pageSize, addr, flags),
-                          res, returning);
+          FLAGCXCHECKGOTO(
+              wrap_ibv_reg_mr_iova2(&mr, base->pd,
+                                    cpuptr == NULL ? (void *)addr : cpuptr,
+                                    pages * pageSize, addr, flags),
+              res, returning);
         } else {
-          FLAGCXCHECKGOTO(wrap_ibv_reg_mr(&mr, base->pd, (void *)addr,
-                                          pages * pageSize, flags),
-                          res, returning);
+          FLAGCXCHECKGOTO(
+              wrap_ibv_reg_mr(&mr, base->pd,
+                              cpuptr == NULL ? (void *)addr : cpuptr,
+                              pages * pageSize, flags),
+              res, returning);
+        }
+        if (deviceAdaptor->gdrPtrMmap && deviceAdaptor->gdrPtrMummap) {
+          deviceAdaptor->gdrPtrMummap(cpuptr, pages * pageSize);
         }
       }
       TRACE(FLAGCX_INIT | FLAGCX_NET,

--- a/flagcx/core/net_ib.cc
+++ b/flagcx/core/net_ib.cc
@@ -4,6 +4,7 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
+#include "adaptor.h"
 #include "core.h"
 #include "flagcx_common.h"
 #include "flagcx_net.h"

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -185,7 +185,8 @@ static flagcxResult_t progressOps(struct flagcxProxyState *proxyState,
             struct sendNetResources *resources =
                 (sendNetResources *)op->connection->transportResources;
             flagcxProxySend(resources, op->recvbuff, op->nbytes, &op->args);
-            if (op->args.done && op->args.eventRecorded) {
+            if (op->args.done &&
+                __atomic_load_n(&op->args.eventRecorded, __ATOMIC_RELAXED)) {
               // The P2P object should not be destroyed until the associated
               // event has completed
               if (deviceAdaptor->eventQuery(op->event) == flagcxSuccess) {
@@ -202,7 +203,8 @@ static flagcxResult_t progressOps(struct flagcxProxyState *proxyState,
             struct recvNetResources *resources =
                 (recvNetResources *)op->connection->transportResources;
             flagcxProxyRecv(resources, op->recvbuff, op->nbytes, &op->args);
-            if (op->args.done && op->args.eventRecorded) {
+            if (op->args.done &&
+                __atomic_load_n(&op->args.eventRecorded, __ATOMIC_RELAXED)) {
               if (deviceAdaptor->eventQuery(op->event) == flagcxSuccess) {
                 flagcxIntruQueueDelete(queue, op);
                 FLAGCXCHECK(deviceAdaptor->eventDestroy(op->event));

--- a/flagcx/core/proxy.h
+++ b/flagcx/core/proxy.h
@@ -115,7 +115,8 @@ struct flagcxProxyArgs {
   struct flagcxProxyArgs **proxyAppendPtr;
 
   /*for launch*/
-  bool eventRecorded = false;
+  int deviceFuncRelaxedOrdering = 0;
+  volatile bool eventRecorded = false;
   volatile bool hlArgs = false;
   volatile bool hEventReady = false;
   bool *volatile dlArgs;

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -59,22 +59,31 @@ flagcxResult_t wrapper_deviceMemcpy(void *dst, void *src, size_t size,
   return deviceAdaptor->deviceMemcpy(dst, src, size, type, stream, NULL);
 }
 
-static struct flagcxDeviceHandle globalDeviceHandle {
-  // Basic functions
-  deviceAdaptor->deviceSynchronize, wrapper_deviceMemcpy,
-      deviceAdaptor->deviceMemset, deviceAdaptor->deviceMalloc,
-      deviceAdaptor->deviceFree, deviceAdaptor->setDevice,
-      deviceAdaptor->getDevice, deviceAdaptor->getDeviceCount,
-      deviceAdaptor->getVendor,
-      // Stream functions
-      deviceAdaptor->streamCreate, deviceAdaptor->streamDestroy,
-      deviceAdaptor->streamCopy, deviceAdaptor->streamFree,
-      deviceAdaptor->streamSynchronize, deviceAdaptor->streamQuery,
-      deviceAdaptor->streamWaitEvent,
-      // Event functions
-      deviceAdaptor->eventCreate, deviceAdaptor->eventDestroy,
-      deviceAdaptor->eventRecord, deviceAdaptor->eventSynchronize,
-      deviceAdaptor->eventQuery,
+static struct flagcxDeviceHandle globalDeviceHandle{
+    // Basic functions
+    deviceAdaptor->deviceSynchronize,
+    wrapper_deviceMemcpy,
+    deviceAdaptor->deviceMemset,
+    deviceAdaptor->deviceMalloc,
+    deviceAdaptor->deviceFree,
+    deviceAdaptor->setDevice,
+    deviceAdaptor->getDevice,
+    deviceAdaptor->getDeviceCount,
+    deviceAdaptor->getVendor,
+    // Stream functions
+    deviceAdaptor->streamCreate,
+    deviceAdaptor->streamDestroy,
+    deviceAdaptor->streamCopy,
+    deviceAdaptor->streamFree,
+    deviceAdaptor->streamSynchronize,
+    deviceAdaptor->streamQuery,
+    deviceAdaptor->streamWaitEvent,
+    // Event functions
+    deviceAdaptor->eventCreate,
+    deviceAdaptor->eventDestroy,
+    deviceAdaptor->eventRecord,
+    deviceAdaptor->eventSynchronize,
+    deviceAdaptor->eventQuery,
 };
 
 flagcxResult_t flagcxEnsureCommReady(flagcxComm_t comm) {
@@ -195,7 +204,6 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
   (*comm)->homo_root_rank = -1;
   (*comm)->homo_ranks = -1;
   (*comm)->has_single_rank_homo_comm = -1;
-  (*comm)->support_multi_nic = -1;
   (*comm)->magic = 0;
   (*comm)->abortFlag = 0;
   (*comm)->bootstrap = NULL;
@@ -360,23 +368,7 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
     }
   }
 
-  INFO(
-      FLAGCX_INIT,
-      "rank = %d, nranks = %d, nclusters = %d, cluster_id = %d, cluster_size "
-      "= %d, cluster_inter_rank = %d, homo_rank = %d, homo_root_rank = %d, "
-      "homo_inter_rank = %d, homo_ranks = %d, has_single_rank_homo_comm = %d, ",
-      rank, nranks, (*comm)->nclusters, (*comm)->cluster_ids[rank],
-      (*comm)->cluster_sizes[(*comm)->cluster_ids[rank]],
-      (*comm)->cluster_inter_ranks[(*comm)->cluster_ids[rank]],
-      (*comm)->homo_rank, (*comm)->homo_root_rank, (*comm)->homo_inter_rank,
-      (*comm)->homo_ranks, (*comm)->has_single_rank_homo_comm);
-
   if (!is_homo_comm(*comm)) {
-    char *enableMultiNicSupport = getenv("FLAGCX_ENABLE_MULTI_NIC_SUPPORT");
-    if (enableMultiNicSupport) {
-      (*comm)->support_multi_nic = std::stoi(enableMultiNicSupport);
-    }
-
     // Experimental for multi-nic support
     // Collect nic distance to ranks
     (*comm)->clusterInterRankList.resize((*comm)->nclusters);
@@ -434,15 +426,15 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
         "= %d, "
         "cluster_inter_rank = %d, homo_rank = %d, homo_root_rank = %d, "
         "homo_inter_rank = %d, homo_ranks = %d, "
-        "has_single_rank_homo_comm = %d, support_multi_nic = %d, "
+        "has_single_rank_homo_comm = %d, "
         "homoInterRootRank = %d, homoInterMyRank = %d, homoInterRanks = %d",
         rank, nranks, (*comm)->nclusters, (*comm)->cluster_ids[rank],
         (*comm)->cluster_sizes[(*comm)->cluster_ids[rank]],
         (*comm)->cluster_inter_ranks[(*comm)->cluster_ids[rank]],
         (*comm)->homo_rank, (*comm)->homo_root_rank, (*comm)->homo_inter_rank,
         (*comm)->homo_ranks, (*comm)->has_single_rank_homo_comm,
-        (*comm)->homo_ranks, (*comm)->homoInterRootRank,
-        (*comm)->homoInterMyRank, (*comm)->homoInterRanks);
+        (*comm)->homoInterRootRank, (*comm)->homoInterMyRank,
+        (*comm)->homoInterRanks);
 
     // Experimental for multi-nic support
     // Reset commId and homo inter root rank calls underlying GetUniqueId

--- a/flagcx/include/flagcx.h
+++ b/flagcx/include/flagcx.h
@@ -86,6 +86,7 @@ typedef enum {
   flagcxMemManaged = 2
 } flagcxMemType_t;
 
+// TODO: add more vendor types
 typedef enum {
   FLAGCX_VENDOR_NVIDIA = 0,
   FLAGCX_VENDOR_ILUVATAR_COREX = 1,
@@ -105,6 +106,13 @@ typedef struct flagcxComm *flagcxComm_t;
 typedef struct flagcxStream *flagcxStream_t;
 /* Opaque handle to flagcxEvent */
 typedef struct flagcxEvent *flagcxEvent_t;
+
+/* Func(kernel) arguments */
+typedef struct {
+  flagcxStream_t stream;
+  flagcxEvent_t event;
+  void **argList;
+} flagcxFuncArgs;
 
 struct flagcxDeviceHandle {
   // Basic functions

--- a/flagcx/kernels/device_async_kernel.cu
+++ b/flagcx/kernels/device_async_kernel.cu
@@ -1,0 +1,23 @@
+// include CUDA-related headers
+#include "flagcx.h"
+
+__global__ void asyncStore(bool* __restrict__ value) {
+  *value = 1; // set value to true
+  // __threadfence_system();  // Ensure that the write is visible to the CPU.
+}
+
+__global__ void asyncLoad(const volatile bool* __restrict__ value) {
+  while (!(*value)) { // no-op; }
+}
+
+extern "C" void deviceAsyncStore(flagcxStream_t stream, void *args) {
+  bool* value = static_cast<bool*>(args);
+  asyncStore<<<1, 1, 0, *(cudaStream_t*)stream>>>(value);
+  return;
+}
+
+extern "C" void deviceAsyncLoad(flagcxStream_t stream, void *args) {
+  bool* value = static_cast<bool*>(args);
+  asyncLoad<<<1, 1, 0, *(cudaStream_t*)stream>>>(value);
+  return;
+}

--- a/flagcx/kernels/device_async_kernel.cu
+++ b/flagcx/kernels/device_async_kernel.cu
@@ -2,7 +2,7 @@
 #include "flagcx.h"
 
 __global__ void asyncStore(bool* __restrict__ value) {
-  *value = 1; // set value to true
+  *value = true; // set value to true
   // __threadfence_system();  // Ensure that the write is visible to the CPU.
 }
 

--- a/flagcx/kernels/device_async_kernel.xpu
+++ b/flagcx/kernels/device_async_kernel.xpu
@@ -1,0 +1,22 @@
+// include XPU-related headers
+#include "flagcx.h"
+
+__global__ void asyncStore(bool* __restrict__ value) {
+  *value = 1; // set value to true
+}
+
+__global__ void asyncLoad(const volatile bool* __restrict__ value) {
+  while (!(*value)) { // no-op; }
+}
+
+extern "C" void deviceAsyncStore(flagcxStream_t stream, void *args) {
+    bool* value = static_cast<bool*>(args);
+    asyncStore<<<1, 1, *(XPUStream*)stream>>>(value);
+    return;
+}
+
+extern "C" void deviceAsyncLoad(flagcxStream_t stream, void *args) {
+    bool* value = static_cast<bool*>(args);
+    asyncLoad<<<1, 1, *(XPUStream*)stream>>>(value);
+    return;
+}

--- a/flagcx/kernels/device_async_kernel.xpu
+++ b/flagcx/kernels/device_async_kernel.xpu
@@ -2,7 +2,8 @@
 #include "flagcx.h"
 
 __global__ void asyncStore(bool* __restrict__ value) {
-  *value = 1; // set value to true
+  *value = true; // set value to true
+  // mfence(); // Ensure that the write is visible to the CPU.
 }
 
 __global__ void asyncLoad(const volatile bool* __restrict__ value) {

--- a/flagcx/kernels/device_async_kernel.xpu
+++ b/flagcx/kernels/device_async_kernel.xpu
@@ -6,7 +6,7 @@ __global__ void asyncStore(bool* __restrict__ value) {
 }
 
 __global__ void asyncLoad(const volatile bool* __restrict__ value) {
-  while (!(*value)) { // no-op; }
+  while (!(*value)) {} // no-op 
 }
 
 extern "C" void deviceAsyncStore(flagcxStream_t stream, void *args) {


### PR DESCRIPTION
This PR introduces support for heterogeneous communication on KunlunXin, composed of three commits:
1. Restrict GDR usage
Call gdrMmap/gdrMunmap only within net_ib.cc to improve portability and maintainability.
2. Add execution order control
Introduce environment variable FLAGCX_DEVICE_FUNC_RELAXED_ORDERING to control whether H2D copy and device function execute in strict sequence or relaxed mode.
3. Ensure proxy resource safety
Guarantee all send/recv operations complete before proxy resource deallocation.
