### PR TITLE
rename all ibv wrapper function to avoid potential symbol conflict

### DIFF
--- a/flagcx/core/ibvwrap.cc
+++ b/flagcx/core/ibvwrap.cc
@@ -15,7 +15,7 @@ static pthread_once_t initOnceControl = PTHREAD_ONCE_INIT;
 static flagcxResult_t initResult;
 struct flagcxIbvSymbols ibvSymbols;
 
-flagcxResult_t wrap_ibv_symbols(void) {
+flagcxResult_t flagcxWrapIbvSymbols(void) {
   pthread_once(&initOnceControl,
                []() { initResult = buildIbvSymbols(&ibvSymbols); });
   return initResult;
@@ -99,25 +99,25 @@ flagcxResult_t wrap_ibv_symbols(void) {
   container.call;                                                              \
   return flagcxSuccess;
 
-flagcxResult_t wrap_ibv_fork_init() {
+flagcxResult_t flagcxWrapIbvForkInit() {
   IBV_INT_CHECK(ibvSymbols, ibv_internal_fork_init, ibv_internal_fork_init(),
                 -1, "ibv_fork_init");
 }
 
-flagcxResult_t wrap_ibv_get_device_list(struct ibv_device ***ret,
-                                        int *num_devices) {
+flagcxResult_t flagcxWrapIbvGetDeviceList(struct ibv_device ***ret,
+                                          int *num_devices) {
   *ret = ibvSymbols.ibv_internal_get_device_list(num_devices);
   if (*ret == NULL)
     *num_devices = 0;
   return flagcxSuccess;
 }
 
-flagcxResult_t wrap_ibv_free_device_list(struct ibv_device **list) {
+flagcxResult_t flagcxWrapIbvFreeDeviceList(struct ibv_device **list) {
   IBV_PASSTHRU(ibvSymbols, ibv_internal_free_device_list,
                ibv_internal_free_device_list(list));
 }
 
-const char *wrap_ibv_get_device_name(struct ibv_device *device) {
+const char *flagcxWrapIbvGetDeviceName(struct ibv_device *device) {
   if (ibvSymbols.ibv_internal_get_device_name == NULL) {
     WARN("lib wrapper not initialized.");
     exit(-1);
@@ -125,7 +125,7 @@ const char *wrap_ibv_get_device_name(struct ibv_device *device) {
   return ibvSymbols.ibv_internal_get_device_name(device);
 }
 
-flagcxResult_t wrap_ibv_open_device(
+flagcxResult_t flagcxWrapIbvOpenDevice(
     struct ibv_context **ret,
     struct ibv_device *device) { /*returns 0 on success, -1 on failure*/
   IBV_PTR_CHECK(ibvSymbols, ibv_internal_open_device,
@@ -133,13 +133,13 @@ flagcxResult_t wrap_ibv_open_device(
                 "ibv_open_device");
 }
 
-flagcxResult_t wrap_ibv_close_device(
+flagcxResult_t flagcxWrapIbvCloseDevice(
     struct ibv_context *context) { /*returns 0 on success, -1 on failure*/
   IBV_INT_CHECK(ibvSymbols, ibv_internal_close_device,
                 ibv_internal_close_device(context), -1, "ibv_close_device");
 }
 
-flagcxResult_t wrap_ibv_get_async_event(
+flagcxResult_t flagcxWrapIbvGetAsyncEvent(
     struct ibv_context *context,
     struct ibv_async_event *event) { /*returns 0 on success, and -1 on error*/
   IBV_INT_CHECK(ibvSymbols, ibv_internal_get_async_event,
@@ -147,12 +147,12 @@ flagcxResult_t wrap_ibv_get_async_event(
                 "ibv_get_async_event");
 }
 
-flagcxResult_t wrap_ibv_ack_async_event(struct ibv_async_event *event) {
+flagcxResult_t flagcxWrapIbvAckAsyncEvent(struct ibv_async_event *event) {
   IBV_PASSTHRU(ibvSymbols, ibv_internal_ack_async_event,
                ibv_internal_ack_async_event(event));
 }
 
-flagcxResult_t wrap_ibv_query_device(
+flagcxResult_t flagcxWrapIbvQueryDevice(
     struct ibv_context *context,
     struct ibv_device_attr
         *device_attr) { /*returns 0 on success, or the value of errno on failure
@@ -162,7 +162,7 @@ flagcxResult_t wrap_ibv_query_device(
                           "ibv_query_device");
 }
 
-flagcxResult_t wrap_ibv_query_port(
+flagcxResult_t flagcxWrapIbvQueryPort(
     struct ibv_context *context, uint8_t port_num,
     struct ibv_port_attr
         *port_attr) { /*returns 0 on success, or the value of errno on failure
@@ -172,44 +172,45 @@ flagcxResult_t wrap_ibv_query_port(
                           0, "ibv_query_port");
 }
 
-flagcxResult_t wrap_ibv_query_gid(struct ibv_context *context, uint8_t port_num,
-                                  int index, union ibv_gid *gid) {
+flagcxResult_t flagcxWrapIbvQueryGid(struct ibv_context *context,
+                                     uint8_t port_num, int index,
+                                     union ibv_gid *gid) {
   IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_query_gid,
                           ibv_internal_query_gid(context, port_num, index, gid),
                           0, "ibv_query_gid");
 }
 
-flagcxResult_t wrap_ibv_query_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
-                                 int attr_mask,
-                                 struct ibv_qp_init_attr *init_attr) {
+flagcxResult_t flagcxWrapIbvQueryQp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
+                                    int attr_mask,
+                                    struct ibv_qp_init_attr *init_attr) {
   IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_query_qp,
                           ibv_internal_query_qp(qp, attr, attr_mask, init_attr),
                           0, "ibv_query_qp");
 }
 
-flagcxResult_t wrap_ibv_alloc_pd(struct ibv_pd **ret,
-                                 struct ibv_context *context) {
+flagcxResult_t flagcxWrapIbvAllocPd(struct ibv_pd **ret,
+                                    struct ibv_context *context) {
   IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_alloc_pd,
                       ibv_internal_alloc_pd(context), *ret, NULL,
                       "ibv_alloc_pd");
 }
 
-flagcxResult_t wrap_ibv_dealloc_pd(
+flagcxResult_t flagcxWrapIbvDeallocPd(
     struct ibv_pd *pd) { /*returns 0 on success, or the value of errno on
                             failure (which indicates the failure reason)*/
   IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_dealloc_pd,
                           ibv_internal_dealloc_pd(pd), 0, "ibv_dealloc_pd");
 }
 
-flagcxResult_t wrap_ibv_reg_mr(struct ibv_mr **ret, struct ibv_pd *pd,
-                               void *addr, size_t length, int access) {
+flagcxResult_t flagcxWrapIbvRegMr(struct ibv_mr **ret, struct ibv_pd *pd,
+                                  void *addr, size_t length, int access) {
   IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_reg_mr,
                       ibv_internal_reg_mr(pd, addr, length, access), *ret, NULL,
                       "ibv_reg_mr");
 }
 
-struct ibv_mr *wrap_direct_ibv_reg_mr(struct ibv_pd *pd, void *addr,
-                                      size_t length, int access) {
+struct ibv_mr *flagcxWrapDirectIbvRegMr(struct ibv_pd *pd, void *addr,
+                                        size_t length, int access) {
   if (ibvSymbols.ibv_internal_reg_mr == NULL) {
     WARN("lib wrapper not initialized.");
     return NULL;
@@ -217,9 +218,9 @@ struct ibv_mr *wrap_direct_ibv_reg_mr(struct ibv_pd *pd, void *addr,
   return ibvSymbols.ibv_internal_reg_mr(pd, addr, length, access);
 }
 
-flagcxResult_t wrap_ibv_reg_mr_iova2(struct ibv_mr **ret, struct ibv_pd *pd,
-                                     void *addr, size_t length, uint64_t iova,
-                                     int access) {
+flagcxResult_t flagcxWrapIbvRegMrIova2(struct ibv_mr **ret, struct ibv_pd *pd,
+                                       void *addr, size_t length, uint64_t iova,
+                                       int access) {
   if (ibvSymbols.ibv_internal_reg_mr_iova2 == NULL) {
     return flagcxInternalError;
   }
@@ -232,18 +233,19 @@ flagcxResult_t wrap_ibv_reg_mr_iova2(struct ibv_mr **ret, struct ibv_pd *pd,
 }
 
 /* DMA-BUF support */
-flagcxResult_t wrap_ibv_reg_dmabuf_mr(struct ibv_mr **ret, struct ibv_pd *pd,
-                                      uint64_t offset, size_t length,
-                                      uint64_t iova, int fd, int access) {
+flagcxResult_t flagcxWrapIbvRegDmabufMr(struct ibv_mr **ret, struct ibv_pd *pd,
+                                        uint64_t offset, size_t length,
+                                        uint64_t iova, int fd, int access) {
   IBV_PTR_CHECK_ERRNO(
       ibvSymbols, ibv_internal_reg_dmabuf_mr,
       ibv_internal_reg_dmabuf_mr(pd, offset, length, iova, fd, access), *ret,
       NULL, "ibv_reg_dmabuf_mr");
 }
 
-struct ibv_mr *wrap_direct_ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
-                                             size_t length, uint64_t iova,
-                                             int fd, int access) {
+struct ibv_mr *flagcxWrapDirectIbvRegDmabufMr(struct ibv_pd *pd,
+                                              uint64_t offset, size_t length,
+                                              uint64_t iova, int fd,
+                                              int access) {
   if (ibvSymbols.ibv_internal_reg_dmabuf_mr == NULL) {
     errno = EOPNOTSUPP; // flagcxIbDmaBufSupport() requires this errno being set
     return NULL;
@@ -252,42 +254,42 @@ struct ibv_mr *wrap_direct_ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
                                                access);
 }
 
-flagcxResult_t wrap_ibv_dereg_mr(
+flagcxResult_t flagcxWrapIbvDeregMr(
     struct ibv_mr *mr) { /*returns 0 on success, or the value of errno on
                             failure (which indicates the failure reason)*/
   IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_dereg_mr,
                           ibv_internal_dereg_mr(mr), 0, "ibv_dereg_mr");
 }
 
-flagcxResult_t wrap_ibv_create_cq(struct ibv_cq **ret,
-                                  struct ibv_context *context, int cqe,
-                                  void *cq_context,
-                                  struct ibv_comp_channel *channel,
-                                  int comp_vector) {
+flagcxResult_t flagcxWrapIbvCreateCq(struct ibv_cq **ret,
+                                     struct ibv_context *context, int cqe,
+                                     void *cq_context,
+                                     struct ibv_comp_channel *channel,
+                                     int comp_vector) {
   IBV_PTR_CHECK_ERRNO(
       ibvSymbols, ibv_internal_create_cq,
       ibv_internal_create_cq(context, cqe, cq_context, channel, comp_vector),
       *ret, NULL, "ibv_create_cq");
 }
 
-flagcxResult_t wrap_ibv_destroy_cq(struct ibv_cq *cq) {
+flagcxResult_t flagcxWrapIbvDestroyCq(struct ibv_cq *cq) {
   IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_destroy_cq,
                           ibv_internal_destroy_cq(cq), 0, "ibv_destroy_cq");
 }
 
-flagcxResult_t wrap_ibv_destroy_qp(struct ibv_qp *qp) {
+flagcxResult_t flagcxWrapIbvDestroyQp(struct ibv_qp *qp) {
   IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_destroy_qp,
                           ibv_internal_destroy_qp(qp), 0, "ibv_destroy_qp");
 }
 
-flagcxResult_t wrap_ibv_create_qp(struct ibv_qp **ret, struct ibv_pd *pd,
-                                  struct ibv_qp_init_attr *qp_init_attr) {
+flagcxResult_t flagcxWrapIbvCreateQp(struct ibv_qp **ret, struct ibv_pd *pd,
+                                     struct ibv_qp_init_attr *qp_init_attr) {
   IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_create_qp,
                       ibv_internal_create_qp(pd, qp_init_attr), *ret, NULL,
                       "ibv_create_qp");
 }
 
-flagcxResult_t wrap_ibv_modify_qp(
+flagcxResult_t flagcxWrapIbvModifyQp(
     struct ibv_qp *qp, struct ibv_qp_attr *attr,
     int attr_mask) { /*returns 0 on success, or the value of errno on failure
                         (which indicates the failure reason)*/
@@ -296,7 +298,7 @@ flagcxResult_t wrap_ibv_modify_qp(
                           "ibv_modify_qp");
 }
 
-flagcxResult_t wrap_ibv_query_ece(
+flagcxResult_t flagcxWrapIbvQueryEce(
     struct ibv_qp *qp, struct ibv_ece *ece,
     int *supported) { /*returns 0 on success, or the value of errno on failure
                          (which indicates the failure reason)*/
@@ -305,7 +307,7 @@ flagcxResult_t wrap_ibv_query_ece(
                                    "ibv_query_ece", supported);
 }
 
-flagcxResult_t wrap_ibv_set_ece(
+flagcxResult_t flagcxWrapIbvSetEce(
     struct ibv_qp *qp, struct ibv_ece *ece,
     int *supported) { /*returns 0 on success, or the value of errno on failure
                          (which indicates the failure reason)*/
@@ -314,7 +316,8 @@ flagcxResult_t wrap_ibv_set_ece(
                                    "ibv_set_ece", supported);
 }
 
-flagcxResult_t wrap_ibv_event_type_str(char **ret, enum ibv_event_type event) {
+flagcxResult_t flagcxWrapIbvEventTypeStr(char **ret,
+                                         enum ibv_event_type event) {
   *ret = (char *)ibvSymbols.ibv_internal_event_type_str(event);
   return flagcxSuccess;
 }

--- a/flagcx/core/ibvwrap.h
+++ b/flagcx/core/ibvwrap.h
@@ -26,60 +26,63 @@ typedef enum ibv_return_enum {
   IBV_SUCCESS = 0, //!< The operation was successful
 } ibv_return_t;
 
-flagcxResult_t wrap_ibv_symbols(void);
+flagcxResult_t flagcxWrapIbvSymbols(void);
 /* FLAGCX wrappers of IB verbs functions */
-flagcxResult_t wrap_ibv_fork_init(void);
-flagcxResult_t wrap_ibv_get_device_list(struct ibv_device ***ret,
-                                        int *num_devices);
-flagcxResult_t wrap_ibv_free_device_list(struct ibv_device **list);
-const char *wrap_ibv_get_device_name(struct ibv_device *device);
-flagcxResult_t wrap_ibv_open_device(struct ibv_context **ret,
-                                    struct ibv_device *device);
-flagcxResult_t wrap_ibv_close_device(struct ibv_context *context);
-flagcxResult_t wrap_ibv_get_async_event(struct ibv_context *context,
-                                        struct ibv_async_event *event);
-flagcxResult_t wrap_ibv_ack_async_event(struct ibv_async_event *event);
-flagcxResult_t wrap_ibv_query_device(struct ibv_context *context,
-                                     struct ibv_device_attr *device_attr);
-flagcxResult_t wrap_ibv_query_port(struct ibv_context *context,
-                                   uint8_t port_num,
-                                   struct ibv_port_attr *port_attr);
-flagcxResult_t wrap_ibv_query_gid(struct ibv_context *context, uint8_t port_num,
-                                  int index, union ibv_gid *gid);
-flagcxResult_t wrap_ibv_query_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
-                                 int attr_mask,
-                                 struct ibv_qp_init_attr *init_attr);
-flagcxResult_t wrap_ibv_alloc_pd(struct ibv_pd **ret,
-                                 struct ibv_context *context);
-flagcxResult_t wrap_ibv_dealloc_pd(struct ibv_pd *pd);
-flagcxResult_t wrap_ibv_reg_mr(struct ibv_mr **ret, struct ibv_pd *pd,
-                               void *addr, size_t length, int access);
-struct ibv_mr *wrap_direct_ibv_reg_mr(struct ibv_pd *pd, void *addr,
-                                      size_t length, int access);
-flagcxResult_t wrap_ibv_reg_mr_iova2(struct ibv_mr **ret, struct ibv_pd *pd,
-                                     void *addr, size_t length, uint64_t iova,
-                                     int access);
+flagcxResult_t flagcxWrapIbvForkInit(void);
+flagcxResult_t flagcxWrapIbvGetDeviceList(struct ibv_device ***ret,
+                                          int *num_devices);
+flagcxResult_t flagcxWrapIbvFreeDeviceList(struct ibv_device **list);
+const char *flagcxWrapIbvGetDeviceName(struct ibv_device *device);
+flagcxResult_t flagcxWrapIbvOpenDevice(struct ibv_context **ret,
+                                       struct ibv_device *device);
+flagcxResult_t flagcxWrapIbvCloseDevice(struct ibv_context *context);
+flagcxResult_t flagcxWrapIbvGetAsyncEvent(struct ibv_context *context,
+                                          struct ibv_async_event *event);
+flagcxResult_t flagcxWrapIbvAckAsyncEvent(struct ibv_async_event *event);
+flagcxResult_t flagcxWrapIbvQueryDevice(struct ibv_context *context,
+                                        struct ibv_device_attr *device_attr);
+flagcxResult_t flagcxWrapIbvQueryPort(struct ibv_context *context,
+                                      uint8_t port_num,
+                                      struct ibv_port_attr *port_attr);
+flagcxResult_t flagcxWrapIbvQueryGid(struct ibv_context *context,
+                                     uint8_t port_num, int index,
+                                     union ibv_gid *gid);
+flagcxResult_t flagcxWrapIbvQueryQp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
+                                    int attr_mask,
+                                    struct ibv_qp_init_attr *init_attr);
+flagcxResult_t flagcxWrapIbvAllocPd(struct ibv_pd **ret,
+                                    struct ibv_context *context);
+flagcxResult_t flagcxWrapIbvDeallocPd(struct ibv_pd *pd);
+flagcxResult_t flagcxWrapIbvRegMr(struct ibv_mr **ret, struct ibv_pd *pd,
+                                  void *addr, size_t length, int access);
+struct ibv_mr *flagcxWrapDirectIbvRegMr(struct ibv_pd *pd, void *addr,
+                                        size_t length, int access);
+flagcxResult_t flagcxWrapIbvRegMrIova2(struct ibv_mr **ret, struct ibv_pd *pd,
+                                       void *addr, size_t length, uint64_t iova,
+                                       int access);
 /* DMA-BUF support */
-flagcxResult_t wrap_ibv_reg_dmabuf_mr(struct ibv_mr **ret, struct ibv_pd *pd,
-                                      uint64_t offset, size_t length,
-                                      uint64_t iova, int fd, int access);
-struct ibv_mr *wrap_direct_ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
-                                             size_t length, uint64_t iova,
-                                             int fd, int access);
-flagcxResult_t wrap_ibv_dereg_mr(struct ibv_mr *mr);
-flagcxResult_t wrap_ibv_create_comp_channel(struct ibv_comp_channel **ret,
-                                            struct ibv_context *context);
-flagcxResult_t wrap_ibv_destroy_comp_channel(struct ibv_comp_channel *channel);
-flagcxResult_t wrap_ibv_create_cq(struct ibv_cq **ret,
-                                  struct ibv_context *context, int cqe,
-                                  void *cq_context,
-                                  struct ibv_comp_channel *channel,
-                                  int comp_vector);
-flagcxResult_t wrap_ibv_destroy_cq(struct ibv_cq *cq);
-static inline flagcxResult_t wrap_ibv_poll_cq(struct ibv_cq *cq,
-                                              int num_entries,
-                                              struct ibv_wc *wc,
-                                              int *num_done) {
+flagcxResult_t flagcxWrapIbvRegDmabufMr(struct ibv_mr **ret, struct ibv_pd *pd,
+                                        uint64_t offset, size_t length,
+                                        uint64_t iova, int fd, int access);
+struct ibv_mr *flagcxWrapDirectIbvRegDmabufMr(struct ibv_pd *pd,
+                                              uint64_t offset, size_t length,
+                                              uint64_t iova, int fd,
+                                              int access);
+flagcxResult_t flagcxWrapIbvDeregMr(struct ibv_mr *mr);
+flagcxResult_t flagcxWrapIbvCreateCompChannel(struct ibv_comp_channel **ret,
+                                              struct ibv_context *context);
+flagcxResult_t
+flagcxWrapIbvDestroyCompChannel(struct ibv_comp_channel *channel);
+flagcxResult_t flagcxWrapIbvCreateCq(struct ibv_cq **ret,
+                                     struct ibv_context *context, int cqe,
+                                     void *cq_context,
+                                     struct ibv_comp_channel *channel,
+                                     int comp_vector);
+flagcxResult_t flagcxWrapIbvDestroyCq(struct ibv_cq *cq);
+static inline flagcxResult_t flagcxWrapIbvPollCq(struct ibv_cq *cq,
+                                                 int num_entries,
+                                                 struct ibv_wc *wc,
+                                                 int *num_done) {
   int done = cq->context->ops.poll_cq(
       cq, num_entries, wc); /*returns the number of wcs or 0 on success, a
                                negative number otherwise*/
@@ -90,19 +93,19 @@ static inline flagcxResult_t wrap_ibv_poll_cq(struct ibv_cq *cq,
   *num_done = done;
   return flagcxSuccess;
 }
-flagcxResult_t wrap_ibv_create_qp(struct ibv_qp **ret, struct ibv_pd *pd,
-                                  struct ibv_qp_init_attr *qp_init_attr);
-flagcxResult_t wrap_ibv_modify_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
-                                  int attr_mask);
-flagcxResult_t wrap_ibv_destroy_qp(struct ibv_qp *qp);
-flagcxResult_t wrap_ibv_query_ece(struct ibv_qp *qp, struct ibv_ece *ece,
-                                  int *supported);
-flagcxResult_t wrap_ibv_set_ece(struct ibv_qp *qp, struct ibv_ece *ece,
-                                int *supported);
+flagcxResult_t flagcxWrapIbvCreateQp(struct ibv_qp **ret, struct ibv_pd *pd,
+                                     struct ibv_qp_init_attr *qp_init_attr);
+flagcxResult_t flagcxWrapIbvModifyQp(struct ibv_qp *qp,
+                                     struct ibv_qp_attr *attr, int attr_mask);
+flagcxResult_t flagcxWrapIbvDestroyQp(struct ibv_qp *qp);
+flagcxResult_t flagcxWrapIbvQueryEce(struct ibv_qp *qp, struct ibv_ece *ece,
+                                     int *supported);
+flagcxResult_t flagcxWrapIbvSetEce(struct ibv_qp *qp, struct ibv_ece *ece,
+                                   int *supported);
 
-static inline flagcxResult_t wrap_ibv_post_send(struct ibv_qp *qp,
-                                                struct ibv_send_wr *wr,
-                                                struct ibv_send_wr **bad_wr) {
+static inline flagcxResult_t
+flagcxWrapIbvPostSend(struct ibv_qp *qp, struct ibv_send_wr *wr,
+                      struct ibv_send_wr **bad_wr) {
   int ret = qp->context->ops.post_send(
       qp, wr, bad_wr); /*returns 0 on success, or the value of errno on failure
                           (which indicates the failure reason)*/
@@ -114,9 +117,9 @@ static inline flagcxResult_t wrap_ibv_post_send(struct ibv_qp *qp,
   return flagcxSuccess;
 }
 
-static inline flagcxResult_t wrap_ibv_post_recv(struct ibv_qp *qp,
-                                                struct ibv_recv_wr *wr,
-                                                struct ibv_recv_wr **bad_wr) {
+static inline flagcxResult_t
+flagcxWrapIbvPostRecv(struct ibv_qp *qp, struct ibv_recv_wr *wr,
+                      struct ibv_recv_wr **bad_wr) {
   int ret = qp->context->ops.post_recv(
       qp, wr, bad_wr); /*returns 0 on success, or the value of errno on failure
                           (which indicates the failure reason)*/
@@ -127,6 +130,6 @@ static inline flagcxResult_t wrap_ibv_post_recv(struct ibv_qp *qp,
   return flagcxSuccess;
 }
 
-flagcxResult_t wrap_ibv_event_type_str(char **ret, enum ibv_event_type event);
+flagcxResult_t flagcxWrapIbvEventTypeStr(char **ret, enum ibv_event_type event);
 
 #endif // End include guard


### PR DESCRIPTION
This PR renames all ibv wrapper function to avoid potential symbol conflict with other linked library. This is a fix for a recent issue where the signature of flagcx's ibv wrapper functions coincided with those declared in another library that FlagCX is linked against, and FlagCX's definitions of these wrapper function overrided the definitions of those in the other library.