### PR TITLE
Add FLAGCX_FUNC_NLOOPS and FLAGCX_FUNC_MAX_SPIN_COUNT to avoid dead lock

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -83,10 +83,9 @@ jobs:
           cd /__w/FlagCX/FlagCX/test/unittest
           mpirun -np 8 --allow-run-as-root ./build/bin/main
 
-
       - name: Run clusters tests with mpirun
         run: |
           cd /__w/FlagCX/FlagCX/test/unittest
-          mpirun -np 8 --allow-run-as-root  -x FLAGCX_DEBUG=TRACE -x FLAGCX_DEBUG_SUBSYS=ALL  -x  FLAGCX_CLUSTER_SPLIT_LIST=2  -x FLAGCX_IB_HCA=mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7  ./build/bin/main
+          mpirun -np 8 --allow-run-as-root  -x FLAGCX_DEBUG=TRACE -x FLAGCX_DEBUG_SUBSYS=ALL -x  FLAGCX_CLUSTER_SPLIT_LIST=2 -x FLAGCX_IB_HCA=mlx5 ./build/bin/main
 
 

--- a/flagcx/core/launch_kernel.cc
+++ b/flagcx/core/launch_kernel.cc
@@ -5,6 +5,9 @@
 flagcxLaunchFunc_t deviceAsyncLoad = NULL;
 flagcxLaunchFunc_t deviceAsyncStore = NULL;
 
+FLAGCX_PARAM(FuncMaxSpinCount, "FUNC_MAX_SPIN_COUNT", INT64_MAX);
+static int64_t funcMaxSpinCount = flagcxParamFuncMaxSpinCount();
+
 flagcxResult_t loadKernelSymbol(const char *path, const char *name,
                                 flagcxLaunchFunc_t *fn) {
   void *handle = flagcxOpenLib(
@@ -33,5 +36,14 @@ void cpuAsyncStore(void *args) {
 void cpuAsyncLoad(void *args) {
   bool *volatile value = (bool *)args;
   while (!__atomic_load_n(value, __ATOMIC_RELAXED)) {
+  }
+}
+
+void cpuAsyncLoadWithMaxSpinCount(void *args) {
+  bool *volatile value = (bool *)args;
+  int64_t spinCount = 0;
+  while (!__atomic_load_n(value, __ATOMIC_RELAXED) &&
+         spinCount < funcMaxSpinCount) {
+    spinCount++;
   }
 }

--- a/flagcx/core/launch_kernel.h
+++ b/flagcx/core/launch_kernel.h
@@ -34,5 +34,6 @@ extern flagcxLaunchFunc_t deviceAsyncLoad;
 
 void cpuAsyncStore(void *args);
 void cpuAsyncLoad(void *args);
+void cpuAsyncLoadWithMaxSpinCount(void *args);
 
 #endif


### PR DESCRIPTION
This PR introduces two environment variables to handle a deadlock scenario caused by deviceFree implicitly waiting for all operations on all streams to complete, which can block subsequent data copy operations and stall host functions.

- FLAGCX_FUNC_NLOOPS: specifies the number of host/device functions to post onto streams
- FLAGCX_FUNC_MAX_SPIN_COUNT: specifies the maximum spin count inside host/device functions