### PR TITLE
Implement unified network adaptor system and refactor network adaptor

### DIFF
--- a/flagcx/adaptor/adaptor.cc
+++ b/flagcx/adaptor/adaptor.cc
@@ -4,6 +4,9 @@
  ************************************************************************/
 
 #include "adaptor.h"
+#include <string.h>
+#include "core.h"
+#include "net.h"
 
 #ifdef USE_NVIDIA_ADAPTOR
 #ifdef USE_BOOTSTRAP_ADAPTOR
@@ -104,3 +107,20 @@ struct flagcxCCLAdaptor *cclAdaptors[NCCLADAPTORS] = {&mpiAdaptor,
 #endif
 struct flagcxDeviceAdaptor *deviceAdaptor = &ducudaAdaptor;
 #endif
+
+// External adaptor declarations
+extern struct flagcxNetAdaptor flagcxNetSocket;
+extern struct flagcxNetAdaptor flagcxNetIb;
+
+// Unified network adaptor entry point
+struct flagcxNetAdaptor *getUnifiedNetAdaptor(int netType) {
+    switch (netType) {
+        case 1:  // IB
+            return &flagcxNetIb;
+        case 2:  // Socket
+            return &flagcxNetSocket;
+        default:
+            return NULL;
+    }
+}
+

--- a/flagcx/adaptor/ccl/ibrc_adaptor.cc
+++ b/flagcx/adaptor/ccl/ibrc_adaptor.cc
@@ -12,7 +12,6 @@
 #include "param.h"
 #include "socket.h"
 #include "utils.h"
-
 #include <assert.h>
 #include <poll.h>
 #include <pthread.h>
@@ -177,11 +176,11 @@ static void *envIbAddrRange(sa_family_t af, int *mask) {
 
 static sa_family_t getGidAddrFamily(union ibv_gid *gid) {
   const struct in6_addr *a = (struct in6_addr *)gid->raw;
-  bool isIpV4Mapped = ((a->s6_addr32[0] | a->s6_addr32[1]) |
-                       (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL;
+  bool isIpV4Mapped = ((a->s6_addr[0] | a->s6_addr[1]) |
+                       (a->s6_addr[2] ^ htonl(0x0000ffff))) == 0UL;
   bool isIpV4MappedMulticast =
-      (a->s6_addr32[0] == htonl(0xff0e0000) &&
-       ((a->s6_addr32[1] | (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL));
+      (a->s6_addr[0] == htonl(0xff0e0000) &&
+       ((a->s6_addr[1] | (a->s6_addr[2] ^ htonl(0x0000ffff))) == 0UL));
   return (isIpV4Mapped || isIpV4MappedMulticast) ? AF_INET : AF_INET6;
 }
 
@@ -204,21 +203,21 @@ static bool matchGidAddrPrefix(sa_family_t af, void *prefix, int prefixlen,
   while (prefixlen > 0 && i < 4) {
     if (af == AF_INET) {
       int mask = NETMASK(prefixlen);
-      if ((base->s_addr & mask) ^ (addr6->s6_addr32[3] & mask)) {
+      if ((base->s_addr & mask) ^ (addr6->s6_addr[3] & mask)) {
         break;
       }
       prefixlen = 0;
       break;
     } else {
       if (prefixlen >= 32) {
-        if (base6->s6_addr32[i] ^ addr6->s6_addr32[i]) {
+        if (base6->s6_addr[i] ^ addr6->s6_addr[i]) {
           break;
         }
         prefixlen -= 32;
         ++i;
       } else {
         int mask = NETMASK(prefixlen);
-        if ((base6->s6_addr32[i] & mask) ^ (addr6->s6_addr32[i] & mask)) {
+        if ((base6->s6_addr[i] & mask) ^ (addr6->s6_addr[i] & mask)) {
           break;
         }
         prefixlen = 0;
@@ -231,9 +230,9 @@ static bool matchGidAddrPrefix(sa_family_t af, void *prefix, int prefixlen,
 
 static bool configuredGid(union ibv_gid *gid) {
   const struct in6_addr *a = (struct in6_addr *)gid->raw;
-  int trailer = (a->s6_addr32[1] | a->s6_addr32[2] | a->s6_addr32[3]);
-  if (((a->s6_addr32[0] | trailer) == 0UL) ||
-      ((a->s6_addr32[0] == htonl(0xfe800000)) && (trailer == 0UL))) {
+  int trailer = (a->s6_addr[1] | a->s6_addr[2] | a->s6_addr[3]);
+  if (((a->s6_addr[0] | trailer) == 0UL) ||
+      ((a->s6_addr[0] == htonl(0xfe800000)) && (trailer == 0UL))) {
     return false;
   }
   return true;
@@ -241,7 +240,7 @@ static bool configuredGid(union ibv_gid *gid) {
 
 static bool linkLocalGid(union ibv_gid *gid) {
   const struct in6_addr *a = (struct in6_addr *)gid->raw;
-  if (a->s6_addr32[0] == htonl(0xfe800000) && a->s6_addr32[1] == 0UL) {
+  if (a->s6_addr[0] == htonl(0xfe800000) && a->s6_addr[1] == 0UL) {
     return true;
   }
   return false;
@@ -432,7 +431,7 @@ int flagcxIbFindMatchingDev(int dev) {
   return flagcxNMergedIbDevs;
 }
 
-flagcxResult_t flagcxIbInit(flagcxDebugLogger_t logFunction) {
+flagcxResult_t flagcxIbInit() {
   flagcxResult_t ret;
   if (flagcxParamIbDisable())
     return flagcxInternalError;
@@ -1056,8 +1055,7 @@ flagcxResult_t flagcxIbListen(int dev, void *opaqueHandle, void **listenComm) {
   return flagcxSuccess;
 }
 
-flagcxResult_t flagcxIbConnect(int dev, void *opaqueHandle, void **sendComm,
-                               flagcxNetDeviceHandle_t ** /*sendDevComm*/) {
+flagcxResult_t flagcxIbConnect(int dev, void *opaqueHandle, void **sendComm) {
   struct flagcxIbHandle *handle = (struct flagcxIbHandle *)opaqueHandle;
   struct flagcxIbCommStage *stage = &handle->stage;
   struct flagcxIbSendComm *comm = (struct flagcxIbSendComm *)stage->comm;
@@ -1320,8 +1318,7 @@ ib_send_ready:
 
 FLAGCX_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
 
-flagcxResult_t flagcxIbAccept(void *listenComm, void **recvComm,
-                              flagcxNetDeviceHandle_t ** /*recvDevComm*/) {
+flagcxResult_t flagcxIbAccept(void *listenComm, void **recvComm) {
   struct flagcxIbListenComm *lComm = (struct flagcxIbListenComm *)listenComm;
   struct flagcxIbCommStage *stage = &lComm->stage;
   struct flagcxIbRecvComm *rComm = (struct flagcxIbRecvComm *)stage->comm;
@@ -1878,8 +1875,8 @@ flagcxResult_t flagcxIbMultiSend(struct flagcxIbSendComm *comm, int slot) {
   return flagcxSuccess;
 }
 
-flagcxResult_t flagcxIbIsend(void *sendComm, void *data, int size, int tag,
-                             void *mhandle, void **request) {
+flagcxResult_t flagcxIbIsend(void *sendComm, void *data, size_t size, int tag,
+                             void *mhandle, void *phandle, void **request) {
   struct flagcxIbSendComm *comm = (struct flagcxIbSendComm *)sendComm;
   if (comm->base.ready == 0) {
     WARN("NET/IB: flagcxIbIsend() called when comm->base.ready == 0");
@@ -1986,7 +1983,7 @@ flagcxResult_t flagcxIbIsend(void *sendComm, void *data, int size, int tag,
 }
 
 flagcxResult_t flagcxIbPostFifo(struct flagcxIbRecvComm *comm, int n,
-                                void **data, int *sizes, int *tags,
+                                void **data, size_t *sizes, int *tags,
                                 void **mhandles, struct flagcxIbRequest *req) {
   struct ibv_send_wr wr;
   memset(&wr, 0, sizeof(wr));
@@ -1994,7 +1991,7 @@ flagcxResult_t flagcxIbPostFifo(struct flagcxIbRecvComm *comm, int n,
   int slot = comm->remFifo.fifoTail % MAX_REQUESTS;
   req->recv.sizes = comm->sizesFifo[slot];
   for (int i = 0; i < n; i++)
-    req->recv.sizes[i] = 0;
+    req->recv.sizes[i] = (int)sizes[i];
   struct flagcxIbSendFifo *localElem = comm->remFifo.elems[slot];
 
   // Select the next devIndex (local) and QP to use for posting this CTS message
@@ -2013,7 +2010,7 @@ flagcxResult_t flagcxIbPostFifo(struct flagcxIbRecvComm *comm, int n,
       localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
 
     localElem[i].nreqs = n;
-    localElem[i].size = sizes[i]; // Sanity/Debugging
+    localElem[i].size = (int)sizes[i]; // Sanity/Debugging
     localElem[i].tag = tags[i];
     localElem[i].idx = comm->remFifo.fifoTail + 1;
   }
@@ -2073,8 +2070,8 @@ flagcxResult_t flagcxIbPostFifo(struct flagcxIbRecvComm *comm, int n,
   return flagcxSuccess;
 }
 
-flagcxResult_t flagcxIbIrecv(void *recvComm, int n, void **data, int *sizes,
-                             int *tags, void **mhandles, void **request) {
+flagcxResult_t flagcxIbIrecv(void *recvComm, int n, void **data, size_t *sizes,
+                             int *tags, void **mhandles, void **phandles, void **request) {
   struct flagcxIbRecvComm *comm = (struct flagcxIbRecvComm *)recvComm;
   if (comm->base.ready == 0) {
     WARN("NET/IB: flagcxIbIrecv() called when comm->base.ready == 0");
@@ -2351,51 +2348,72 @@ flagcxResult_t flagcxIbGetDevFromName(char *name, int *dev) {
   return flagcxSystemError;
 }
 
-flagcxResult_t flagcxIbGetProperties(int dev, flagcxNetProperties_t *props) {
+flagcxResult_t flagcxIbGetProperties(int dev, void *props) {
   struct flagcxIbMergedDev *mergedDev = flagcxIbMergedDevs + dev;
-  props->name = mergedDev->devName;
-  props->speed = mergedDev->speed;
+  flagcxNetProperties_t *properties = (flagcxNetProperties_t *)props;
+  
+  properties->name = mergedDev->devName;
+  properties->speed = mergedDev->speed;
 
   // Take the rest of the properties from an arbitrary sub-device (should be the
   // same)
   struct flagcxIbDev *ibDev = flagcxIbDevs + mergedDev->devs[0];
-  props->pciPath = ibDev->pciPath;
-  props->guid = ibDev->guid;
-  props->ptrSupport = FLAGCX_PTR_HOST;
+  properties->pciPath = ibDev->pciPath;
+  properties->guid = ibDev->guid;
+  properties->ptrSupport = FLAGCX_PTR_HOST;
 
   if (flagcxIbGdrSupport() == flagcxSuccess) {
-    props->ptrSupport |= FLAGCX_PTR_CUDA; // GDR support via nv_peermem
+    properties->ptrSupport |= FLAGCX_PTR_CUDA; // GDR support via nv_peermem
   }
-  props->regIsGlobal = 1;
+  properties->regIsGlobal = 1;
   if (flagcxIbDmaBufSupport(dev) == flagcxSuccess) {
-    props->ptrSupport |= FLAGCX_PTR_DMABUF;
+    properties->ptrSupport |= FLAGCX_PTR_DMABUF;
   }
-  props->latency = 0; // Not set
-  props->port = ibDev->portNum + ibDev->realPort;
-  props->maxComms = ibDev->maxQp;
-  props->maxRecvs = FLAGCX_NET_IB_MAX_RECVS;
-  props->netDeviceType = FLAGCX_NET_DEVICE_HOST;
-  props->netDeviceVersion = FLAGCX_NET_DEVICE_INVALID_VERSION;
+  properties->latency = 0; // Not set
+  properties->port = ibDev->portNum + ibDev->realPort;
+  properties->maxComms = ibDev->maxQp;
+  properties->maxRecvs = FLAGCX_NET_IB_MAX_RECVS;
+  properties->netDeviceType = FLAGCX_NET_DEVICE_HOST;
+  properties->netDeviceVersion = FLAGCX_NET_DEVICE_INVALID_VERSION;
   return flagcxSuccess;
 }
 
-flagcxNet_t flagcxNetIb = {"IB",
-                           flagcxIbInit,
-                           flagcxIbDevices,
-                           flagcxIbGetProperties,
-                           flagcxIbListen,
-                           flagcxIbConnect,
-                           flagcxIbAccept,
-                           flagcxIbRegMr,
-                           flagcxIbRegMrDmaBuf,
-                           flagcxIbDeregMr,
-                           flagcxIbIsend,
-                           flagcxIbIrecv,
-                           flagcxIbIflush,
-                           flagcxIbTest,
-                           flagcxIbCloseSend,
-                           flagcxIbCloseRecv,
-                           flagcxIbCloseListen,
-                           NULL /* getDeviceMr */,
-                           NULL /* irecvConsumed */,
-                           flagcxIbGetDevFromName};
+// Adapter wrapper functions
+
+struct flagcxNetAdaptor flagcxNetIb = {
+    // Basic functions
+    "IB",
+    flagcxIbInit,
+    flagcxIbDevices,
+    flagcxIbGetProperties,
+    NULL, // reduceSupport
+    NULL, // getDeviceMr
+    NULL, // irecvConsumed
+    
+    // Setup functions
+    flagcxIbListen,
+    flagcxIbConnect,
+    flagcxIbAccept,
+    flagcxIbCloseSend,
+    flagcxIbCloseRecv,
+    flagcxIbCloseListen,
+    
+    // Memory region functions
+    flagcxIbRegMr,
+    flagcxIbRegMrDmaBuf,
+    flagcxIbDeregMr,
+    
+    // Two-sided functions
+    flagcxIbIsend,
+    flagcxIbIrecv,
+    flagcxIbIflush,
+    flagcxIbTest,
+    
+    // One-sided functions
+    NULL, // write
+    NULL, // read
+    NULL, // signal
+    
+    // Device name lookup
+    flagcxIbGetDevFromName
+};

--- a/flagcx/adaptor/include/adaptor.h
+++ b/flagcx/adaptor/include/adaptor.h
@@ -43,6 +43,11 @@ extern struct flagcxDeviceAdaptor kunlunAdaptor;
 extern struct flagcxDeviceAdaptor ducudaAdaptor;
 extern struct flagcxDeviceAdaptor *deviceAdaptor;
 
+extern struct flagcxNetAdaptor *netAdaptor;
+
+// Unified network adaptor function declarations
+struct flagcxNetAdaptor *getUnifiedNetAdaptor(int netType);
+
 inline bool flagcxCCLAdaptorNeedSendrecv(size_t value) { return value != 0; }
 
 struct flagcxCCLAdaptor {
@@ -218,7 +223,8 @@ struct flagcxNetAdaptor {
   flagcxResult_t (*accept)(
       void *listenComm,
       void **recvComm); // TODO: add flagcxNetDeviceHandle_t** recvDevComm
-  flagcxResult_t (*close)(void *comm);
+  flagcxResult_t (*closeSend)(void *sendComm);
+  flagcxResult_t (*closeRecv)(void *recvComm);
   flagcxResult_t (*closeListen)(void *listenComm);
 
   // Memory region functions
@@ -245,6 +251,9 @@ struct flagcxNetAdaptor {
                          void *mhandle, void *phandle, void **request);
   flagcxResult_t (*signal)(void *sendComm, void *data, size_t size, int tag,
                            void *mhandle, void *phandle, void **request);
+
+  // Device name lookup
+  flagcxResult_t (*getDevFromName)(char *name, int *dev);
 
   // TODO: add switch functions such as
   // iallreduce, iallgather, ireducescatter,

--- a/flagcx/core/comm.h
+++ b/flagcx/core/comm.h
@@ -176,7 +176,7 @@ struct flagcxHeteroComm {
   struct flagcxTopoServer *topoServer;
   struct flagcxInterServerTopo *interServerTopo;
 
-  flagcxNet_t *flagcxNet;
+  struct flagcxNetAdaptor *netAdaptor;
   flagcxCollNet_t *flagcxCollNet;
   struct bootstrapState *bootstrap;
   // Bitmasks for flagcxTransportP2pSetup

--- a/flagcx/core/init.cc
+++ b/flagcx/core/init.cc
@@ -215,7 +215,7 @@ static flagcxResult_t flagcxCommInitRankFunc(struct flagcxAsyncJob *job_) {
     }
   }
   FLAGCXCHECK(flagcxNetInit(comm));
-  INFO(FLAGCX_INIT, "Using network %s", comm->flagcxNet->name);
+  INFO(FLAGCX_INIT, "Using network %s", comm->netAdaptor->name);
   if (env && strcmp(env, "TRUE") == 0) {
     INFO(FLAGCX_INIT, "getting busId for cudaDev %d", comm->cudaDev);
     FLAGCXCHECK(getBusId(comm->cudaDev, &comm->busId));

--- a/flagcx/core/net.h
+++ b/flagcx/core/net.h
@@ -27,15 +27,16 @@ int flagcxNetVersion(struct flagcxHeteroComm *comm);
 flagcxResult_t flagcxGpuGdrSupport(struct flagcxHeteroComm *comm,
                                    int *gdrSupport);
 
-extern flagcxNet_t flagcxNetIb;
-extern flagcxNet_t flagcxNetSocket;
+// Network adaptor declarations
+extern struct flagcxNetAdaptor flagcxNetSocket;
+extern struct flagcxNetAdaptor flagcxNetIb;
 
 struct sendNetResources {
   void *netSendComm;
   struct flagcxSendMem *sendMem;
   struct flagcxRecvMem *recvMem;
 
-  flagcxNet_t *flagcxNet;
+  struct flagcxNetAdaptor *netAdaptor;
   flagcxCollNet_t *flagcxCollNet;
   int tpRank;
   int tpLocalRank;
@@ -67,7 +68,7 @@ struct recvNetResources {
   struct flagcxSendMem *sendMem;
   struct flagcxRecvMem *recvMem;
 
-  flagcxNet_t *flagcxNet;
+  struct flagcxNetAdaptor *netAdaptor;
   flagcxCollNet_t *flagcxCollNet;
   int tpRank;
   int tpLocalRank;

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -505,9 +505,8 @@ static flagcxResult_t proxyProgressAsync(flagcxProxyAsyncOp **opHead,
       struct sendNetResources *resources =
           (struct sendNetResources *)op->connection->transportResources;
       if (!resources->netSendComm) {
-        FLAGCXCHECK(resources->flagcxNet->connect(
-            resources->netDev, (void *)op->reqBuff, &resources->netSendComm,
-            NULL));
+        FLAGCXCHECK(resources->netAdaptor->connect(
+            resources->netDev, (void *)op->reqBuff, &resources->netSendComm));
       } else {
         bool dmaBufferSupport = false;
         if (deviceAdaptor->dmaSupport != NULL) {
@@ -519,17 +518,17 @@ static flagcxResult_t proxyProgressAsync(flagcxProxyAsyncOp **opHead,
           FLAGCXCHECK(deviceAdaptor->getHandleForAddressRange(
               (void *)&dmabuf_fd, resources->buffers[0],
               resources->buffSizes[0], 0));
-          FLAGCXCHECK(resources->flagcxNet->regMrDmaBuf(
+          FLAGCXCHECK(resources->netAdaptor->regMrDmaBuf(
               resources->netSendComm, resources->buffers[0],
               resources->buffSizes[0], 2, 0ULL, dmabuf_fd,
               &resources->mhandles[0]));
         } else {
-          if (resources->flagcxNet == &flagcxNetIb) {
-            FLAGCXCHECK(resources->flagcxNet->regMr(
+          if (resources->netAdaptor == getUnifiedNetAdaptor(1)) {
+            FLAGCXCHECK(resources->netAdaptor->regMr(
                 resources->netSendComm, resources->buffers[0],
                 resources->buffSizes[0], 2, &resources->mhandles[0]));
-          } else if (resources->flagcxNet == &flagcxNetSocket) {
-            FLAGCXCHECK(resources->flagcxNet->regMr(
+          } else if (resources->netAdaptor == getUnifiedNetAdaptor(2)) {
+            FLAGCXCHECK(resources->netAdaptor->regMr(
                 resources->netSendComm, resources->buffers[0],
                 resources->buffSizes[0], 1, &resources->mhandles[0]));
           }
@@ -540,8 +539,8 @@ static flagcxResult_t proxyProgressAsync(flagcxProxyAsyncOp **opHead,
       struct recvNetResources *resources =
           (struct recvNetResources *)op->connection->transportResources;
       if (!resources->netRecvComm) {
-        FLAGCXCHECK(resources->flagcxNet->accept(
-            resources->netListenComm, &resources->netRecvComm, NULL));
+        FLAGCXCHECK(resources->netAdaptor->accept(
+            resources->netListenComm, &resources->netRecvComm));
       } else {
         bool dmaBufferSupport = false;
         if (deviceAdaptor->dmaSupport != NULL) {
@@ -553,17 +552,17 @@ static flagcxResult_t proxyProgressAsync(flagcxProxyAsyncOp **opHead,
           FLAGCXCHECK(deviceAdaptor->getHandleForAddressRange(
               (void *)&dmabuf_fd, resources->buffers[0],
               resources->buffSizes[0], 0));
-          FLAGCXCHECK(resources->flagcxNet->regMrDmaBuf(
+          FLAGCXCHECK(resources->netAdaptor->regMrDmaBuf(
               resources->netRecvComm, resources->buffers[0],
               resources->buffSizes[0], 2, 0ULL, dmabuf_fd,
               &resources->mhandles[0]));
         } else {
-          if (resources->flagcxNet == &flagcxNetIb) {
-            FLAGCXCHECK(resources->flagcxNet->regMr(
+          if (resources->netAdaptor == getUnifiedNetAdaptor(1)) {
+            FLAGCXCHECK(resources->netAdaptor->regMr(
                 resources->netRecvComm, resources->buffers[0],
                 resources->buffSizes[0], 2, &resources->mhandles[0]));
-          } else if (resources->flagcxNet == &flagcxNetSocket) {
-            FLAGCXCHECK(resources->flagcxNet->regMr(
+          } else if (resources->netAdaptor == getUnifiedNetAdaptor(2)) {
+            FLAGCXCHECK(resources->netAdaptor->regMr(
                 resources->netRecvComm, resources->buffers[0],
                 resources->buffSizes[0], 1, &resources->mhandles[0]));
           }

--- a/flagcx/core/proxy.h
+++ b/flagcx/core/proxy.h
@@ -304,7 +304,7 @@ struct flagcxProxyState {
   int buffSizes[FLAGCX_NUM_PROTOCOLS];
   bool allocP2pNetLLBuffers;
   bool dmaBufSupport;
-  flagcxNet_t *flagcxNet;
+  struct flagcxNetAdaptor *netAdaptor;
   flagcxCollNet_t *flagcxCollNet;
   volatile uint32_t *abortFlag;
   // Service threads

--- a/flagcx/core/topo.cc
+++ b/flagcx/core/topo.cc
@@ -533,7 +533,7 @@ flagcxResult_t flagcxGetLocalNetFromGpu(int apu, int *dev,
     }
   }
   if (strlen(name) != 0) {
-    comm->flagcxNet->getDevFromName(name, dev);
+    comm->netAdaptor->getDevFromName(name, dev);
   }
 
   if (strlen(name) == 0 && enable_topo_detect &&
@@ -698,10 +698,10 @@ flagcxResult_t flagcxTopoGetXmlTopo(struct flagcxHeteroComm *comm,
   }
 
   int netDevCount = 0;
-  FLAGCXCHECK(comm->flagcxNet->devices(&netDevCount));
+  FLAGCXCHECK(comm->netAdaptor->devices(&netDevCount));
   for (int n = 0; n < netDevCount; n++) {
     flagcxNetProperties_t props;
-    FLAGCXCHECK(comm->flagcxNet->getProperties(n, &props));
+    FLAGCXCHECK(comm->netAdaptor->getProperties(n, (void *)&props));
     struct flagcxXmlNode *netNode;
     FLAGCXCHECK(flagcxTopoFillNet(xml, props.pciPath, props.name, &netNode));
     FLAGCXCHECK(xmlSetAttrInt(netNode, "dev", n));

--- a/flagcx/core/transport.cc
+++ b/flagcx/core/transport.cc
@@ -26,8 +26,8 @@ flagcxResult_t flagcxTransportP2pSetup(struct flagcxHeteroComm *comm,
         conn->proxyConn.connection->send = 0;
         conn->proxyConn.connection->transportResources = (void *)resources;
         resources->netDev = comm->netDev;
-        resources->flagcxNet = comm->flagcxNet;
-        comm->flagcxNet->listen(resources->netDev, (void *)handle,
+        resources->netAdaptor = comm->netAdaptor;
+        comm->netAdaptor->listen(resources->netDev, (void *)handle,
                                 &resources->netListenComm);
         bootstrapSend(comm->bootstrap, peer, 1001 + c, handle,
                       sizeof(flagcxIbHandle));
@@ -36,12 +36,12 @@ flagcxResult_t flagcxTransportP2pSetup(struct flagcxHeteroComm *comm,
           deviceAdaptor->eventCreate(&resources->cpEvents[s]);
         }
         resources->buffSizes[0] = REGMRBUFFERSIZE;
-        if (comm->flagcxNet == &flagcxNetSocket) {
+        if (comm->netAdaptor == getUnifiedNetAdaptor(2)) {
           resources->buffers[0] = (char *)malloc(resources->buffSizes[0]);
           if (!resources->buffers[0]) {
             return flagcxSystemError;
           }
-        } else if (comm->flagcxNet == &flagcxNetIb) {
+        } else if (comm->netAdaptor == getUnifiedNetAdaptor(1)) {
           deviceAdaptor->gdrMemAlloc((void **)&resources->buffers[0],
                                      resources->buffSizes[0], NULL);
         }
@@ -62,7 +62,7 @@ flagcxResult_t flagcxTransportP2pSetup(struct flagcxHeteroComm *comm,
         conn->proxyConn.connection->send = 1;
         conn->proxyConn.connection->transportResources = (void *)resources;
         resources->netDev = comm->netDev;
-        resources->flagcxNet = comm->flagcxNet;
+        resources->netAdaptor = comm->netAdaptor;
         bootstrapRecv(comm->bootstrap, peer, 1001 + c, handle,
                       sizeof(flagcxIbHandle));
         handle->stage.comm = comm;
@@ -71,12 +71,12 @@ flagcxResult_t flagcxTransportP2pSetup(struct flagcxHeteroComm *comm,
           deviceAdaptor->eventCreate(&resources->cpEvents[s]);
         }
         resources->buffSizes[0] = REGMRBUFFERSIZE;
-        if (comm->flagcxNet == &flagcxNetSocket) {
+        if (comm->netAdaptor == getUnifiedNetAdaptor(2)) {
           resources->buffers[0] = (char *)malloc(resources->buffSizes[0]);
           if (!resources->buffers[0]) {
             return flagcxSystemError;
           }
-        } else if (comm->flagcxNet == &flagcxNetIb) {
+        } else if (comm->netAdaptor == getUnifiedNetAdaptor(1)) {
           deviceAdaptor->gdrMemAlloc((void **)&resources->buffers[0],
                                      resources->buffSizes[0], NULL);
         }


### PR DESCRIPTION
- Introduced a unified network adaptor system by adding `getUnifiedNetAdaptor` function to manage different network types (IB and Socket).
- Refactored related structures and function calls to accommodate the new adaptor approach, ensuring compatibility with existing functionality.
- Removed obsolete `net_ib` and `net_socket` implementations, streamlining the codebase.