### PR TITLE
Add UCX_UCP network adaptor support and refactor related components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,14 @@ USE_MUSA ?= 0
 USE_KUNLUNXIN ?=0
 USE_DU ?= 0
 USE_MPI ?= 0
+USE_UCX ?= 0
 
 # set to empty if not provided
 DEVICE_HOME ?=
 CCL_HOME ?=
 HOST_CCL_HOME ?=
 MPI_HOME ?=
+UCX_HOME ?=
 
 ifeq ($(strip $(DEVICE_HOME)),)
 	ifeq ($(USE_NVIDIA), 1)
@@ -81,6 +83,12 @@ ifeq ($(strip $(MPI_HOME)),)
 	endif
 endif
 
+ifeq ($(strip $(UCX_HOME)),)
+	ifeq ($(USE_UCX), 1)
+		UCX_HOME = /usr/local/ucx
+	endif
+endif
+
 DEVICE_LIB =
 DEVICE_INCLUDE =
 DEVICE_LINK =
@@ -92,6 +100,10 @@ HOST_CCL_INCLUDE =
 HOST_CCL_LINK =
 ADAPTOR_FLAG =
 HOST_CCL_ADAPTOR_FLAG =
+UCX_LIB =
+UCX_INCLUDE =
+UCX_LINK =
+NET_ADAPTOR_FLAG =
 ifeq ($(USE_NVIDIA), 1)
 	DEVICE_LIB = $(DEVICE_HOME)/lib64
 	DEVICE_INCLUDE = $(DEVICE_HOME)/include
@@ -184,6 +196,14 @@ else
 	HOST_CCL_INCLUDE = /usr/local/include
 	HOST_CCL_LINK = 
 	HOST_CCL_ADAPTOR_FLAG = -DUSE_BOOTSTRAP_ADAPTOR
+endif
+
+# UCX network adaptor configuration
+ifeq ($(USE_UCX), 1)
+	UCX_LIB = $(UCX_HOME)/lib
+	UCX_INCLUDE = $(UCX_HOME)/include
+	UCX_LINK = -lucp -lucs -luct
+	NET_ADAPTOR_FLAG = -DUSE_UCX
 endif
 
 LIBDIR := $(BUILDDIR)/lib

--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,11 @@ ifeq ($(USE_UCX), 1)
 	UCX_INCLUDE = $(UCX_HOME)/include
 	UCX_LINK = -lucp -lucs -luct
 	NET_ADAPTOR_FLAG = -DUSE_UCX
+else
+	UCX_LIB = $(UCX_HOME)/lib
+	UCX_INCLUDE = $(UCX_HOME)/include
+	UCX_LINK = 
+	NET_ADAPTOR_FLAG = 
 endif
 
 LIBDIR := $(BUILDDIR)/lib
@@ -252,6 +257,11 @@ print_var:
 	@echo "HOST_CCL_INCLUDE: $(HOST_CCL_INCLUDE)"
 	@echo "ADAPTOR_FLAG: $(ADAPTOR_FLAG)"
 	@echo "HOST_CCL_ADAPTOR_FLAG: $(HOST_CCL_ADAPTOR_FLAG)"
+	@echo "USE_UCX: $(USE_UCX)"
+	@echo "UCX_HOME: $(UCX_HOME)"
+	@echo "UCX_LIB: $(UCX_LIB)"
+	@echo "UCX_INCLUDE: $(UCX_INCLUDE)"
+	@echo "NET_ADAPTOR_FLAG: $(NET_ADAPTOR_FLAG)"
 
 $(LIBDIR)/$(TARGET): $(LIBOBJ)
 	@mkdir -p `dirname $@`

--- a/Makefile
+++ b/Makefile
@@ -256,12 +256,12 @@ print_var:
 $(LIBDIR)/$(TARGET): $(LIBOBJ)
 	@mkdir -p `dirname $@`
 	@echo "Linking   $@"
-	@g++ $(LIBOBJ) -o $@ -L$(CCL_LIB) -L$(DEVICE_LIB) -L$(HOST_CCL_LIB) -shared -fvisibility=default -Wl,--no-as-needed -Wl,-rpath,$(LIBDIR) -Wl,-rpath,$(CCL_LIB) -Wl,-rpath,$(HOST_CCL_LIB) -lpthread -lrt -ldl $(CCL_LINK) $(DEVICE_LINK) $(HOST_CCL_LINK) -g
+	@g++ $(LIBOBJ) -o $@ -L$(CCL_LIB) -L$(DEVICE_LIB) -L$(HOST_CCL_LIB) -L$(UCX_LIB) -shared -fvisibility=default -Wl,--no-as-needed -Wl,-rpath,$(LIBDIR) -Wl,-rpath,$(CCL_LIB) -Wl,-rpath,$(HOST_CCL_LIB) -Wl,-rpath,$(UCX_LIB) -lpthread -lrt -ldl $(CCL_LINK) $(DEVICE_LINK) $(HOST_CCL_LINK) $(UCX_LINK) -g
 
 $(OBJDIR)/%.o: %.cc
 	@mkdir -p `dirname $@`
 	@echo "Compiling $@"
-	@g++ $< -o $@ $(foreach dir,$(INCLUDEDIR),-I$(dir)) -I$(CCL_INCLUDE) -I$(DEVICE_INCLUDE) -I$(HOST_CCL_INCLUDE) $(ADAPTOR_FLAG) $(HOST_CCL_ADAPTOR_FLAG) -c -fPIC -fvisibility=default -Wvla -Wno-unused-function -Wno-sign-compare -Wall -MMD -MP -g
+	@g++ $< -o $@ $(foreach dir,$(INCLUDEDIR),-I$(dir)) -I$(CCL_INCLUDE) -I$(DEVICE_INCLUDE) -I$(HOST_CCL_INCLUDE) -I$(UCX_INCLUDE) $(ADAPTOR_FLAG) $(HOST_CCL_ADAPTOR_FLAG) $(NET_ADAPTOR_FLAG) -c -fPIC -fvisibility=default -Wvla -Wno-unused-function -Wno-sign-compare -Wall -MMD -MP -g
 
 -include $(LIBOBJ:.o=.d)
 

--- a/flagcx/adaptor/adaptor.cc
+++ b/flagcx/adaptor/adaptor.cc
@@ -112,11 +112,20 @@ struct flagcxDeviceAdaptor *deviceAdaptor = &ducudaAdaptor;
 extern struct flagcxNetAdaptor flagcxNetSocket;
 extern struct flagcxNetAdaptor flagcxNetIb;
 
+#ifdef USE_UCX
+extern struct flagcxNetAdaptor flagcxNetUcx;
+#endif
+
 // Unified network adaptor entry point
 struct flagcxNetAdaptor *getUnifiedNetAdaptor(int netType) {
   switch (netType) {
     case IBRC:
+#ifdef USE_UCX
+      // When UCX is enabled, use UCX instead of IBRC
+      return &flagcxNetUcx;
+#else
       return &flagcxNetIb;
+#endif
     case SOCKET:
       return &flagcxNetSocket;
     default:

--- a/flagcx/adaptor/include/adaptor.h
+++ b/flagcx/adaptor/include/adaptor.h
@@ -47,7 +47,7 @@ extern struct flagcxNetAdaptor *netAdaptor;
 
 // Network type enumeration
 enum NetType {
-  IBRC = 1,    // InfiniBand RC
+  IBRC = 1,    // InfiniBand RC (or UCX when USE_UCX=1)
   SOCKET = 2   // Socket
 };
 

--- a/flagcx/adaptor/include/adaptor.h
+++ b/flagcx/adaptor/include/adaptor.h
@@ -47,8 +47,8 @@ extern struct flagcxNetAdaptor *netAdaptor;
 
 // Network type enumeration
 enum NetType {
-  IBRC = 1,    // InfiniBand RC (or UCX when USE_UCX=1)
-  SOCKET = 2   // Socket
+  IBRC = 1,  // InfiniBand RC (or UCX when USE_UCX=1)
+  SOCKET = 2 // Socket
 };
 
 // Unified network adaptor function declarations

--- a/flagcx/adaptor/include/tuner.h
+++ b/flagcx/adaptor/include/tuner.h
@@ -1,6 +1,7 @@
 #ifndef FLAGCX_ADAPTOR_TUNER_H_
 #define FLAGCX_ADAPTOR_TUNER_H_
 
+#include "debug.h"
 #include "flagcx.h"
 #include "debug.h"
 
@@ -11,16 +12,20 @@ extern "C" {
 // Flagcx environment variable types
 enum flagcxEnvType {
   FLAGCX_ENV_TYPE_CREATION = 0x01, // envs used when creating the communicator
-  FLAGCX_ENV_TYPE_COLL = 0x02,     // envs should be set for every specific collective at runtime
-  FLAGCX_ENV_TYPE_ONETIME = 0x04   // envs take effect only the first time they are used at runtime
+  FLAGCX_ENV_TYPE_COLL =
+      0x02, // envs should be set for every specific collective at runtime
+  FLAGCX_ENV_TYPE_ONETIME =
+      0x04 // envs take effect only the first time they are used at runtime
 };
 
-#define FLAGCX_ENV_ENTITY_MAX_LENGTH 128 // max length of a single env name or value
+#define FLAGCX_ENV_ENTITY_MAX_LENGTH                                           \
+  128 // max length of a single env name or value
 struct flagcxEnvEntity {
   uint32_t type; // env type bitmap, OR of FLAGCX_ENV_TYPE_*
   char name[FLAGCX_ENV_ENTITY_MAX_LENGTH];
   char value[FLAGCX_ENV_ENTITY_MAX_LENGTH];
-  char defaultValue[FLAGCX_ENV_ENTITY_MAX_LENGTH]; // default value used to unset this env
+  char defaultValue[FLAGCX_ENV_ENTITY_MAX_LENGTH]; // default value used to
+                                                   // unset this env
 };
 
 #define FLAGCX_COMM_TAG_MAX_LENGTH 64 // max length of communicator tag
@@ -29,19 +34,20 @@ struct flagcxCommTag {
   char tag[FLAGCX_COMM_TAG_MAX_LENGTH]; // tag string
 };
 
-// Structure of environment list for a specific communicator candidate configuration
-#define FLAGCX_ENV_LIST_MAX_LENGTH 32   // max length of env list per communicator
+// Structure of environment list for a specific communicator candidate
+// configuration
+#define FLAGCX_ENV_LIST_MAX_LENGTH 32 // max length of env list per communicator
 struct flagcxEnvConfig {
-  flagcxCommTag commTag;    // communicator tag
-  int envCount;             // number of env vars
+  flagcxCommTag commTag; // communicator tag
+  int envCount;          // number of env vars
   struct flagcxEnvEntity envs[FLAGCX_ENV_LIST_MAX_LENGTH];
 };
 
 #define FLAGCX_ENV_CONFIG_MAX_COUNT 4 // max number of communicator configs
 // A list of flagcxEnvConfig
 struct flagcxEnvConfigList {
-    int nConfigs; // number of communicator configs
-    struct flagcxEnvConfig configList[FLAGCX_ENV_CONFIG_MAX_COUNT];
+  int nConfigs; // number of communicator configs
+  struct flagcxEnvConfig configList[FLAGCX_ENV_CONFIG_MAX_COUNT];
 };
 
 struct flagcxTuner {
@@ -60,17 +66,17 @@ struct flagcxTuner {
   flagcxResult_t (*init)(size_t nRanks, size_t nNodes,
                          flagcxDebugLogger_t logFunction, void **context);
 
-  // Gets number of candidate communicator env settings available from this tuner.
-  // Inputs:
+  // Gets number of candidate communicator env settings available from this
+  // tuner. Inputs:
   //   - context: tuner context object
   // Outputs:
   //   - nCandidates: number of candidate communicator
   flagcxResult_t (*getCandidateNumber)(void* context, uint32_t* nCandidates);
 
-  // Set appropriate environment variables according to index, and return the communicator tag.
-  // Note that all the env settings are set before returning from this function.
-  // Only env of type FLAGCX_ENV_TYPE_CREATION will be set in this function.
-  // Inputs:
+  // Set appropriate environment variables according to index, and return the
+  // communicator tag. Note that all the env settings are set before returning
+  // from this function. Only env of type FLAGCX_ENV_TYPE_CREATION will be set
+  // in this function. Inputs:
   //   - context: tuner context object
   //   - index: index of candidate communicator, range [0, nCandidates)
   // Outputs:
@@ -78,9 +84,8 @@ struct flagcxTuner {
   flagcxResult_t (*setCandidate)(void* context, uint32_t index, struct flagcxCommTag* commTag);
 
   // Select the best communicator candidate for this collective.
-  // All the env of type FLAGCX_ENV_TYPE_COLL and FLAGCX_ENV_TYPE_ONETIME if necessary
-  // will be set before returning from this function.
-  // Inputs:
+  // All the env of type FLAGCX_ENV_TYPE_COLL and FLAGCX_ENV_TYPE_ONETIME if
+  // necessary will be set before returning from this function. Inputs:
   //   - context: tuner context object
   //   - collType: collective type , e.g., allreduce, allgather…
   //   - nBytes: collective size in bytes
@@ -90,13 +95,14 @@ struct flagcxTuner {
   //   - commTag: communicator tag, used to select the underlying communicator.
   //
   // InOut:
-  //   - collCostTable: collective cost table.  the caller is responsible for allocating and
+  //   - collCostTable: collective cost table.  the caller is responsible for
+  //   allocating and
   //                    deallocating the memory
   //
-  flagcxResult_t (*getCollInfo)(void* context, flagcxCommOp_t collType,
+  flagcxResult_t (*getCollInfo)(void *context, flagcxCommOp_t collType,
                                 size_t nBytes, int numPipeOps,
-                                float** collCostTable, int regBuff,
-                                struct flagcxCommTag* commTag);
+                                float **collCostTable, int regBuff,
+                                struct flagcxCommTag *commTag);
 
   // Terminates the tuner and cleans up any resources that the tuner allocated.
   flagcxResult_t (*destroy)(void *context);

--- a/flagcx/adaptor/include/tuner.h
+++ b/flagcx/adaptor/include/tuner.h
@@ -3,7 +3,6 @@
 
 #include "debug.h"
 #include "flagcx.h"
-#include "debug.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -71,7 +70,7 @@ struct flagcxTuner {
   //   - context: tuner context object
   // Outputs:
   //   - nCandidates: number of candidate communicator
-  flagcxResult_t (*getCandidateNumber)(void* context, uint32_t* nCandidates);
+  flagcxResult_t (*getCandidateNumber)(void *context, uint32_t *nCandidates);
 
   // Set appropriate environment variables according to index, and return the
   // communicator tag. Note that all the env settings are set before returning
@@ -81,7 +80,8 @@ struct flagcxTuner {
   //   - index: index of candidate communicator, range [0, nCandidates)
   // Outputs:
   //   - commTag: communicator tag for this particular candidate
-  flagcxResult_t (*setCandidate)(void* context, uint32_t index, struct flagcxCommTag* commTag);
+  flagcxResult_t (*setCandidate)(void *context, uint32_t index,
+                                 struct flagcxCommTag *commTag);
 
   // Select the best communicator candidate for this collective.
   // All the env of type FLAGCX_ENV_TYPE_COLL and FLAGCX_ENV_TYPE_ONETIME if

--- a/flagcx/adaptor/include/ucx_adaptor.h
+++ b/flagcx/adaptor/include/ucx_adaptor.h
@@ -12,9 +12,9 @@
 #ifdef USE_UCX
 
 #include "check.h"
+#include "socket.h"
 #include <pthread.h>
 #include <ucp/api/ucp.h>
-#include "socket.h"
 
 // UCX Constants
 #define MAX_REQUESTS 16

--- a/flagcx/adaptor/include/ucx_adaptor.h
+++ b/flagcx/adaptor/include/ucx_adaptor.h
@@ -1,0 +1,157 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2016-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef UCX_ADAPTOR_H
+#define UCX_ADAPTOR_H
+
+#ifdef USE_UCX
+
+#include "check.h"
+#include <pthread.h>
+#include <ucp/api/ucp.h>
+
+// UCX Constants
+#define MAX_REQUESTS 16
+#define FLAGCX_NET_IB_MAX_RECVS 16
+
+// UCX Communication State Enum
+enum flagcxUcxCommState {
+  flagcxUcxCommStateStart = 0,
+  flagcxUcxCommStateConnect = 1,
+  flagcxUcxCommStateAccept = 3,
+};
+
+// UCX Communication Stage Structure
+struct flagcxUcxCommStage {
+  enum flagcxUcxCommState state;
+  uint8_t iteration;
+  void *sock;
+  void *comm;
+};
+
+// UCX Memory Handle
+typedef struct flagcxUcxMhandle {
+  ucp_mem_h ucp_memh;
+  ucp_rkey_h rkey;
+  int mem_type;
+} flagcxUcxMhandle_t;
+
+// UCX Endpoint List
+struct flagcxUcxEpList {
+  struct flagcxSocket *sock;
+  struct flagcxUcxEpList *next;
+};
+
+// UCX Worker Structure
+typedef struct flagcxUcxWorker {
+  ucp_worker_h worker; /* ucp worker associated with ctx */
+  ucp_context_h ctx;   /* ucp_context bounded to specific device */
+  struct flagcxUcxEpList
+      *eps; /* oob conection to all endpoints that were opened on this worker */
+
+  int count;        /* number of connections that uses this worker */
+  int dev;          /* Managed device */
+  pthread_t thread; /* Owner thread */
+
+  struct flagcxUcxWorker *next;
+} flagcxUcxWorker_t;
+
+// UCX Listen Handle
+typedef struct flagcxUcxListenHandle {
+  union flagcxSocketAddress connectAddr; /* reciever socket address */
+  uint64_t magic;                        /* random number to help debugging */
+  ucp_tag_t tag; /* tag that is used to distiguish data that was sent to
+                    this reciever. Required when shared worker is used. */
+  struct flagcxUcxCommStage stage;
+} flagcxUcxListenHandle_t;
+
+// UCX Listen Communicator
+typedef struct flagcxUcxListenComm {
+  int dev;                  /* device number in flagcxIbDevs which will
+                             * be used to recieve data */
+  struct flagcxSocket sock; /* socket for OOB connection */
+  ucp_context_h ctx; /* ucp_context associated with specific device dev */
+  flagcxUcxWorker_t *ucx_worker; /* flagcxUcxWorker created on ctx, worker can
+                           be shared between multiple connections */
+  ucp_tag_t tag; /* tag that is used to distiguish data that was sent to
+                    this reciever. Required when shared worker is used.*/
+  struct flagcxUcxCommStage stage;
+} flagcxUcxListenComm_t;
+
+// UCX Connect Message
+typedef struct flagcxUcxConnectMsg {
+  size_t addr_len;
+} flagcxUcxConnectMsg_t;
+
+// Forward declaration
+struct flagcxUcxComm;
+
+// UCX Request Structure
+typedef struct flagcxUcxRequest {
+  struct flagcxUcxRequest *next; /* Next request in the free list */
+  struct flagcxUcxComm *comm;    /* Owning communicator */
+  ucp_worker_h worker;           /* Worker for all requests */
+  int pending;                   /* How many requests are still pending */
+  int count;                     /* How many requests are contained */
+  int size[FLAGCX_NET_IB_MAX_RECVS];
+} flagcxUcxRequest_t;
+
+// UCX GPU Flush Structure
+typedef struct flagcxUcxGpuFlush {
+  int enabled;
+  int hostMem;
+  ucp_ep_h flush_ep;
+} flagcxUcxGpuFlush_t;
+
+// UCX Context Structure
+typedef struct flagcxUcxCtx {
+  ucp_context_h flagcxUcxCtx;
+  flagcxUcxGpuFlush_t gpuFlush;
+} flagcxUcxCtx_t;
+
+// UCX Communicator Structure
+typedef struct flagcxUcxComm {
+  ucp_context_h ctx;             /* ucp_context bounded to specific device */
+  flagcxUcxGpuFlush_t gpuFlush;  /* flushing handle */
+  flagcxUcxWorker_t *ucx_worker; /* ucp worker associated with ctx */
+  ucp_ep_h ep;                   /* ucp endpoint created on worker */
+  ucp_tag_t tag;  /* datapath tag to filter out message that are not
+                     belong to this connnection */
+  ucp_tag_t ctag; /* controlpath tag to filter out message that are not
+                     belong to this connnection */
+  struct flagcxSocket sock; /* socket for OOB connection */
+  int ready; /* indicates that receive communicator is fully initialized */
+  flagcxUcxRequest_t reqs[MAX_REQUESTS]; /* max inflight requests */
+  flagcxUcxRequest_t *free_req;          /* first request available */
+  flagcxUcxConnectMsg_t *msg; /* message to establish reverse connection */
+  void *connect_req;          /* msg request */
+} flagcxUcxComm_t;
+
+// UCX Macros
+#define UCXCHECK(cmd)                                                          \
+  do {                                                                         \
+    ucs_status_t e = cmd;                                                      \
+    if (UCS_OK != e) {                                                         \
+      WARN("Failed: UCX error %s:%d '%s'\n", __FILE__, __LINE__,               \
+           ucs_status_string(e));                                              \
+      return flagcxInternalError;                                              \
+    }                                                                          \
+  } while (0)
+
+#define UCXCHECK_VOID(cmd)                                                     \
+  do {                                                                         \
+    ucs_status_t e = cmd;                                                      \
+    if (UCS_OK != e) {                                                         \
+      WARN("Failed: UCX error %s:%d '%s'\n", __FILE__, __LINE__,               \
+           ucs_status_string(e));                                              \
+    }                                                                          \
+  } while (0)
+
+#endif // USE_UCX
+
+#endif // UCX_ADAPTOR_H

--- a/flagcx/adaptor/include/ucx_adaptor.h
+++ b/flagcx/adaptor/include/ucx_adaptor.h
@@ -14,6 +14,7 @@
 #include "check.h"
 #include <pthread.h>
 #include <ucp/api/ucp.h>
+#include "socket.h"
 
 // UCX Constants
 #define MAX_REQUESTS 16

--- a/flagcx/adaptor/net/ibrc_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_adaptor.cc
@@ -21,8 +21,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 #define ENABLE_TIMER 0
-#include "net.h"
 #include "ib_common.h"
+#include "net.h"
 #include "timer.h"
 
 static char flagcxIbIfName[MAX_IF_NAME_SIZE + 1];

--- a/flagcx/adaptor/net/ibrc_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_adaptor.cc
@@ -22,58 +22,17 @@
 #include <unistd.h>
 #define ENABLE_TIMER 0
 #include "net.h"
+#include "ib_common.h"
 #include "timer.h"
 
-#define MAXNAMESIZE 64
 static char flagcxIbIfName[MAX_IF_NAME_SIZE + 1];
 static union flagcxSocketAddress flagcxIbIfAddr;
 
-struct flagcxIbMr {
-  uintptr_t addr;
-  size_t pages;
-  int refs;
-  ibv_mr *mr;
-};
-
-struct flagcxIbMrCache {
-  struct flagcxIbMr *slots;
-  int capacity, population;
-};
-
 static int flagcxNMergedIbDevs = -1;
-#define FLAGCX_IB_MAX_DEVS_PER_NIC 2
-#define MAX_MERGED_DEV_NAME                                                    \
-  (MAXNAMESIZE * FLAGCX_IB_MAX_DEVS_PER_NIC) + FLAGCX_IB_MAX_DEVS_PER_NIC
-struct alignas(64) flagcxIbMergedDev {
-  int ndevs;
-  int devs[FLAGCX_IB_MAX_DEVS_PER_NIC]; // Points to an index in flagcxIbDevs
-  int speed;
-  char devName[MAX_MERGED_DEV_NAME]; // Up to FLAGCX_IB_MAX_DEVS_PER_NIC * name
-                                     // size, and a character for each '+'
-};
-
 static int flagcxNIbDevs = -1;
-struct alignas(64) flagcxIbDev {
-  pthread_mutex_t lock;
-  int device;
-  uint64_t guid;
-  uint8_t portNum;
-  uint8_t link;
-  int speed;
-  ibv_context *context;
-  int pdRefs;
-  ibv_pd *pd;
-  char devName[MAXNAMESIZE];
-  char *pciPath;
-  int realPort;
-  int maxQp;
-  struct flagcxIbMrCache mrCache;
-  int ar; // ADAPTIVE_ROUTING
-  struct ibv_port_attr portAttr;
-};
 
-#define MAX_IB_DEVS 32
-struct flagcxIbMergedDev flagcxIbMergedDevs[MAX_IB_DEVS];
+// Define global arrays
+struct flagcxIbMergedDev flagcxIbMergedDevs[MAX_IB_VDEVS];
 struct flagcxIbDev flagcxIbDevs[MAX_IB_DEVS];
 pthread_mutex_t flagcxIbLock = PTHREAD_MUTEX_INITIALIZER;
 static int flagcxIbRelaxedOrderingEnabled = 0;
@@ -1920,7 +1879,7 @@ flagcxResult_t flagcxIbIsend(void *sendComm, void *data, size_t size, int tag,
       union flagcxSocketAddress addr;
       flagcxSocketGetAddr(&comm->base.sock, &addr);
       WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: "
-           "size %d addr %lx rkeys[0]=%x",
+           "size %ld addr %lx rkeys[0]=%x",
            r, nreqs, tag, flagcxSocketToString(&addr, line), slots[r].size,
            slots[r].addr, slots[r].rkeys[0]);
       return flagcxInternalError;

--- a/flagcx/adaptor/net/ucx_adaptor.cc
+++ b/flagcx/adaptor/net/ucx_adaptor.cc
@@ -11,22 +11,22 @@
 #include "adaptor.h"
 #include "comm.h"
 #include "core.h"
+#include "debug.h"
+#include "flagcx.h"
+#include "ib_common.h"
+#include "ibvwrap.h"
 #include "net.h"
 #include "param.h"
 #include "socket.h"
 #include "utils.h"
-#include "flagcx.h"
-#include "debug.h"
-#include "ibvwrap.h"
-#include "ib_common.h"
 #include <assert.h>
+#include <errno.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
-#include <errno.h>
 #include <ucp/api/ucp.h>
+#include <unistd.h>
 
 // Additional macro definitions
 #define MAX_REQUESTS 16
@@ -34,19 +34,22 @@
 
 // Type definitions
 // Structures now defined in ib_common.h
-#define PTHREADCHECKGOTO(statement, name, RES, label) do { \
-  int retval = (statement); \
-  if (retval != 0) { \
-    WARN("Call to " name " failed: %s", strerror(retval)); \
-    RES = flagcxSystemError; \
-    goto label; \
-  } \
-} while (0)
+#define PTHREADCHECKGOTO(statement, name, RES, label)                          \
+  do {                                                                         \
+    int retval = (statement);                                                  \
+    if (retval != 0) {                                                         \
+      WARN("Call to " name " failed: %s", strerror(retval));                   \
+      RES = flagcxSystemError;                                                 \
+      goto label;                                                              \
+    }                                                                          \
+  } while (0)
 // Enums and constants (now defined in ib_common.h)
 
-#define FLAGCX_IB_LLSTR(link_layer) ((link_layer) == IBV_LINK_LAYER_INFINIBAND ? "IB" : "ETH")
+#define FLAGCX_IB_LLSTR(link_layer)                                            \
+  ((link_layer) == IBV_LINK_LAYER_INFINIBAND ? "IB" : "ETH")
 #define FLAGCX_NET_IB_MAX_RECVS 16
-#define FLAGCX_STATIC_ASSERT(condition, message) static_assert(condition, message)
+#define FLAGCX_STATIC_ASSERT(condition, message)                               \
+  static_assert(condition, message)
 #define FLAGCX_NET_HANDLE_MAXSIZE 128
 FLAGCX_PARAM(SharpMaxComms, "SHARP_MAX_COMMS", 1);
 // Global variables (now defined in ib_common.h)
@@ -57,19 +60,20 @@ static int flagcxNMergedIbDevs = -1;
 static int flagcxNSharpDevs = 0;
 static pthread_mutex_t flagcx_p2p_lock = PTHREAD_MUTEX_INITIALIZER;
 static int flagcxIbGdrModuleLoaded = 0;
-static struct {
-  pthread_once_t once;
-} onces[MAX_IB_DEVS];
+static struct { pthread_once_t once; } onces[MAX_IB_DEVS];
 
-flagcxResult_t flagcxIbMakeVDeviceInternal(int* d, flagcxNetVDeviceProps_t* props, int flagcxNIbDevs, int *flagcxNMergedIbDevs) {
+flagcxResult_t flagcxIbMakeVDeviceInternal(int *d,
+                                           flagcxNetVDeviceProps_t *props,
+                                           int flagcxNIbDevs,
+                                           int *flagcxNMergedIbDevs) {
   if ((flagcxParamIbMergeNics() == 0) && props->ndevs > 1) {
     INFO(FLAGCX_NET, "NET/IB : Skipping makeVDevice, flagcx_IB_MERGE_NICS=0");
     return flagcxInvalidUsage;
   }
 
   if (props->ndevs == 0) {
-   WARN("NET/IB : Can't make virtual NIC with 0 devices");
-   return flagcxInvalidUsage;
+    WARN("NET/IB : Can't make virtual NIC with 0 devices");
+    return flagcxInvalidUsage;
   }
 
   if (*flagcxNMergedIbDevs == MAX_IB_DEVS) {
@@ -78,35 +82,42 @@ flagcxResult_t flagcxIbMakeVDeviceInternal(int* d, flagcxNetVDeviceProps_t* prop
   }
 
   // Always count up number of merged devices
-  flagcxIbMergedDev* mDev = flagcxIbMergedDevs + *flagcxNMergedIbDevs;
+  flagcxIbMergedDev *mDev = flagcxIbMergedDevs + *flagcxNMergedIbDevs;
   mDev->vProps.ndevs = 0;
   mDev->speed = 0;
 
   for (int i = 0; i < props->ndevs; i++) {
-    flagcxIbDev* dev = flagcxIbDevs + props->devs[i];
-    if (mDev->vProps.ndevs == 2) return flagcxInvalidUsage; // FLAGCX_IB_MAX_DEVS_PER_NIC
+    flagcxIbDev *dev = flagcxIbDevs + props->devs[i];
+    if (mDev->vProps.ndevs == 2)
+      return flagcxInvalidUsage; // FLAGCX_IB_MAX_DEVS_PER_NIC
     mDev->vProps.devs[mDev->vProps.ndevs++] = props->devs[i];
     mDev->speed += dev->speed;
     // Each successive time, copy the name '+' new name
     if (mDev->vProps.ndevs > 1) {
-      snprintf(mDev->devName + strlen(mDev->devName), sizeof(mDev->devName) - strlen(mDev->devName), "+%s", dev->devName);
-    // First time, copy the plain name
+      snprintf(mDev->devName + strlen(mDev->devName),
+               sizeof(mDev->devName) - strlen(mDev->devName), "+%s",
+               dev->devName);
+      // First time, copy the plain name
     } else {
       strncpy(mDev->devName, dev->devName, MAXNAMESIZE);
-     }
-   }
+    }
+  }
 
   // Check link layers
-  flagcxIbDev* dev0 = flagcxIbDevs + props->devs[0];
+  flagcxIbDev *dev0 = flagcxIbDevs + props->devs[0];
   for (int i = 1; i < props->ndevs; i++) {
     if (props->devs[i] >= flagcxNIbDevs) {
-      WARN("NET/IB : Cannot use physical device %d, max %d", props->devs[i], flagcxNIbDevs);
+      WARN("NET/IB : Cannot use physical device %d, max %d", props->devs[i],
+           flagcxNIbDevs);
       return flagcxInvalidUsage;
     }
-    flagcxIbDev* dev = flagcxIbDevs + props->devs[i];
+    flagcxIbDev *dev = flagcxIbDevs + props->devs[i];
     if (dev->link != dev0->link) {
-      WARN("NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using flagcx_IB_HCA",
-        props->devs[0], dev0->devName, dev0->portNum, "IB", props->devs[i], dev->devName, dev->portNum, "IB"); 
+      WARN("NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and "
+           "[%d]%s:%d/%s. Try selecting NICs of only one link type using "
+           "flagcx_IB_HCA",
+           props->devs[0], dev0->devName, dev0->portNum, "IB", props->devs[i],
+           dev->devName, dev->portNum, "IB");
       return flagcxInvalidUsage;
     }
   }
@@ -114,45 +125,50 @@ flagcxResult_t flagcxIbMakeVDeviceInternal(int* d, flagcxNetVDeviceProps_t* prop
   *d = *flagcxNMergedIbDevs;
   (*flagcxNMergedIbDevs)++;
 
-  INFO(FLAGCX_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, mDev->devName, mDev->speed, mDev->vProps.ndevs);
+  INFO(FLAGCX_NET,
+       "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d,
+       mDev->devName, mDev->speed, mDev->vProps.ndevs);
   return flagcxSuccess;
 }
-static int flagcxIbMatchVfPath(char* path1, char* path2) {
+static int flagcxIbMatchVfPath(char *path1, char *path2) {
   // Merge multi-port NICs into the same PCI device
   if (flagcxParamIbMergeVfs()) {
-    return strncmp(path1, path2, strlen(path1)-4) == 0;
+    return strncmp(path1, path2, strlen(path1) - 4) == 0;
   } else {
-    return strncmp(path1, path2, strlen(path1)-1) == 0;
+    return strncmp(path1, path2, strlen(path1) - 1) == 0;
   }
 }
-static void flagcxIbStatsFatalError(struct flagcxIbStats* stat){
+static void flagcxIbStatsFatalError(struct flagcxIbStats *stat) {
   __atomic_fetch_add(&stat->fatalErrorCount, 1, __ATOMIC_RELAXED);
 }
-static void flagcxIbQpFatalError(struct ibv_qp* qp) {
-  flagcxIbStatsFatalError((struct flagcxIbStats*)qp->qp_context);
+static void flagcxIbQpFatalError(struct ibv_qp *qp) {
+  flagcxIbStatsFatalError((struct flagcxIbStats *)qp->qp_context);
 }
-static void flagcxIbCqFatalError(struct ibv_cq* cq) {
-  flagcxIbStatsFatalError((struct flagcxIbStats*)cq->cq_context);
+static void flagcxIbCqFatalError(struct ibv_cq *cq) {
+  flagcxIbStatsFatalError((struct flagcxIbStats *)cq->cq_context);
 }
-static void flagcxIbDevFatalError(struct flagcxIbDev* dev) {
+static void flagcxIbDevFatalError(struct flagcxIbDev *dev) {
   flagcxIbStatsFatalError(&dev->stats);
 }
 #define KNL_MODULE_LOADED(a) ((access(a, F_OK) == -1) ? 0 : 1)
 static void ibGdrSupportInitOnce() {
   // Check for the nv_peer_mem module being loaded
-  flagcxIbGdrModuleLoaded = KNL_MODULE_LOADED("/sys/kernel/mm/memory_peers/nv_mem/version") ||
-                          KNL_MODULE_LOADED("/sys/kernel/mm/memory_peers/nv_mem_nc/version") ||
-                          KNL_MODULE_LOADED("/sys/module/nvidia_peermem/version");
+  flagcxIbGdrModuleLoaded =
+      KNL_MODULE_LOADED("/sys/kernel/mm/memory_peers/nv_mem/version") ||
+      KNL_MODULE_LOADED("/sys/kernel/mm/memory_peers/nv_mem_nc/version") ||
+      KNL_MODULE_LOADED("/sys/module/nvidia_peermem/version");
 }
 
 /* for data direct nic, the device name is ends with suffix '_dma`.
  * remove this suffix before passing name to libsharp */
- void plugin_get_device_name(const char *input, char *output, size_t output_size) {
+void plugin_get_device_name(const char *input, char *output,
+                            size_t output_size) {
   const char *suffix = "_dma";
   size_t input_len = strlen(input);
   size_t suffix_len = strlen(suffix);
 
-  if (input_len >= suffix_len && strcmp(input + input_len - suffix_len, suffix) == 0) {
+  if (input_len >= suffix_len &&
+      strcmp(input + input_len - suffix_len, suffix) == 0) {
     size_t new_len = input_len - suffix_len;
     if (new_len >= output_size) {
       new_len = output_size - 1;
@@ -166,129 +182,140 @@ static void ibGdrSupportInitOnce() {
 }
 // Missing arrays and constants
 static int ibv_widths[] = {1, 2, 4, 8, 12};
-static int ibv_speeds[] = {2500, 5000, 10000, 14000, 25000, 50000, 100000, 200000};
+static int ibv_speeds[] = {2500,  5000,  10000,  14000,
+                           25000, 50000, 100000, 200000};
 
 // Helper function
 static int first_bit_set(int value, int max_bits) {
   for (int i = 0; i <= max_bits; i++) {
-    if (value & (1 << i)) return i;
+    if (value & (1 << i))
+      return i;
   }
   return max_bits;
 }
 
 // Function implementations from ucx_adaptor.cc
-int flagcx_p2p_ib_width(int width)
-{
-  return ibv_widths[first_bit_set(width, sizeof(ibv_widths)/sizeof(int)-1)];
+int flagcx_p2p_ib_width(int width) {
+  return ibv_widths[first_bit_set(width, sizeof(ibv_widths) / sizeof(int) - 1)];
 }
 
-int flagcx_p2p_ib_speed(int speed)
-{
-  return ibv_speeds[first_bit_set(speed, sizeof(ibv_speeds)/sizeof(int)-1)];
+int flagcx_p2p_ib_speed(int speed) {
+  return ibv_speeds[first_bit_set(speed, sizeof(ibv_speeds) / sizeof(int) - 1)];
 }
 
-flagcxResult_t flagcxIbStatsInit(struct flagcxIbStats* stat) {
+flagcxResult_t flagcxIbStatsInit(struct flagcxIbStats *stat) {
   __atomic_store_n(&stat->fatalErrorCount, 0, __ATOMIC_RELAXED);
   return flagcxSuccess;
 }
 
-flagcxResult_t flagcx_p2p_ib_pci_path(flagcxIbDev *devs, int num_devs, char* dev_name, char** path, int* real_port)
-{
+flagcxResult_t flagcx_p2p_ib_pci_path(flagcxIbDev *devs, int num_devs,
+                                      char *dev_name, char **path,
+                                      int *real_port) {
   char device_path[PATH_MAX];
   snprintf(device_path, PATH_MAX, "/sys/class/infiniband/%s/device", dev_name);
-  char* p = realpath(device_path, NULL);
+  char *p = realpath(device_path, NULL);
   if (p == NULL) {
     WARN("Could not find real path of %s", device_path);
   } else {
     // Merge multi-port NICs into the same PCI device
-    p[strlen(p)-1] = '0';
+    p[strlen(p) - 1] = '0';
     // Also merge virtual functions (VF) into the same device
-    if (flagcxParamIbMergeVfs()) p[strlen(p)-3] = p[strlen(p)-4] = '0';
+    if (flagcxParamIbMergeVfs())
+      p[strlen(p) - 3] = p[strlen(p) - 4] = '0';
     // Keep the real port aside (the ibv port is always 1 on recent cards)
     *real_port = 0;
-    for (int d=0; d<num_devs; d++) {
-      if (flagcxIbMatchVfPath(p, flagcxIbDevs[d].pciPath)) (*real_port)++;
+    for (int d = 0; d < num_devs; d++) {
+      if (flagcxIbMatchVfPath(p, flagcxIbDevs[d].pciPath))
+        (*real_port)++;
     }
     *path = p;
   }
   return flagcxSuccess;
 }
 
-static void* flagcxIbAsyncThreadMain(void* args) {
-  struct flagcxIbDev* dev = (struct flagcxIbDev*)args;
+static void *flagcxIbAsyncThreadMain(void *args) {
+  struct flagcxIbDev *dev = (struct flagcxIbDev *)args;
   while (1) {
     struct ibv_async_event event;
-    if (flagcxSuccess != flagcxWrapIbvGetAsyncEvent(dev->context, &event)) { break; }
-    char *str;
-    struct ibv_cq* cq __attribute__((unused)) = event.element.cq;    // only valid if CQ error
-    struct ibv_qp* qp __attribute__((unused)) = event.element.qp;    // only valid if QP error
-    struct ibv_srq* srq __attribute__((unused)) = event.element.srq; // only valid if SRQ error
-    if (flagcxSuccess != flagcxWrapIbvEventTypeStr(&str, event.event_type)) { break; }
-    switch (event.event_type) {
-    case IBV_EVENT_DEVICE_FATAL:
-      // the above is device fatal error
-      WARN("NET/IB : %s:%d async fatal event: %s", dev->devName, dev->portNum, str);
-      flagcxIbDevFatalError(dev);
+    if (flagcxSuccess != flagcxWrapIbvGetAsyncEvent(dev->context, &event)) {
       break;
-    case IBV_EVENT_PORT_ACTIVE:
-    case IBV_EVENT_PORT_ERR:
-      WARN("NET/IB : %s:%d port event: %s", dev->devName, dev->portNum, str);
-      break;
-    case IBV_EVENT_CQ_ERR:
-      WARN("NET/IB : %s:%d CQ event: %s", dev->devName, dev->portNum, str);
-      break;
-    case IBV_EVENT_QP_FATAL:
-    case IBV_EVENT_QP_ACCESS_ERR:
-      WARN("NET/IB : %s:%d QP event: %s", dev->devName, dev->portNum, str);
-      break;
-    case IBV_EVENT_SRQ_ERR:
-      WARN("NET/IB : %s:%d SRQ event: %s", dev->devName, dev->portNum, str);
-      break;
-    default:
-      WARN("NET/IB : %s:%d unknown event: %s", dev->devName, dev->portNum, str);
     }
-    if (flagcxSuccess != flagcxWrapIbvAckAsyncEvent(&event)) { break; }
+    char *str;
+    struct ibv_cq *cq __attribute__((unused)) =
+        event.element.cq; // only valid if CQ error
+    struct ibv_qp *qp __attribute__((unused)) =
+        event.element.qp; // only valid if QP error
+    struct ibv_srq *srq __attribute__((unused)) =
+        event.element.srq; // only valid if SRQ error
+    if (flagcxSuccess != flagcxWrapIbvEventTypeStr(&str, event.event_type)) {
+      break;
+    }
+    switch (event.event_type) {
+      case IBV_EVENT_DEVICE_FATAL:
+        // the above is device fatal error
+        WARN("NET/IB : %s:%d async fatal event: %s", dev->devName, dev->portNum,
+             str);
+        flagcxIbDevFatalError(dev);
+        break;
+      case IBV_EVENT_PORT_ACTIVE:
+      case IBV_EVENT_PORT_ERR:
+        WARN("NET/IB : %s:%d port event: %s", dev->devName, dev->portNum, str);
+        break;
+      case IBV_EVENT_CQ_ERR:
+        WARN("NET/IB : %s:%d CQ event: %s", dev->devName, dev->portNum, str);
+        break;
+      case IBV_EVENT_QP_FATAL:
+      case IBV_EVENT_QP_ACCESS_ERR:
+        WARN("NET/IB : %s:%d QP event: %s", dev->devName, dev->portNum, str);
+        break;
+      case IBV_EVENT_SRQ_ERR:
+        WARN("NET/IB : %s:%d SRQ event: %s", dev->devName, dev->portNum, str);
+        break;
+      default:
+        WARN("NET/IB : %s:%d unknown event: %s", dev->devName, dev->portNum,
+             str);
+    }
+    if (flagcxSuccess != flagcxWrapIbvAckAsyncEvent(&event)) {
+      break;
+    }
   }
   return NULL;
 }
 
+#define UCXCHECK(cmd)                                                          \
+  do {                                                                         \
+    ucs_status_t e = cmd;                                                      \
+    if (UCS_OK != e) {                                                         \
+      WARN("Failed: UCX error %s:%d '%s'\n", __FILE__, __LINE__,               \
+           ucs_status_string(e));                                              \
+      return flagcxInternalError;                                              \
+    }                                                                          \
+  } while (0)
 
+#define UCXCHECK_VOID(cmd)                                                     \
+  do {                                                                         \
+    ucs_status_t e = cmd;                                                      \
+    if (UCS_OK != e) {                                                         \
+      WARN("Failed: UCX error %s:%d '%s'\n", __FILE__, __LINE__,               \
+           ucs_status_string(e));                                              \
+    }                                                                          \
+  } while (0)
 
-
-
-#define UCXCHECK(cmd) do {                           \
-  ucs_status_t e = cmd;                              \
-  if( UCS_OK != e ) {                                \
-    WARN("Failed: UCX error %s:%d '%s'\n",           \
-        __FILE__,__LINE__, ucs_status_string(e));    \
-    return flagcxInternalError;                      \
-  }                                                  \
-} while(0)
-
-#define UCXCHECK_VOID(cmd) do {                      \
-  ucs_status_t e = cmd;                              \
-  if( UCS_OK != e ) {                                \
-    WARN("Failed: UCX error %s:%d '%s'\n",           \
-        __FILE__,__LINE__, ucs_status_string(e));    \
-  }                                                  \
-} while(0)
-
-// With flagcxNet_v11_t the FlagCX core initializes the network plugin per-communicator
-// rather than once for all communicators. However, the internal plugin implementation
-// still assumes the plugin is initialized only once across all communicators. The ref
-// counter makes sure the plugin internally initializes only once. When per communicator
-// context support is added to the plugin the ref counter can be removed.
+// With flagcxNet_v11_t the FlagCX core initializes the network plugin
+// per-communicator rather than once for all communicators. However, the
+// internal plugin implementation still assumes the plugin is initialized only
+// once across all communicators. The ref counter makes sure the plugin
+// internally initializes only once. When per communicator context support is
+// added to the plugin the ref counter can be removed.
 static int flagcxUcxRefCount = 0;
-
 
 FLAGCX_PARAM(UCXDisable, "UCX_DISABLE", 0);
 /* Exclude cuda-related UCX transports */
 FLAGCX_PARAM(UCXCudaDisable, "UCX_CUDA_DISABLE", 1);
 
 flagcxDebugLogger_t flagcxUcxPluginLogFunction;
-static const ucp_tag_t tag      = 0x8a000000;
+static const ucp_tag_t tag = 0x8a000000;
 static const ucp_tag_t tagMask = (uint64_t)(-1);
-
 
 enum flagcxUCXCommState {
   flagcxUCXCommStateStart = 0,
@@ -299,39 +326,43 @@ enum flagcxUCXCommState {
 struct flagcxUCXCommStage {
   enum flagcxUCXCommState state;
   uint8_t iteration;
-  void* sock;
-  void* comm;
+  void *sock;
+  void *comm;
 };
 
 typedef struct flagcxUcxMhandle {
-  ucp_mem_h  ucp_memh;
+  ucp_mem_h ucp_memh;
   ucp_rkey_h rkey;
-  int        mem_type;
+  int mem_type;
 } flagcxUcxMhandle_t;
 
-flagcxResult_t flagcxUcxDevices(int* ndev) {
+flagcxResult_t flagcxUcxDevices(int *ndev) {
   *ndev = flagcxNIbDevs;
   return flagcxSuccess;
 }
 
-static __thread int flagcxUcxDmaSupportInitDev; // which device to init, must be thread local
-static void flagcxUcxDmaBufSupportInitOnce(){
+static __thread int
+    flagcxUcxDmaSupportInitDev; // which device to init, must be thread local
+static void flagcxUcxDmaBufSupportInitOnce() {
   flagcxResult_t res;
   int dev_fail = 0;
 
   // This is a physical device, not a virtual one, so select from ibDevs
-  flagcxIbMergedDev* mergedDev = flagcxIbMergedDevs + flagcxUcxDmaSupportInitDev;
-  flagcxIbDev* ibDev = flagcxIbDevs + mergedDev->vProps.devs[0];
-  struct ibv_pd* pd;
-  struct ibv_context* ctx = ibDev->context;
+  flagcxIbMergedDev *mergedDev =
+      flagcxIbMergedDevs + flagcxUcxDmaSupportInitDev;
+  flagcxIbDev *ibDev = flagcxIbDevs + mergedDev->vProps.devs[0];
+  struct ibv_pd *pd;
+  struct ibv_context *ctx = ibDev->context;
   FLAGCXCHECKGOTO(flagcxWrapIbvAllocPd(&pd, ctx), res, failure);
   // Test kernel DMA-BUF support with a dummy call (fd=-1)
   (void)flagcxWrapDirectIbvRegMr(pd, 0ULL /*addr*/, 0ULL /*len*/, 0 /*access*/);
-  // ibv_reg_dmabuf_mr() will fail with EOPNOTSUPP/EPROTONOSUPPORT if not supported (EBADF otherwise)
+  // ibv_reg_dmabuf_mr() will fail with EOPNOTSUPP/EPROTONOSUPPORT if not
+  // supported (EBADF otherwise)
   dev_fail |= (errno == EOPNOTSUPP) || (errno == EPROTONOSUPPORT);
   FLAGCXCHECKGOTO(flagcxWrapIbvDeallocPd(pd), res, failure);
   // stop the search and goto failure
-  if (dev_fail) goto failure;
+  if (dev_fail)
+    goto failure;
   ibDev->dmaBufSupported = 1;
   return;
 failure:
@@ -342,14 +373,15 @@ flagcxResult_t flagcx_p2p_dmabuf_support(int dev) {
   // init the device only once
   flagcxUcxDmaSupportInitDev = dev;
   pthread_once(&onces[dev].once, flagcxUcxDmaBufSupportInitOnce);
-  flagcxIbMergedDev* mergedDev = flagcxIbMergedDevs + flagcxUcxDmaSupportInitDev;
-  flagcxIbDev* ibDev = flagcxIbDevs + mergedDev->vProps.devs[0];
+  flagcxIbMergedDev *mergedDev =
+      flagcxIbMergedDevs + flagcxUcxDmaSupportInitDev;
+  flagcxIbDev *ibDev = flagcxIbDevs + mergedDev->vProps.devs[0];
   int dmaBufSupported = ibDev->dmaBufSupported;
-  if (dmaBufSupported == 1) return flagcxSuccess;
+  if (dmaBufSupported == 1)
+    return flagcxSuccess;
   return flagcxSystemError;
 }
-flagcxResult_t flagcx_p2p_gdr_support()
-{
+flagcxResult_t flagcx_p2p_gdr_support() {
   static pthread_once_t once = PTHREAD_ONCE_INIT;
   pthread_once(&once, ibGdrSupportInitOnce);
   if (!flagcxIbGdrModuleLoaded)
@@ -357,15 +389,18 @@ flagcxResult_t flagcx_p2p_gdr_support()
   return flagcxSuccess;
 }
 
-flagcxResult_t flagcx_p2p_ib_init(int *nDevs, int *nmDevs, flagcxIbDev *flagcxIbDevs, char *flagcxIbIfName, union flagcxSocketAddress *flagcxIbIfAddr, pthread_t *flagcxIbAsyncThread, flagcxDebugLogger_t logFunction)
-{
-    printf("liuheliuhe \n");
+flagcxResult_t flagcx_p2p_ib_init(int *nDevs, int *nmDevs,
+                                  flagcxIbDev *flagcxIbDevs,
+                                  char *flagcxIbIfName,
+                                  union flagcxSocketAddress *flagcxIbIfAddr,
+                                  pthread_t *flagcxIbAsyncThread,
+                                  flagcxDebugLogger_t logFunction) {
   flagcxResult_t ret = flagcxSuccess;
   int flagcxNIbDevs = *nDevs;
   int flagcxNMergedIbDevs = *nmDevs;
   flagcxUcxPluginLogFunction = logFunction;
   if (flagcxNIbDevs == -1) {
-    for (int i=0; i< MAX_IB_DEVS; i++)
+    for (int i = 0; i < MAX_IB_DEVS; i++)
       onces[i].once = PTHREAD_ONCE_INIT;
     pthread_mutex_lock(&flagcx_p2p_lock);
     flagcxWrapIbvForkInit();
@@ -374,7 +409,8 @@ flagcxResult_t flagcx_p2p_ib_init(int *nDevs, int *nmDevs, flagcxIbDev *flagcxIb
       flagcxNIbDevs = 0;
       flagcxNMergedIbDevs = 0;
       flagcxNSharpDevs = 0;
-      nIpIfs = flagcxFindInterfaces(flagcxIbIfName, flagcxIbIfAddr, MAX_IF_NAME_SIZE, 1);
+      nIpIfs = flagcxFindInterfaces(flagcxIbIfName, flagcxIbIfAddr,
+                                    MAX_IF_NAME_SIZE, 1);
       if (nIpIfs != 1) {
         WARN("NET/IB : No IP interface found.");
         ret = flagcxInternalError;
@@ -383,20 +419,26 @@ flagcxResult_t flagcx_p2p_ib_init(int *nDevs, int *nmDevs, flagcxIbDev *flagcxIb
 
       // Detect IB cards
       int nIbDevs;
-      struct ibv_device** devices;
+      struct ibv_device **devices;
       // Check if user defined which IB device:port to use
-      const char* userIbEnv = flagcxGetEnv("FLAGCX_IB_HCA");
+      const char *userIbEnv = flagcxGetEnv("FLAGCX_IB_HCA");
       struct netIf userIfs[MAX_IB_DEVS];
       int searchNot = userIbEnv && userIbEnv[0] == '^';
-      if (searchNot) userIbEnv++;
+      if (searchNot)
+        userIbEnv++;
       int searchExact = userIbEnv && userIbEnv[0] == '=';
-      if (searchExact) userIbEnv++;
+      if (searchExact)
+        userIbEnv++;
       int nUserIfs = parseStringList(userIbEnv, userIfs, MAX_IB_DEVS);
 
-      if (flagcxSuccess != flagcxWrapIbvGetDeviceList(&devices, &nIbDevs)) { ret = flagcxInternalError; goto fail; }
-      for (int d=0; d<nIbDevs && flagcxNIbDevs<MAX_IB_DEVS; d++) {
-        struct ibv_context * context;
-        if (flagcxSuccess != flagcxWrapIbvOpenDevice(&context, devices[d]) || context == NULL) {
+      if (flagcxSuccess != flagcxWrapIbvGetDeviceList(&devices, &nIbDevs)) {
+        ret = flagcxInternalError;
+        goto fail;
+      }
+      for (int d = 0; d < nIbDevs && flagcxNIbDevs < MAX_IB_DEVS; d++) {
+        struct ibv_context *context;
+        if (flagcxSuccess != flagcxWrapIbvOpenDevice(&context, devices[d]) ||
+            context == NULL) {
           WARN("NET/IB : Unable to open device %s", devices[d]->name);
           continue;
         }
@@ -408,23 +450,32 @@ flagcxResult_t flagcx_p2p_ib_init(int *nDevs, int *nmDevs, flagcxIbDev *flagcxIb
         struct ibv_device_attr devAttr;
         if (flagcxSuccess != flagcxWrapIbvQueryDevice(context, &devAttr)) {
           WARN("NET/IB : Unable to query device %s", devices[d]->name);
-          if (flagcxSuccess != flagcxWrapIbvCloseDevice(context)) { ret = flagcxInternalError; goto fail; }
+          if (flagcxSuccess != flagcxWrapIbvCloseDevice(context)) {
+            ret = flagcxInternalError;
+            goto fail;
+          }
           continue;
         }
         for (int port_num = 1; port_num <= devAttr.phys_port_cnt; port_num++) {
-          for (int dataDirect = skipNetDevForDataDirect; dataDirect < 1 + dataDirectSupported; ++dataDirect) {
+          for (int dataDirect = skipNetDevForDataDirect;
+               dataDirect < 1 + dataDirectSupported; ++dataDirect) {
             struct ibv_port_attr portAttr;
             uint32_t portSpeed;
-            if (flagcxSuccess != flagcxWrapIbvQueryPort(context, port_num, &portAttr)) {
+            if (flagcxSuccess !=
+                flagcxWrapIbvQueryPort(context, port_num, &portAttr)) {
               WARN("NET/IB : Unable to query port_num %d", port_num);
               continue;
             }
-            if (portAttr.state != IBV_PORT_ACTIVE) continue;
-            if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND
-                && portAttr.link_layer != IBV_LINK_LAYER_ETHERNET) continue;
+            if (portAttr.state != IBV_PORT_ACTIVE)
+              continue;
+            if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND &&
+                portAttr.link_layer != IBV_LINK_LAYER_ETHERNET)
+              continue;
 
             // check against user specified HCAs/ports
-            if (! (matchIfList(devices[d]->name, port_num, userIfs, nUserIfs, searchExact) ^ searchNot)) {
+            if (!(matchIfList(devices[d]->name, port_num, userIfs, nUserIfs,
+                              searchExact) ^
+                  searchNot)) {
               continue;
             }
             pthread_mutex_init(&flagcxIbDevs[flagcxNIbDevs].lock, NULL);
@@ -434,23 +485,33 @@ flagcxResult_t flagcx_p2p_ib_init(int *nDevs, int *nmDevs, flagcxIbDev *flagcxIb
             flagcxIbDevs[flagcxNIbDevs].portAttr = portAttr;
             flagcxIbDevs[flagcxNIbDevs].portNum = port_num;
             flagcxIbDevs[flagcxNIbDevs].link = portAttr.link_layer;
-            #if HAVE_STRUCT_IBV_PORT_ATTR_ACTIVE_SPEED_EX
-            portSpeed = portAttr.active_speed_ex ? portAttr.active_speed_ex : portAttr.active_speed;
-            #else
+#if HAVE_STRUCT_IBV_PORT_ATTR_ACTIVE_SPEED_EX
+            portSpeed = portAttr.active_speed_ex ? portAttr.active_speed_ex
+                                                 : portAttr.active_speed;
+#else
             portSpeed = portAttr.active_speed;
-            #endif
-            flagcxIbDevs[flagcxNIbDevs].speed = flagcx_p2p_ib_speed(portSpeed) * flagcx_p2p_ib_width(portAttr.active_width);
+#endif
+            flagcxIbDevs[flagcxNIbDevs].speed =
+                flagcx_p2p_ib_speed(portSpeed) *
+                flagcx_p2p_ib_width(portAttr.active_width);
             flagcxIbDevs[flagcxNIbDevs].context = context;
             flagcxIbDevs[flagcxNIbDevs].pdRefs = 0;
             flagcxIbDevs[flagcxNIbDevs].pd = NULL;
             if (!dataDirect) {
-              strncpy(flagcxIbDevs[flagcxNIbDevs].devName, devices[d]->name, MAXNAMESIZE);
-              FLAGCXCHECKGOTO(flagcx_p2p_ib_pci_path(flagcxIbDevs, flagcxNIbDevs, flagcxIbDevs[flagcxNIbDevs].devName, &flagcxIbDevs[flagcxNIbDevs].pciPath, &flagcxIbDevs[flagcxNIbDevs].realPort), ret, fail);
+              strncpy(flagcxIbDevs[flagcxNIbDevs].devName, devices[d]->name,
+                      MAXNAMESIZE);
+              FLAGCXCHECKGOTO(
+                  flagcx_p2p_ib_pci_path(flagcxIbDevs, flagcxNIbDevs,
+                                         flagcxIbDevs[flagcxNIbDevs].devName,
+                                         &flagcxIbDevs[flagcxNIbDevs].pciPath,
+                                         &flagcxIbDevs[flagcxNIbDevs].realPort),
+                  ret, fail);
             } else {
-              snprintf(flagcxIbDevs[flagcxNIbDevs].devName, MAXNAMESIZE, "%.*s_dma", 
-                       (int)(MAXNAMESIZE - 5), devices[d]->name);
-              flagcxIbDevs[flagcxNIbDevs].pciPath = (char*)malloc(PATH_MAX);
-              strncpy(flagcxIbDevs[flagcxNIbDevs].pciPath, dataDirectDevicePath, PATH_MAX);
+              snprintf(flagcxIbDevs[flagcxNIbDevs].devName, MAXNAMESIZE,
+                       "%.*s_dma", (int)(MAXNAMESIZE - 5), devices[d]->name);
+              flagcxIbDevs[flagcxNIbDevs].pciPath = (char *)malloc(PATH_MAX);
+              strncpy(flagcxIbDevs[flagcxNIbDevs].pciPath, dataDirectDevicePath,
+                      PATH_MAX);
               flagcxIbDevs[flagcxNIbDevs].capsProvider.mlx5.dataDirect = 1;
             }
             flagcxIbDevs[flagcxNIbDevs].maxQp = devAttr.max_qp;
@@ -459,24 +520,39 @@ flagcxResult_t flagcx_p2p_ib_init(int *nDevs, int *nmDevs, flagcxIbDev *flagcxIb
             flagcxIbDevs[flagcxNIbDevs].mrCache.slots = NULL;
             FLAGCXCHECK(flagcxIbStatsInit(&flagcxIbDevs[flagcxNIbDevs].stats));
 
-          // Enable ADAPTIVE_ROUTING by default on IB networks
+            // Enable ADAPTIVE_ROUTING by default on IB networks
             // But allow it to be overloaded by an env parameter
-            flagcxIbDevs[flagcxNIbDevs].ar = (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) ? 1 : 0;
-            if (flagcxParamIbAdaptiveRouting() != -2) flagcxIbDevs[flagcxNIbDevs].ar = flagcxParamIbAdaptiveRouting();
+            flagcxIbDevs[flagcxNIbDevs].ar =
+                (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) ? 1 : 0;
+            if (flagcxParamIbAdaptiveRouting() != -2)
+              flagcxIbDevs[flagcxNIbDevs].ar = flagcxParamIbAdaptiveRouting();
 
             flagcxIbDevs[flagcxNIbDevs].isSharpDev = 0;
-            if (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND)
-            {
+            if (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) {
               flagcxIbDevs[flagcxNIbDevs].isSharpDev = 1;
               flagcxIbDevs[flagcxNIbDevs].maxQp = flagcxParamSharpMaxComms();
               flagcxNSharpDevs++;
             }
-            TRACE(FLAGCX_NET,"NET/IB: [%d] %s:%s:%d/%s provider=%s speed=%d context=%p pciPath=%s ar=%d", d, devices[d]->name, devices[d]->dev_name, flagcxIbDevs[flagcxNIbDevs].portNum,
-              FLAGCX_IB_LLSTR(portAttr.link_layer), ibProviderName[flagcxIbDevs[flagcxNIbDevs].ibProvider], flagcxIbDevs[flagcxNIbDevs].speed, context, flagcxIbDevs[flagcxNIbDevs].pciPath, flagcxIbDevs[flagcxNIbDevs].ar);
+            TRACE(FLAGCX_NET,
+                  "NET/IB: [%d] %s:%s:%d/%s provider=%s speed=%d context=%p "
+                  "pciPath=%s ar=%d",
+                  d, devices[d]->name, devices[d]->dev_name,
+                  flagcxIbDevs[flagcxNIbDevs].portNum,
+                  FLAGCX_IB_LLSTR(portAttr.link_layer),
+                  ibProviderName[flagcxIbDevs[flagcxNIbDevs].ibProvider],
+                  flagcxIbDevs[flagcxNIbDevs].speed, context,
+                  flagcxIbDevs[flagcxNIbDevs].pciPath,
+                  flagcxIbDevs[flagcxNIbDevs].ar);
             if (flagcxIbAsyncThread != NULL) {
-              PTHREADCHECKGOTO(pthread_create(flagcxIbAsyncThread, NULL, flagcxIbAsyncThreadMain, flagcxIbDevs + flagcxNIbDevs), "pthread_create", ret, fail);
-              flagcxSetThreadName(*flagcxIbAsyncThread, "flagcx IbAsync %2d", flagcxNIbDevs);
-              PTHREADCHECKGOTO(pthread_detach(*flagcxIbAsyncThread), "pthread_detach", ret, fail); // will not be pthread_join()'d
+              PTHREADCHECKGOTO(pthread_create(flagcxIbAsyncThread, NULL,
+                                              flagcxIbAsyncThreadMain,
+                                              flagcxIbDevs + flagcxNIbDevs),
+                               "pthread_create", ret, fail);
+              flagcxSetThreadName(*flagcxIbAsyncThread, "flagcx IbAsync %2d",
+                                  flagcxNIbDevs);
+              PTHREADCHECKGOTO(pthread_detach(*flagcxIbAsyncThread),
+                               "pthread_detach", ret,
+                               fail); // will not be pthread_join()'d
             }
 
             // Add this plain physical device to the list of virtual devices
@@ -484,19 +560,26 @@ flagcxResult_t flagcx_p2p_ib_init(int *nDevs, int *nmDevs, flagcxIbDev *flagcxIb
             flagcxNetVDeviceProps_t vProps = {0};
             vProps.ndevs = 1;
             vProps.devs[0] = flagcxNIbDevs;
-            FLAGCXCHECK(flagcxIbMakeVDeviceInternal(&vDev, &vProps, flagcxNIbDevs, &flagcxNMergedIbDevs));
+            FLAGCXCHECK(flagcxIbMakeVDeviceInternal(
+                &vDev, &vProps, flagcxNIbDevs, &flagcxNMergedIbDevs));
 
             flagcxNIbDevs++;
             nPorts++;
           }
         }
-        if (nPorts == 0 && flagcxSuccess != flagcxWrapIbvCloseDevice(context))  { ret = flagcxInternalError; goto fail; }
+        if (nPorts == 0 && flagcxSuccess != flagcxWrapIbvCloseDevice(context)) {
+          ret = flagcxInternalError;
+          goto fail;
+        }
       }
-      
-      if (nIbDevs && (flagcxSuccess != flagcxWrapIbvFreeDeviceList(devices))) { ret = flagcxInternalError; goto fail; };
+
+      if (nIbDevs && (flagcxSuccess != flagcxWrapIbvFreeDeviceList(devices))) {
+        ret = flagcxInternalError;
+        goto fail;
+      };
     }
     if (flagcxNIbDevs == 0) {
-      INFO(FLAGCX_INIT|FLAGCX_NET, "NET/IB : No device found.");
+      INFO(FLAGCX_INIT | FLAGCX_NET, "NET/IB : No device found.");
     }
 
     // Print out all net devices to the user (in the same format as before)
@@ -508,23 +591,25 @@ flagcxResult_t flagcx_p2p_ib_init(int *nDevs, int *nmDevs, flagcxIbDev *flagcxIb
 #endif
     for (int d = 0; d < flagcxNIbDevs; d++) {
 #ifdef HAVE_SHARP_PLUGIN
-            snprintf(line+strlen(line), sizeof(line)-strlen(line), " [%d]%s:%d/%s%s", d, flagcxIbDevs[d].devName,
-              flagcxIbDevs[d].portNum, FLAGCX_IB_LLSTR(flagcxIbDevs[d].link),
-              flagcxIbDevs[d].isSharpDev ? "/SHARP" : "");
+      snprintf(line + strlen(line), sizeof(line) - strlen(line),
+               " [%d]%s:%d/%s%s", d, flagcxIbDevs[d].devName,
+               flagcxIbDevs[d].portNum, FLAGCX_IB_LLSTR(flagcxIbDevs[d].link),
+               flagcxIbDevs[d].isSharpDev ? "/SHARP" : "");
 #else
-      snprintf(line+strlen(line), sizeof(line)-strlen(line), " [%d]%s:%d/%s", d, flagcxIbDevs[d].devName,
-        flagcxIbDevs[d].portNum, FLAGCX_IB_LLSTR(flagcxIbDevs[d].link));
+      snprintf(line + strlen(line), sizeof(line) - strlen(line),
+               " [%d]%s:%d/%s", d, flagcxIbDevs[d].devName,
+               flagcxIbDevs[d].portNum, FLAGCX_IB_LLSTR(flagcxIbDevs[d].link));
 #endif
     }
-    char addrline[SOCKET_NAME_MAXLEN+1];
-    INFO(FLAGCX_INIT|FLAGCX_NET, "NET/IB : Using%s %s; OOB %s:%s", line, 
+    char addrline[SOCKET_NAME_MAXLEN + 1];
+    INFO(FLAGCX_INIT | FLAGCX_NET, "NET/IB : Using%s %s; OOB %s:%s", line,
 #ifdef HAVE_IB_PLUGIN
-      flagcxIbRelaxedOrderingEnabled ? "[RO]" : ""
+         flagcxIbRelaxedOrderingEnabled ? "[RO]" : ""
 #else
-      ""
+         ""
 #endif
-      ,
-      flagcxIbIfName, flagcxSocketToString(flagcxIbIfAddr, addrline, 1));
+         ,
+         flagcxIbIfName, flagcxSocketToString(flagcxIbIfAddr, addrline, 1));
     *nDevs = flagcxNIbDevs;
     *nmDevs = flagcxNMergedIbDevs;
     pthread_mutex_unlock(&flagcx_p2p_lock);
@@ -535,25 +620,29 @@ fail:
   pthread_mutex_unlock(&flagcx_p2p_lock);
   goto exit;
 }
-flagcxResult_t flagcxIbGetPhysProperties(int dev, flagcxNetProperties_v8_t* props) {
-  struct flagcxIbDev* ibDev = flagcxIbDevs + dev;
+flagcxResult_t flagcxIbGetPhysProperties(int dev,
+                                         flagcxNetProperties_v8_t *props) {
+  struct flagcxIbDev *ibDev = flagcxIbDevs + dev;
   pthread_mutex_lock(&ibDev->lock);
   props->name = ibDev->devName;
   props->speed = ibDev->speed;
   props->pciPath = ibDev->pciPath;
   props->guid = ibDev->guid;
-  props->ptrSupport   = FLAGCX_PTR_HOST;
+  props->ptrSupport = FLAGCX_PTR_HOST;
   if (flagcx_p2p_gdr_support() == flagcxSuccess) {
     props->ptrSupport |= FLAGCX_PTR_CUDA; // GDR support via nv_peermem
-    INFO(FLAGCX_NET,"NET/IB : GPU Direct RDMA (nvidia-peermem) enabled for HCA %d '%s", dev, ibDev->devName);
+    INFO(FLAGCX_NET,
+         "NET/IB : GPU Direct RDMA (nvidia-peermem) enabled for HCA %d '%s",
+         dev, ibDev->devName);
   }
   props->regIsGlobal = 1;
   if (flagcx_p2p_dmabuf_support(dev) == flagcxSuccess) {
     props->ptrSupport |= FLAGCX_PTR_DMABUF; // GDR support via DMA-BUF
-    INFO(FLAGCX_NET,"NET/IB : GPU Direct RDMA (DMABUF) enabled for HCA %d '%s", dev, ibDev->devName);
+    INFO(FLAGCX_NET, "NET/IB : GPU Direct RDMA (DMABUF) enabled for HCA %d '%s",
+         dev, ibDev->devName);
   }
 
-  props->latency      = 0; // Not set
+  props->latency = 0; // Not set
   props->port = ibDev->portNum + ibDev->realPort;
   props->maxComms = ibDev->maxQp;
   props->maxRecvs = FLAGCX_NET_IB_MAX_RECVS;
@@ -562,25 +651,29 @@ flagcxResult_t flagcxIbGetPhysProperties(int dev, flagcxNetProperties_v8_t* prop
   pthread_mutex_unlock(&ibDev->lock);
   return flagcxSuccess;
 }
-flagcxResult_t flagcx_p2p_ib_get_properties(flagcxIbDev *devs, int flagcxNMergedIbDevs, int dev, flagcxNetProperties_v8_t* props)
-{
+flagcxResult_t flagcx_p2p_ib_get_properties(flagcxIbDev *devs,
+                                            int flagcxNMergedIbDevs, int dev,
+                                            flagcxNetProperties_v8_t *props) {
   if (dev >= flagcxNMergedIbDevs) {
-    WARN("NET/IB : Requested properties for vNic %d, only %d vNics have been created", dev, flagcxNMergedIbDevs);
+    WARN("NET/IB : Requested properties for vNic %d, only %d vNics have been "
+         "created",
+         dev, flagcxNMergedIbDevs);
     return flagcxInvalidUsage;
   }
-  struct flagcxIbMergedDev* mergedDev = flagcxIbMergedDevs + dev;
-  // Take the rest of the properties from an arbitrary sub-device (should be the same)
+  struct flagcxIbMergedDev *mergedDev = flagcxIbMergedDevs + dev;
+  // Take the rest of the properties from an arbitrary sub-device (should be the
+  // same)
   FLAGCXCHECK(flagcxIbGetPhysProperties(mergedDev->vProps.devs[0], props));
   props->name = mergedDev->devName;
   props->speed = mergedDev->speed;
-//   memcpy(&props->vProps, &mergedDev->vProps, sizeof(flagcxNetVDeviceProps_v8_t));
+  //   memcpy(&props->vProps, &mergedDev->vProps,
+  //   sizeof(flagcxNetVDeviceProps_v8_t));
   return flagcxSuccess;
 }
-flagcxResult_t flagcxUcxGetProperties(int dev, void* props)
-{
-  return flagcx_p2p_ib_get_properties(flagcxIbDevs, flagcxNMergedIbDevs, dev, (flagcxNetProperties_v8_t*)props);
+flagcxResult_t flagcxUcxGetProperties(int dev, void *props) {
+  return flagcx_p2p_ib_get_properties(flagcxIbDevs, flagcxNMergedIbDevs, dev,
+                                      (flagcxNetProperties_v8_t *)props);
 }
-
 
 pthread_mutex_t flagcxUcxLock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -593,13 +686,14 @@ struct flagcxUcxEpList {
  * Connection descriptor. Used to store all opened connections.
  */
 typedef struct ucx_worker {
-  ucp_worker_h   worker;   /* ucp worker associated with ctx */
-  ucp_context_h  ctx;      /* ucp_context bounded to specific device */
-  struct flagcxUcxEpList *eps;     /* oob conection to all endpoints that were opened on this worker */
+  ucp_worker_h worker; /* ucp worker associated with ctx */
+  ucp_context_h ctx;   /* ucp_context bounded to specific device */
+  struct flagcxUcxEpList
+      *eps; /* oob conection to all endpoints that were opened on this worker */
 
-  int            count;    /* number of connections that uses this worker */
-  int            dev;      /* Managed device */
-  pthread_t      thread;   /* Owner thread */
+  int count;        /* number of connections that uses this worker */
+  int dev;          /* Managed device */
+  pthread_t thread; /* Owner thread */
 
   struct ucx_worker *next;
 } ucx_worker_t;
@@ -609,9 +703,9 @@ typedef struct ucx_worker {
  */
 typedef struct flagcxUcxListenHandle {
   union flagcxSocketAddress connectAddr; /* reciever socket address */
-  uint64_t magic;                      /* random number to help debugging */
-  ucp_tag_t               tag;         /* tag that is used to distiguish data that was sent to
-                                          this reciever. Required when shared worker is used. */
+  uint64_t magic;                        /* random number to help debugging */
+  ucp_tag_t tag; /* tag that is used to distiguish data that was sent to
+                    this reciever. Required when shared worker is used. */
   struct flagcxUCXCommStage stage;
 } flagcxUcxListenHandle_t;
 
@@ -619,14 +713,14 @@ typedef struct flagcxUcxListenHandle {
  * Listen commincator for UCX plugin.
  */
 typedef struct flagcxUcxListenComm {
-  int           dev;    /* device number in flagcxIbDevs which will
-                         * be used to recieve data */
-  struct flagcxSocket sock;/* socket for OOB connection */
-  ucp_context_h ctx;    /* ucp_context associated with specific device dev */
-  ucx_worker_t *ucx_worker; /* ucx_worker created on ctx, worker can be shared between
-                           multiple connections */
-  ucp_tag_t     tag;    /* tag that is used to distiguish data that was sent to 
-                           this reciever. Required when shared worker is used.*/
+  int dev;                  /* device number in flagcxIbDevs which will
+                             * be used to recieve data */
+  struct flagcxSocket sock; /* socket for OOB connection */
+  ucp_context_h ctx; /* ucp_context associated with specific device dev */
+  ucx_worker_t *ucx_worker; /* ucx_worker created on ctx, worker can be shared
+                           between multiple connections */
+  ucp_tag_t tag; /* tag that is used to distiguish data that was sent to
+                    this reciever. Required when shared worker is used.*/
   struct flagcxUCXCommStage stage;
 } flagcxUcxListenComm_t;
 
@@ -640,22 +734,22 @@ struct flagcxUcxComm;
  * Batch of UCX Requests from FlagCX perspective
  */
 typedef struct flagcxUcxRequest {
-  struct flagcxUcxRequest *next;    /* Next request in the free list */
-  struct flagcxUcxComm    *comm;    /* Owning communicator */
-  ucp_worker_h        worker;  /* Worker for all requests */
-  int                 pending; /* How many requests are still pending */
-  int                 count;   /* How many requests are contained */
-  int                 size[FLAGCX_NET_IB_MAX_RECVS];
+  struct flagcxUcxRequest *next; /* Next request in the free list */
+  struct flagcxUcxComm *comm;    /* Owning communicator */
+  ucp_worker_h worker;           /* Worker for all requests */
+  int pending;                   /* How many requests are still pending */
+  int count;                     /* How many requests are contained */
+  int size[FLAGCX_NET_IB_MAX_RECVS];
 } flagcxUcxRequest_t;
 
-static ucp_tag_t              flagcxUcxWorkerTags[MAX_IB_DEVS];
-static ucp_context_h          flagcxUcxCtx[MAX_IB_DEVS];
+static ucp_tag_t flagcxUcxWorkerTags[MAX_IB_DEVS];
+static ucp_context_h flagcxUcxCtx[MAX_IB_DEVS];
 static struct ucx_worker *flagcxUcxWorkers[MAX_IB_DEVS];
 static int ucx_workerCount = 0;
 
 typedef struct flagcxUcxGpuFlush {
-  int      enabled;
-  int      hostMem;
+  int enabled;
+  int hostMem;
   ucp_ep_h flush_ep;
 } flagcxUcxGpuFlush_t;
 
@@ -664,7 +758,7 @@ typedef struct flagcxUcxGpuFlush {
  * Used to map/unmap memory in flagcxUcxRegMr/flagcxUcxDeregMr
  */
 typedef struct flagcxUcxCtx {
-  ucp_context_h   flagcxUcxCtx;
+  ucp_context_h flagcxUcxCtx;
   flagcxUcxGpuFlush_t gpuFlush;
 } flagcxUcxCtx_t;
 
@@ -672,25 +766,25 @@ typedef struct flagcxUcxCtx {
  * Sender and Receiver communicator
  */
 typedef struct flagcxUcxComm {
-  ucp_context_h   ctx;           /* ucp_context bounded to specific device */
-  flagcxUcxGpuFlush_t gpuFlush;      /* flushing handle */
-  ucx_worker_t *ucx_worker; /* ucp worker associated with ctx */
-  ucp_ep_h        ep;            /* ucp endpoint created on worker */
-  ucp_tag_t       tag;           /* datapath tag to filter out message that are not
-                                    belong to this connnection */
-  ucp_tag_t       ctag;          /* controlpath tag to filter out message that are not
-                                    belong to this connnection */
-  struct flagcxSocket sock;        /* socket for OOB connection */
-  int             ready;         /* indicates that receive communicator is fully initialized */
-  flagcxUcxRequest_t   reqs[MAX_REQUESTS]; /* max inflight requests */
-  flagcxUcxRequest_t   *free_req;     /* first request available */
-  flagcxUcxConnectMsg_t   *msg;          /* message to establish reverse connection */
-  void            *connect_req;  /* msg request */
+  ucp_context_h ctx;            /* ucp_context bounded to specific device */
+  flagcxUcxGpuFlush_t gpuFlush; /* flushing handle */
+  ucx_worker_t *ucx_worker;     /* ucp worker associated with ctx */
+  ucp_ep_h ep;                  /* ucp endpoint created on worker */
+  ucp_tag_t tag;  /* datapath tag to filter out message that are not
+                     belong to this connnection */
+  ucp_tag_t ctag; /* controlpath tag to filter out message that are not
+                     belong to this connnection */
+  struct flagcxSocket sock; /* socket for OOB connection */
+  int ready; /* indicates that receive communicator is fully initialized */
+  flagcxUcxRequest_t reqs[MAX_REQUESTS]; /* max inflight requests */
+  flagcxUcxRequest_t *free_req;          /* first request available */
+  flagcxUcxConnectMsg_t *msg; /* message to establish reverse connection */
+  void *connect_req;          /* msg request */
 } flagcxUcxComm_t;
 
 static void send_handler_nbx(void *request, ucs_status_t status,
                              void *user_data) {
-  int *pending = (int*)user_data;
+  int *pending = (int *)user_data;
 
   assert(status == UCS_OK);
   assert(*pending > 0);
@@ -729,7 +823,8 @@ static flagcxResult_t flagcxUcxConfigNoCuda(ucp_config_t *config) {
     flagcxUcxTls = tmp;
   } else {
     /* Positive expression cannot allow cuda-like transports */
-    if ((strstr(flagcxUcxTls, "cuda") != NULL) || (strstr(flagcxUcxTls, "gdr") != NULL)) {
+    if ((strstr(flagcxUcxTls, "cuda") != NULL) ||
+        (strstr(flagcxUcxTls, "gdr") != NULL)) {
       WARN("Cannot use cuda/gdr transports as part of specified UCX_TLS");
       return flagcxInternalError;
     }
@@ -746,12 +841,13 @@ static flagcxResult_t flagcxUcxConfigNoCuda(ucp_config_t *config) {
 static flagcxResult_t flagcxUcxInitContext(ucp_context_h *ctx, int dev) {
   ucp_params_t ucp_params;
   ucp_config_t *config;
-  char         flagcxUcxDevName[PATH_MAX];
+  char flagcxUcxDevName[PATH_MAX];
   flagcxResult_t result;
 
   if (flagcxUcxCtx[dev] == NULL) {
     plugin_get_device_name(flagcxIbDevs[dev].devName, flagcxUcxDevName, 64);
-    snprintf(flagcxUcxDevName + strlen(flagcxUcxDevName), PATH_MAX - strlen(flagcxUcxDevName), ":%d",
+    snprintf(flagcxUcxDevName + strlen(flagcxUcxDevName),
+             PATH_MAX - strlen(flagcxUcxDevName), ":%d",
              flagcxIbDevs[dev].portNum);
 
     UCXCHECK(ucp_config_read("FLAGCX", NULL, &config));
@@ -766,7 +862,7 @@ static flagcxResult_t flagcxUcxInitContext(ucp_context_h *ctx, int dev) {
 
     memset(&ucp_params, 0, sizeof(ucp_params));
     ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES;
-    ucp_params.features   = UCP_FEATURE_TAG | UCP_FEATURE_RMA;
+    ucp_params.features = UCP_FEATURE_TAG | UCP_FEATURE_RMA;
 
     UCXCHECK(ucp_init(&ucp_params, config, &flagcxUcxCtx[dev]));
     ucp_config_release(config);
@@ -777,12 +873,13 @@ static flagcxResult_t flagcxUcxInitContext(ucp_context_h *ctx, int dev) {
   return flagcxSuccess;
 }
 
-static flagcxResult_t flagcxUcxInitWorker(ucp_context_h ctx, ucp_worker_h *worker) {
+static flagcxResult_t flagcxUcxInitWorker(ucp_context_h ctx,
+                                          ucp_worker_h *worker) {
   ucp_worker_params_t worker_params;
-  ucp_worker_attr_t   worker_attr;
+  ucp_worker_attr_t worker_attr;
 
   memset(&worker_params, 0, sizeof(worker_params));
-  worker_params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
+  worker_params.field_mask = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
   worker_params.thread_mode = UCS_THREAD_MODE_MULTI;
 
   UCXCHECK(ucp_worker_create(ctx, &worker_params, worker));
@@ -797,16 +894,16 @@ static flagcxResult_t flagcxUcxInitWorker(ucp_context_h ctx, ucp_worker_h *worke
 }
 
 static flagcxResult_t flagcxUcxWorkerGetNetaddress(ucp_worker_h worker,
-                                              ucp_address_t **address,
-                                              size_t *address_length) {
+                                                   ucp_address_t **address,
+                                                   size_t *address_length) {
   ucp_worker_attr_t attr;
 
-  attr.field_mask    = UCP_WORKER_ATTR_FIELD_ADDRESS |
-                       UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS;
+  attr.field_mask =
+      UCP_WORKER_ATTR_FIELD_ADDRESS | UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS;
   attr.address_flags = UCP_WORKER_ADDRESS_FLAG_NET_ONLY;
 
   UCXCHECK(ucp_worker_query(worker, &attr));
-  *address = (ucp_address_t*)malloc(attr.address_length);
+  *address = (ucp_address_t *)malloc(attr.address_length);
   if (address == NULL) {
     return flagcxSystemError;
   }
@@ -819,8 +916,8 @@ static flagcxResult_t flagcxUcxWorkerGetNetaddress(ucp_worker_h worker,
 }
 
 static flagcxResult_t flagcxUcxGetCtxAndWorker(int dev, ucp_context_h *ctx,
-                                           ucx_worker_t **ucx_worker,
-                                           ucp_tag_t *newtag) {
+                                               ucx_worker_t **ucx_worker,
+                                               ucp_tag_t *newtag) {
   pthread_mutex_lock(&flagcxUcxLock);
   flagcxResult_t result;
 
@@ -838,19 +935,19 @@ static flagcxResult_t flagcxUcxGetCtxAndWorker(int dev, ucp_context_h *ctx,
   }
 
   if (w == NULL) {
-    w = (ucx_worker_t*)calloc(1, sizeof(*w));
+    w = (ucx_worker_t *)calloc(1, sizeof(*w));
     if (w == NULL) {
       WARN("Worker allocation failure");
       goto err;
     }
 
-    w->dev    = dev;
+    w->dev = dev;
     w->thread = pthread_self();
-    w->count  = 0;
+    w->count = 0;
 
     result = flagcxUcxInitContext(&w->ctx, dev);
     if (result != flagcxSuccess) {
-        return result;
+      return result;
     }
     flagcxUcxInitWorker(w->ctx, &w->worker);
     ucx_workerCount++;
@@ -859,7 +956,7 @@ static flagcxResult_t flagcxUcxGetCtxAndWorker(int dev, ucp_context_h *ctx,
     flagcxUcxWorkers[dev] = w;
   }
 
-  *ctx        = w->ctx;
+  *ctx = w->ctx;
   *ucx_worker = w;
   if (newtag != NULL) {
     *newtag = ++flagcxUcxWorkerTags[dev];
@@ -884,8 +981,8 @@ static flagcxResult_t flagcxUcxFreeWorker(ucx_worker_t *ucx_worker) {
   pthread_mutex_lock(&flagcxUcxLock);
   ucx_worker->count--;
   if (ucx_worker->count == 0) {
-      ucx_workerCount--;
-      done = ucx_workerCount == 0;
+    ucx_workerCount--;
+    done = ucx_workerCount == 0;
   }
   pthread_mutex_unlock(&flagcxUcxLock);
 
@@ -893,14 +990,16 @@ static flagcxResult_t flagcxUcxFreeWorker(ucx_worker_t *ucx_worker) {
     return flagcxSuccess;
   }
 
-  for (dev = 0; dev < sizeof(flagcxUcxWorkers) / sizeof(*flagcxUcxWorkers); dev++) {
-    for (ucx_worker = flagcxUcxWorkers[dev]; ucx_worker != NULL; ucx_worker = next) {
+  for (dev = 0; dev < sizeof(flagcxUcxWorkers) / sizeof(*flagcxUcxWorkers);
+       dev++) {
+    for (ucx_worker = flagcxUcxWorkers[dev]; ucx_worker != NULL;
+         ucx_worker = next) {
       next = ucx_worker->next;
       assert(ucx_worker->count == 0);
 
       ep = ucx_worker->eps;
       while (ep) {
-        cur    = ep;
+        cur = ep;
         result = flagcxSocketRecv(ep->sock, &dummy, sizeof(int));
         if (result != flagcxSuccess) {
           WARN("Failed to receive close for worker cleanup (res:%d)", result);
@@ -925,25 +1024,27 @@ static flagcxResult_t flagcxUcxFreeWorker(ucx_worker_t *ucx_worker) {
 }
 
 static flagcxResult_t flagcxUcxAddEp(ucx_worker_t *ucx_worker,
-                                    struct flagcxSocket *sock) {
-  struct flagcxUcxEpList *new_ep = (struct flagcxUcxEpList*)malloc(sizeof(struct flagcxUcxEpList));
+                                     struct flagcxSocket *sock) {
+  struct flagcxUcxEpList *new_ep =
+      (struct flagcxUcxEpList *)malloc(sizeof(struct flagcxUcxEpList));
   if (new_ep == NULL) {
     return flagcxSystemError;
   }
 
-  new_ep->sock    = sock;
-  new_ep->next    = ucx_worker->eps;
+  new_ep->sock = sock;
+  new_ep->next = ucx_worker->eps;
   ucx_worker->eps = new_ep;
   return flagcxSuccess;
 }
 
-
-
 flagcxResult_t flagcxUcxInit() {
-  if (flagcxUcxRefCount++) return flagcxSuccess;
-  if (flagcxParamUCXDisable()) return flagcxInternalError;
+  if (flagcxUcxRefCount++)
+    return flagcxSuccess;
+  if (flagcxParamUCXDisable())
+    return flagcxInternalError;
 
-  for (int i = 0; i < sizeof(flagcxUcxWorkerTags) / sizeof(*flagcxUcxWorkerTags); i++) {
+  for (int i = 0;
+       i < sizeof(flagcxUcxWorkerTags) / sizeof(*flagcxUcxWorkerTags); i++) {
     flagcxUcxWorkerTags[i] = tag;
   }
 
@@ -953,26 +1054,30 @@ flagcxResult_t flagcxUcxInit() {
     return flagcxInternalError;
   }
 
-  return flagcx_p2p_ib_init(&flagcxNIbDevs, &flagcxNMergedIbDevs, flagcxIbDevs, if_name,
-                          &flagcxUcxIfAddr, NULL, NULL);
+  return flagcx_p2p_ib_init(&flagcxNIbDevs, &flagcxNMergedIbDevs, flagcxIbDevs,
+                            if_name, &flagcxUcxIfAddr, NULL, NULL);
 }
 
 flagcxResult_t flagcxUcxListen(int dev, void *handle, void **listen_comm) {
-  flagcxUcxListenHandle_t *my_handle = (flagcxUcxListenHandle_t*)handle;
-  flagcxUcxListenComm_t   *comm      = (flagcxUcxListenComm_t*)calloc(1, sizeof(*comm));
+  flagcxUcxListenHandle_t *my_handle = (flagcxUcxListenHandle_t *)handle;
+  flagcxUcxListenComm_t *comm =
+      (flagcxUcxListenComm_t *)calloc(1, sizeof(*comm));
 
-  FLAGCX_STATIC_ASSERT(sizeof(flagcxUcxListenHandle_t) < FLAGCX_NET_HANDLE_MAXSIZE,
-                     "UCX listen handle size too large");
+  FLAGCX_STATIC_ASSERT(sizeof(flagcxUcxListenHandle_t) <
+                           FLAGCX_NET_HANDLE_MAXSIZE,
+                       "UCX listen handle size too large");
   my_handle->magic = FLAGCX_SOCKET_MAGIC;
-  FLAGCXCHECK(flagcxSocketInit(&comm->sock, &flagcxUcxIfAddr, my_handle->magic, flagcxSocketTypeNetIb, NULL, 1));
+  FLAGCXCHECK(flagcxSocketInit(&comm->sock, &flagcxUcxIfAddr, my_handle->magic,
+                               flagcxSocketTypeNetIb, NULL, 1));
   FLAGCXCHECK(flagcxSocketListen(&comm->sock));
   FLAGCXCHECK(flagcxSocketGetAddr(&comm->sock, &my_handle->connectAddr));
-  FLAGCXCHECK(flagcxUcxGetCtxAndWorker(dev, &comm->ctx, &comm->ucx_worker, &comm->tag));
+  FLAGCXCHECK(
+      flagcxUcxGetCtxAndWorker(dev, &comm->ctx, &comm->ucx_worker, &comm->tag));
 
   comm->dev = dev;
   my_handle->tag = comm->tag;
   *listen_comm = comm;
- 
+
   return flagcxSuccess;
 }
 
@@ -981,40 +1086,47 @@ static void flagcxUcxRequestInit(flagcxUcxComm_t *comm) {
 
   comm->free_req = NULL;
   for (int i = entries - 1; i >= 0; i--) {
-      comm->reqs[i].comm = comm;
-      comm->reqs[i].next = comm->free_req;
-      comm->free_req = &comm->reqs[i];
+    comm->reqs[i].comm = comm;
+    comm->reqs[i].next = comm->free_req;
+    comm->free_req = &comm->reqs[i];
   }
 }
 
 flagcxResult_t flagcxUcxConnect(int dev, void *handle, void **send_comm) {
-  flagcxUcxListenHandle_t     *recv_handle = (flagcxUcxListenHandle_t*)handle;
-  struct flagcxUCXCommStage *stage       = &recv_handle->stage;
-  flagcxUcxComm_t              *comm        = (flagcxUcxComm_t*)stage->comm;
-  ucp_address_t           *my_addr;
-  size_t                  local_addr_len;
-  int                     ready;
+  flagcxUcxListenHandle_t *recv_handle = (flagcxUcxListenHandle_t *)handle;
+  struct flagcxUCXCommStage *stage = &recv_handle->stage;
+  flagcxUcxComm_t *comm = (flagcxUcxComm_t *)stage->comm;
+  ucp_address_t *my_addr;
+  size_t local_addr_len;
+  int ready;
 
   *send_comm = NULL;
 
-  if (stage->state == flagcxUCXCommStateConnect) goto flagcxUcxConnectCheck;
+  if (stage->state == flagcxUCXCommStateConnect)
+    goto flagcxUcxConnectCheck;
 
-  FLAGCXCHECK(flagcxIbMalloc((void**)&comm, sizeof(flagcxUcxComm_t)));
-  FLAGCXCHECK(flagcxSocketInit(&comm->sock, &recv_handle->connectAddr, recv_handle->magic, flagcxSocketTypeNetIb, NULL, 1));
+  FLAGCXCHECK(flagcxIbMalloc((void **)&comm, sizeof(flagcxUcxComm_t)));
+  FLAGCXCHECK(flagcxSocketInit(&comm->sock, &recv_handle->connectAddr,
+                               recv_handle->magic, flagcxSocketTypeNetIb, NULL,
+                               1));
   stage->comm = comm;
   stage->state = flagcxUCXCommStateConnect;
   FLAGCXCHECK(flagcxSocketConnect(&comm->sock));
   flagcxUcxRequestInit(comm);
 
 flagcxUcxConnectCheck:
-  /* since flagcxSocketConnect is async, we must check if connection is complete */
+  /* since flagcxSocketConnect is async, we must check if connection is complete
+   */
   FLAGCXCHECK(flagcxSocketReady(&comm->sock, &ready));
-  if (!ready) return flagcxSuccess;
+  if (!ready)
+    return flagcxSuccess;
 
-  FLAGCXCHECK(flagcxUcxGetCtxAndWorker(dev, &comm->ctx, &comm->ucx_worker, &comm->ctag));
-  comm->tag              = recv_handle->tag;
+  FLAGCXCHECK(flagcxUcxGetCtxAndWorker(dev, &comm->ctx, &comm->ucx_worker,
+                                       &comm->ctag));
+  comm->tag = recv_handle->tag;
   comm->gpuFlush.enabled = 0;
-  FLAGCXCHECK(flagcxUcxWorkerGetNetaddress(comm->ucx_worker->worker, &my_addr, &local_addr_len));
+  FLAGCXCHECK(flagcxUcxWorkerGetNetaddress(comm->ucx_worker->worker, &my_addr,
+                                           &local_addr_len));
   FLAGCXCHECK(flagcxUcxAddEp(comm->ucx_worker, &comm->sock));
   TRACE(FLAGCX_NET, "NET/UCX: Worker address length: %zu", local_addr_len);
 
@@ -1027,58 +1139,63 @@ flagcxUcxConnectCheck:
   return flagcxSuccess;
 }
 
-flagcxResult_t flagcxUcxAccept(void *listen_comm, void **recv_comm)
-{
-  flagcxUcxListenComm_t  *l_comm = (flagcxUcxListenComm_t *)listen_comm;
-  struct flagcxUCXCommStage* stage = &l_comm->stage;
-  flagcxUcxComm_t         *r_comm = (flagcxUcxComm_t *)stage->comm;
-  size_t             peer_addr_len;
-  ucp_address_t      *peer_addr;
-  ucp_ep_params_t    ep_params;
-  int                ready;
+flagcxResult_t flagcxUcxAccept(void *listen_comm, void **recv_comm) {
+  flagcxUcxListenComm_t *l_comm = (flagcxUcxListenComm_t *)listen_comm;
+  struct flagcxUCXCommStage *stage = &l_comm->stage;
+  flagcxUcxComm_t *r_comm = (flagcxUcxComm_t *)stage->comm;
+  size_t peer_addr_len;
+  ucp_address_t *peer_addr;
+  ucp_ep_params_t ep_params;
+  int ready;
 
   *recv_comm = NULL;
-  if (stage->state == flagcxUCXCommStateAccept) goto flagcxUcxAcceptCheck;
+  if (stage->state == flagcxUCXCommStateAccept)
+    goto flagcxUcxAcceptCheck;
 
-  FLAGCXCHECK(flagcxIbMalloc((void**)&r_comm, sizeof(flagcxUcxComm_t)));
+  FLAGCXCHECK(flagcxIbMalloc((void **)&r_comm, sizeof(flagcxUcxComm_t)));
   stage->comm = r_comm;
   stage->state = flagcxUCXCommStateAccept;
   l_comm->sock.asyncFlag = 1;
   r_comm->sock.asyncFlag = 1;
 
-  FLAGCXCHECK(flagcxSocketInit(&r_comm->sock, NULL, FLAGCX_SOCKET_MAGIC, flagcxSocketTypeUnknown, NULL, 0));
+  FLAGCXCHECK(flagcxSocketInit(&r_comm->sock, NULL, FLAGCX_SOCKET_MAGIC,
+                               flagcxSocketTypeUnknown, NULL, 0));
   FLAGCXCHECK(flagcxSocketAccept(&r_comm->sock, &l_comm->sock));
 flagcxUcxAcceptCheck:
   FLAGCXCHECK(flagcxSocketReady(&r_comm->sock, &ready));
-  if (!ready) return flagcxSuccess;
+  if (!ready)
+    return flagcxSuccess;
 
-  r_comm->ctx        = l_comm->ctx;
+  r_comm->ctx = l_comm->ctx;
   r_comm->ucx_worker = l_comm->ucx_worker;
-  r_comm->tag        = l_comm->tag;
+  r_comm->tag = l_comm->tag;
 
   flagcxUcxRequestInit(r_comm);
 
   FLAGCXCHECK(flagcxSocketRecv(&r_comm->sock, &peer_addr_len, sizeof(size_t)));
-  peer_addr = (ucp_address_t*)malloc(peer_addr_len);
+  peer_addr = (ucp_address_t *)malloc(peer_addr_len);
   if (peer_addr == NULL) {
     return flagcxSystemError;
   }
 
   FLAGCXCHECK(flagcxSocketRecv(&r_comm->sock, peer_addr, peer_addr_len));
   ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
-  ep_params.address    = peer_addr;
+  ep_params.address = peer_addr;
   UCXCHECK(ucp_ep_create(r_comm->ucx_worker->worker, &ep_params, &r_comm->ep));
-  FLAGCXCHECK(flagcxSocketRecv(&r_comm->sock, &r_comm->ctag, sizeof(ucp_tag_t)));
+  FLAGCXCHECK(
+      flagcxSocketRecv(&r_comm->sock, &r_comm->ctag, sizeof(ucp_tag_t)));
 
-  r_comm->gpuFlush.enabled = (flagcx_p2p_gdr_support() == flagcxSuccess);  
+  r_comm->gpuFlush.enabled = (flagcx_p2p_gdr_support() == flagcxSuccess);
   if (r_comm->gpuFlush.enabled) {
     ucp_address_t *my_addr;
-    size_t        local_addr_len;
+    size_t local_addr_len;
 
-    FLAGCXCHECK(flagcxUcxWorkerGetNetaddress(r_comm->ucx_worker->worker, &my_addr, &local_addr_len));
+    FLAGCXCHECK(flagcxUcxWorkerGetNetaddress(r_comm->ucx_worker->worker,
+                                             &my_addr, &local_addr_len));
     ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
-    ep_params.address    = my_addr;
-    UCXCHECK(ucp_ep_create(r_comm->ucx_worker->worker, &ep_params, &r_comm->gpuFlush.flush_ep));
+    ep_params.address = my_addr;
+    UCXCHECK(ucp_ep_create(r_comm->ucx_worker->worker, &ep_params,
+                           &r_comm->gpuFlush.flush_ep));
     free(my_addr);
   }
 
@@ -1089,45 +1206,48 @@ flagcxUcxAcceptCheck:
 }
 
 #define REG_ALIGN (4096)
-flagcxResult_t flagcxUcxRegMr(void* comm, void* data, size_t size, int type, void** mhandle) {
-  flagcxUcxCtx_t *ctx = (flagcxUcxCtx_t*)comm;
-  uint64_t  addr = (uint64_t)  data;
+flagcxResult_t flagcxUcxRegMr(void *comm, void *data, size_t size, int type,
+                              void **mhandle) {
+  flagcxUcxCtx_t *ctx = (flagcxUcxCtx_t *)comm;
+  uint64_t addr = (uint64_t)data;
   ucp_mem_map_params_t mmap_params;
-  flagcxUcxMhandle_t        *mh;
-  uint64_t             reg_addr, reg_size;
-  size_t               rkey_buf_size;
-  void                 *rkey_buf;
-  
-  FLAGCXCHECK(flagcxIbMalloc((void**)&mh, sizeof(flagcxUcxMhandle_t)));
+  flagcxUcxMhandle_t *mh;
+  uint64_t reg_addr, reg_size;
+  size_t rkey_buf_size;
+  void *rkey_buf;
+
+  FLAGCXCHECK(flagcxIbMalloc((void **)&mh, sizeof(flagcxUcxMhandle_t)));
   reg_addr = addr & (~(REG_ALIGN - 1));
   reg_size = addr + size - reg_addr;
   reg_size = ROUNDUP(reg_size, REG_ALIGN);
 
-  mmap_params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
-                           UCP_MEM_MAP_PARAM_FIELD_LENGTH; 
-  mmap_params.address    = (void*)reg_addr;
-  mmap_params.length     = reg_size;  
-  mh->mem_type = (type == FLAGCX_PTR_HOST)? UCS_MEMORY_TYPE_HOST: UCS_MEMORY_TYPE_CUDA;
-  mmap_params.field_mask  |= UCP_MEM_MAP_PARAM_FIELD_MEMORY_TYPE; 
+  mmap_params.field_mask =
+      UCP_MEM_MAP_PARAM_FIELD_ADDRESS | UCP_MEM_MAP_PARAM_FIELD_LENGTH;
+  mmap_params.address = (void *)reg_addr;
+  mmap_params.length = reg_size;
+  mh->mem_type =
+      (type == FLAGCX_PTR_HOST) ? UCS_MEMORY_TYPE_HOST : UCS_MEMORY_TYPE_CUDA;
+  mmap_params.field_mask |= UCP_MEM_MAP_PARAM_FIELD_MEMORY_TYPE;
   mmap_params.memory_type = (ucs_memory_type_t)mh->mem_type;
 
   UCXCHECK(ucp_mem_map(ctx->flagcxUcxCtx, &mmap_params, &mh->ucp_memh));
   if (ctx->gpuFlush.enabled) {
-    UCXCHECK(ucp_rkey_pack(ctx->flagcxUcxCtx, mh->ucp_memh, &rkey_buf, &rkey_buf_size));
+    UCXCHECK(ucp_rkey_pack(ctx->flagcxUcxCtx, mh->ucp_memh, &rkey_buf,
+                           &rkey_buf_size));
     UCXCHECK(ucp_ep_rkey_unpack(ctx->gpuFlush.flush_ep, rkey_buf, &mh->rkey));
     ucp_rkey_buffer_release(rkey_buf);
   }
-  
+
   *mhandle = mh;
   return flagcxSuccess;
 }
 
-flagcxResult_t flagcxUcxDeregMr(void* comm, void* mhandle) {
-  flagcxUcxCtx_t     *ctx = (flagcxUcxCtx_t*)comm;
-  flagcxUcxMhandle_t *mh  = (flagcxUcxMhandle_t*)mhandle;
+flagcxResult_t flagcxUcxDeregMr(void *comm, void *mhandle) {
+  flagcxUcxCtx_t *ctx = (flagcxUcxCtx_t *)comm;
+  flagcxUcxMhandle_t *mh = (flagcxUcxMhandle_t *)mhandle;
 
   if (ctx->gpuFlush.enabled) {
-      ucp_rkey_destroy(mh->rkey);
+    ucp_rkey_destroy(mh->rkey);
   }
 
   ucp_mem_unmap(ctx->flagcxUcxCtx, mh->ucp_memh);
@@ -1136,8 +1256,10 @@ flagcxResult_t flagcxUcxDeregMr(void* comm, void* mhandle) {
   return flagcxSuccess;
 }
 
-flagcxResult_t flagcxUcxRegMrDmaBuf(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle) {
-	return flagcxUcxRegMr(comm, data, size, type, mhandle);
+flagcxResult_t flagcxUcxRegMrDmaBuf(void *comm, void *data, size_t size,
+                                    int type, uint64_t offset, int fd,
+                                    void **mhandle) {
+  return flagcxUcxRegMr(comm, data, size, type, mhandle);
 }
 
 static flagcxUcxRequest_t *flagcxUcxRequestGet(flagcxUcxComm_t *comm) {
@@ -1149,15 +1271,15 @@ static flagcxUcxRequest_t *flagcxUcxRequestGet(flagcxUcxComm_t *comm) {
   }
 
   comm->free_req = req->next;
-  req->worker  = comm->ucx_worker->worker;
+  req->worker = comm->ucx_worker->worker;
   req->pending = 0;
-  req->count   = 0;
+  req->count = 0;
   return req;
 }
 
 static void flagcxUcxRequestRelease(flagcxUcxRequest_t *req) {
-    req->next = req->comm->free_req;
-    req->comm->free_req = req;
+  req->next = req->comm->free_req;
+  req->comm->free_req = req;
 }
 
 static void flagcxUcxRequestAdd(flagcxUcxRequest_t *req, int size) {
@@ -1168,11 +1290,11 @@ static void flagcxUcxRequestAdd(flagcxUcxRequest_t *req, int size) {
 
 static flagcxResult_t flagcxUcxSendCheck(flagcxUcxComm_t *comm) {
   ucp_request_param_t params;
-  ucp_tag_message_h   msg_tag;
+  ucp_tag_message_h msg_tag;
   ucp_tag_recv_info_t info_tag;
-  ucp_ep_params_t     ep_params;
-  void                *ucp_req;
-  ucs_status_t        status;
+  ucp_ep_params_t ep_params;
+  void *ucp_req;
+  ucs_status_t status;
 
   ucp_worker_progress(comm->ucx_worker->worker);
 
@@ -1186,7 +1308,7 @@ static flagcxResult_t flagcxUcxSendCheck(flagcxUcxComm_t *comm) {
     return flagcxSuccess;
   }
 
-  comm->msg = (flagcxUcxConnectMsg_t*)malloc(info_tag.length);
+  comm->msg = (flagcxUcxConnectMsg_t *)malloc(info_tag.length);
   if (comm->msg == NULL) {
     return flagcxSystemError;
   }
@@ -1225,7 +1347,7 @@ out_check_status:
 
 out_set_ready:
   ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
-  ep_params.address    = (ucp_address_t*)(comm->msg + 1);
+  ep_params.address = (ucp_address_t *)(comm->msg + 1);
   UCXCHECK(ucp_ep_create(comm->ucx_worker->worker, &ep_params, &comm->ep));
   comm->ready = 1;
   free(comm->msg);
@@ -1236,43 +1358,43 @@ out_set_ready:
 
 static void flagcxUcxRecvSetReady(flagcxUcxComm_t *comm) {
   free(comm->msg);
-  comm->msg   = NULL;
+  comm->msg = NULL;
   comm->ready = 1;
 }
 
 static void check_handler(void *request, ucs_status_t status, void *user_data) {
   assert(status == UCS_OK);
-  flagcxUcxRecvSetReady((flagcxUcxComm_t*)user_data);
+  flagcxUcxRecvSetReady((flagcxUcxComm_t *)user_data);
   ucp_request_free(request);
 }
 
 flagcxResult_t flagcxUcxRecvCheck(flagcxUcxComm_t *comm) {
   ucp_request_param_t params;
-  ucp_address_t       *my_addr;
-  size_t              local_addr_len;
-  size_t              msg_len;
+  ucp_address_t *my_addr;
+  size_t local_addr_len;
+  size_t msg_len;
 
   if (comm->connect_req != NULL) {
     goto done;
   }
 
   FLAGCXCHECK(flagcxUcxWorkerGetNetaddress(comm->ucx_worker->worker, &my_addr,
-                                      &local_addr_len));
+                                           &local_addr_len));
   flagcxUcxAddEp(comm->ucx_worker, &comm->sock);
 
-  msg_len             = sizeof(flagcxUcxConnectMsg_t) + local_addr_len;
-  comm->msg           = (flagcxUcxConnectMsg_t*)calloc(1, msg_len);
+  msg_len = sizeof(flagcxUcxConnectMsg_t) + local_addr_len;
+  comm->msg = (flagcxUcxConnectMsg_t *)calloc(1, msg_len);
   comm->msg->addr_len = local_addr_len;
   memcpy(comm->msg + 1, my_addr, local_addr_len);
 
-  params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
-                        UCP_OP_ATTR_FIELD_USER_DATA;
-  params.cb.send      = check_handler;
-  params.user_data    = comm;
+  params.op_attr_mask =
+      UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_USER_DATA;
+  params.cb.send = check_handler;
+  params.user_data = comm;
 
   assert(comm->connect_req == NULL);
-  comm->connect_req   = ucp_tag_send_nbx(comm->ep, comm->msg, msg_len,
-                                         comm->ctag, &params);
+  comm->connect_req =
+      ucp_tag_send_nbx(comm->ep, comm->msg, msg_len, comm->ctag, &params);
   if (UCS_PTR_IS_ERR(comm->connect_req)) {
     WARN("Unable to send connect message");
     free(comm->msg);
@@ -1287,20 +1409,18 @@ done:
   return flagcxSuccess;
 }
 
-static ucp_tag_t flagcxUcxUcpTag(ucp_tag_t comm_tag, uint64_t tag)
-{
+static ucp_tag_t flagcxUcxUcpTag(ucp_tag_t comm_tag, uint64_t tag) {
   assert(tag <= UINT32_MAX);
   assert(comm_tag <= UINT32_MAX);
   return comm_tag + (tag << 32);
 }
 
-flagcxResult_t flagcxUcxIsend(void *send_comm, void *data, size_t size,
-                                   int tag, void *mhandle, void* phandle, void **request)
-{
-  flagcxUcxComm_t         *comm = (flagcxUcxComm_t *)send_comm;
-  flagcxUcxMhandle_t      *mh   = (flagcxUcxMhandle_t*)mhandle;
-  flagcxUcxRequest_t      *req;
-  void               *ucp_req;
+flagcxResult_t flagcxUcxIsend(void *send_comm, void *data, size_t size, int tag,
+                              void *mhandle, void *phandle, void **request) {
+  flagcxUcxComm_t *comm = (flagcxUcxComm_t *)send_comm;
+  flagcxUcxMhandle_t *mh = (flagcxUcxMhandle_t *)mhandle;
+  flagcxUcxRequest_t *req;
+  void *ucp_req;
   ucp_request_param_t params;
 
   if (comm->ready == 0) {
@@ -1318,15 +1438,14 @@ flagcxResult_t flagcxUcxIsend(void *send_comm, void *data, size_t size,
 
   flagcxUcxRequestAdd(req, size);
 
-  params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
-                        UCP_OP_ATTR_FIELD_USER_DATA;
-  params.cb.send      = send_handler_nbx;
-  params.user_data    = &req->pending;
+  params.op_attr_mask =
+      UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_USER_DATA;
+  params.cb.send = send_handler_nbx;
+  params.user_data = &req->pending;
   if (mh) {
     params.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMH;
-    params.memh          = mh->ucp_memh;
+    params.memh = mh->ucp_memh;
   }
-
 
   ucp_req = ucp_tag_send_nbx(comm->ep, data, size,
                              flagcxUcxUcpTag(comm->tag, tag), &params);
@@ -1343,13 +1462,12 @@ flagcxResult_t flagcxUcxIsend(void *send_comm, void *data, size_t size,
 }
 
 flagcxResult_t flagcxUcxIrecv(void *recv_comm, int n, void **data,
-                                   size_t *sizes, int *tags, void **mhandle,
-                                   void** phandles, void **request)
-{
-  flagcxUcxComm_t         *comm = (flagcxUcxComm_t*)recv_comm;
-  flagcxUcxMhandle_t      **mh  = (flagcxUcxMhandle_t**)mhandle;
-  void               *ucp_req;
-  flagcxUcxRequest_t      *req;
+                              size_t *sizes, int *tags, void **mhandle,
+                              void **phandles, void **request) {
+  flagcxUcxComm_t *comm = (flagcxUcxComm_t *)recv_comm;
+  flagcxUcxMhandle_t **mh = (flagcxUcxMhandle_t **)mhandle;
+  void *ucp_req;
+  flagcxUcxRequest_t *req;
   ucp_request_param_t params;
 
   if (comm->ready == 0) {
@@ -1370,24 +1488,24 @@ flagcxResult_t flagcxUcxIrecv(void *recv_comm, int n, void **data,
     return flagcxInternalError;
   }
 
-  params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
-                        UCP_OP_ATTR_FIELD_USER_DATA;
-  params.cb.recv      = recv_handler_nbx;
-  params.user_data    = &req->pending;
+  params.op_attr_mask =
+      UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_USER_DATA;
+  params.cb.recv = recv_handler_nbx;
+  params.user_data = &req->pending;
 
   for (int i = 0; i < n; i++) {
     flagcxUcxRequestAdd(req, sizes[i]);
 
     if (mh[i]) {
       params.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMH;
-      params.memh          = mh[i]->ucp_memh;
+      params.memh = mh[i]->ucp_memh;
     } else {
       params.op_attr_mask &= ~UCP_OP_ATTR_FIELD_MEMH;
     }
 
-    ucp_req = ucp_tag_recv_nbx(comm->ucx_worker->worker, data[i], sizes[i],
-                               flagcxUcxUcpTag(comm->tag, tags[i]), tagMask,
-                               &params);
+    ucp_req =
+        ucp_tag_recv_nbx(comm->ucx_worker->worker, data[i], sizes[i],
+                         flagcxUcxUcpTag(comm->tag, tags[i]), tagMask, &params);
     if (UCS_PTR_IS_ERR(ucp_req)) {
       WARN("ucx_irecv: unable to post receive %d/%d (%s)", i, n,
            ucs_status_string(UCS_PTR_STATUS(ucp_req)));
@@ -1402,18 +1520,21 @@ flagcxResult_t flagcxUcxIrecv(void *recv_comm, int n, void **data,
 }
 
 flagcxResult_t flagcxUcxIflush(void *recv_comm, int n, void **data, int *sizes,
-                             void **mhandle, void **request) {
-  int last            = -1;
-  int size            = 1;
-  flagcxUcxComm_t    *comm = (flagcxUcxComm_t *)recv_comm;
-  flagcxUcxMhandle_t **mh  = (flagcxUcxMhandle_t**)mhandle;
+                               void **mhandle, void **request) {
+  int last = -1;
+  int size = 1;
+  flagcxUcxComm_t *comm = (flagcxUcxComm_t *)recv_comm;
+  flagcxUcxMhandle_t **mh = (flagcxUcxMhandle_t **)mhandle;
   flagcxUcxRequest_t *req;
   void *ucp_req;
   ucp_request_param_t params;
 
   *request = NULL;
-  for (int i=0; i<n; i++) if (sizes[i]) last = i;
-  if (comm->gpuFlush.enabled == 0 || last == -1) return flagcxSuccess;
+  for (int i = 0; i < n; i++)
+    if (sizes[i])
+      last = i;
+  if (comm->gpuFlush.enabled == 0 || last == -1)
+    return flagcxSuccess;
 
   req = flagcxUcxRequestGet(comm);
   if (req == NULL) {
@@ -1422,10 +1543,10 @@ flagcxResult_t flagcxUcxIflush(void *recv_comm, int n, void **data, int *sizes,
 
   flagcxUcxRequestAdd(req, size);
 
-  params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
-                        UCP_OP_ATTR_FIELD_USER_DATA;
-  params.cb.send      = send_handler_nbx;
-  params.user_data    = &req->pending;
+  params.op_attr_mask =
+      UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_USER_DATA;
+  params.cb.send = send_handler_nbx;
+  params.user_data = &req->pending;
   ucp_req = ucp_get_nbx(comm->gpuFlush.flush_ep, &comm->gpuFlush.hostMem, size,
                         (uint64_t)data[last], mh[last]->rkey, &params);
   if (UCS_PTR_IS_ERR(ucp_req)) {
@@ -1441,7 +1562,7 @@ flagcxResult_t flagcxUcxIflush(void *recv_comm, int n, void **data, int *sizes,
 }
 
 flagcxResult_t flagcxUcxTest(void *request, int *done, int *size) {
-  flagcxUcxRequest_t *req = (flagcxUcxRequest_t*)request;
+  flagcxUcxRequest_t *req = (flagcxUcxRequest_t *)request;
   unsigned p;
 
   while (req->pending > 0) {
@@ -1469,7 +1590,7 @@ static void wait_close(ucp_worker_h worker, void *ucp_req) {
     do {
       ucp_worker_progress(worker);
       status = ucp_request_check_status(ucp_req);
-    } while(status == UCS_INPROGRESS);
+    } while (status == UCS_INPROGRESS);
     ucp_request_free(ucp_req);
   } else if (ucp_req != NULL) {
     WARN("Failed to close UCX endpoint");
@@ -1477,7 +1598,7 @@ static void wait_close(ucp_worker_h worker, void *ucp_req) {
 }
 
 flagcxResult_t flagcxUcxCloseSend(void *send_comm) {
-  flagcxUcxComm_t *comm = (flagcxUcxComm_t*)send_comm;
+  flagcxUcxComm_t *comm = (flagcxUcxComm_t *)send_comm;
   void *close_req;
 
   if (comm) {
@@ -1495,18 +1616,19 @@ flagcxResult_t flagcxUcxCloseSend(void *send_comm) {
 }
 
 flagcxResult_t flagcxUcxCloseRecv(void *recv_comm) {
-  flagcxUcxComm_t *comm = (flagcxUcxComm_t*)recv_comm;
+  flagcxUcxComm_t *comm = (flagcxUcxComm_t *)recv_comm;
   void *close_req;
 
   if (comm) {
     if (comm->gpuFlush.enabled) {
-      close_req = ucp_ep_close_nb(comm->gpuFlush.flush_ep, UCP_EP_CLOSE_MODE_FLUSH);
+      close_req =
+          ucp_ep_close_nb(comm->gpuFlush.flush_ep, UCP_EP_CLOSE_MODE_FLUSH);
       wait_close(comm->ucx_worker->worker, close_req);
     }
     if (comm->ep) {
       close_req = ucp_ep_close_nb(comm->ep, UCP_EP_CLOSE_MODE_FLUSH);
       wait_close(comm->ucx_worker->worker, close_req);
-      int close=1;
+      int close = 1;
       FLAGCXCHECK(flagcxSocketSend(&comm->sock, &close, sizeof(int)));
     }
     flagcxUcxFreeWorker(comm->ucx_worker);
@@ -1523,11 +1645,11 @@ flagcxResult_t flagcxUcxCloseListen(void *listen_comm) {
     close(comm->sock.fd);
     free(comm);
   }
-  
+
   return flagcxSuccess;
 }
 
-flagcxResult_t flagcxUcxFinalize(void* ctx) {
+flagcxResult_t flagcxUcxFinalize(void *ctx) {
   flagcxUcxRefCount--;
   return flagcxSuccess;
 }
@@ -1552,23 +1674,23 @@ struct flagcxNetAdaptor flagcxNetUcx = {
     NULL, // irecvConsumed
 
     // Setup functions
-    flagcxUcxListen, // listen
-    flagcxUcxConnect, // connect
-    flagcxUcxAccept, // accept
-    flagcxUcxCloseSend, // closeSend
-    flagcxUcxCloseRecv, // closeRecv
+    flagcxUcxListen,      // listen
+    flagcxUcxConnect,     // connect
+    flagcxUcxAccept,      // accept
+    flagcxUcxCloseSend,   // closeSend
+    flagcxUcxCloseRecv,   // closeRecv
     flagcxUcxCloseListen, // closeListen
 
     // Memory region functions
-    flagcxUcxRegMr, // regMr
+    flagcxUcxRegMr,       // regMr
     flagcxUcxRegMrDmaBuf, // regMrDmaBuf
-    flagcxUcxDeregMr, // deregMr
+    flagcxUcxDeregMr,     // deregMr
 
     // Two-sided functions
-    flagcxUcxIsend, // isend
-    flagcxUcxIrecv, // irecv
+    flagcxUcxIsend,  // isend
+    flagcxUcxIrecv,  // irecv
     flagcxUcxIflush, // iflush
-    flagcxUcxTest, // test
+    flagcxUcxTest,   // test
 
     // One-sided functions
     NULL, // write - TODO: Implement
@@ -1576,7 +1698,7 @@ struct flagcxNetAdaptor flagcxNetUcx = {
     NULL, // signal - TODO: Implement
 
     // Device name lookup
-    flagcxUcxGetDevFromName  // getDevFromName
+    flagcxUcxGetDevFromName // getDevFromName
 };
 
 #endif // USE_UCX

--- a/flagcx/adaptor/net/ucx_adaptor.cc
+++ b/flagcx/adaptor/net/ucx_adaptor.cc
@@ -1,0 +1,1582 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+ * Copyright (c) 2016-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifdef USE_UCX
+
+#include "adaptor.h"
+#include "comm.h"
+#include "core.h"
+#include "net.h"
+#include "param.h"
+#include "socket.h"
+#include "utils.h"
+#include "flagcx.h"
+#include "debug.h"
+#include "ibvwrap.h"
+#include "ib_common.h"
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <ucp/api/ucp.h>
+
+// Additional macro definitions
+#define MAX_REQUESTS 16
+// Parameter function declarations (now in ib_common.h)
+
+// Type definitions
+// Structures now defined in ib_common.h
+#define PTHREADCHECKGOTO(statement, name, RES, label) do { \
+  int retval = (statement); \
+  if (retval != 0) { \
+    WARN("Call to " name " failed: %s", strerror(retval)); \
+    RES = flagcxSystemError; \
+    goto label; \
+  } \
+} while (0)
+// Enums and constants (now defined in ib_common.h)
+
+#define FLAGCX_IB_LLSTR(link_layer) ((link_layer) == IBV_LINK_LAYER_INFINIBAND ? "IB" : "ETH")
+#define FLAGCX_NET_IB_MAX_RECVS 16
+#define FLAGCX_STATIC_ASSERT(condition, message) static_assert(condition, message)
+#define FLAGCX_NET_HANDLE_MAXSIZE 128
+FLAGCX_PARAM(SharpMaxComms, "SHARP_MAX_COMMS", 1);
+// Global variables (now defined in ib_common.h)
+
+// Additional global variables
+static int flagcxNIbDevs = -1;
+static int flagcxNMergedIbDevs = -1;
+static int flagcxNSharpDevs = 0;
+static pthread_mutex_t flagcx_p2p_lock = PTHREAD_MUTEX_INITIALIZER;
+static int flagcxIbGdrModuleLoaded = 0;
+static struct {
+  pthread_once_t once;
+} onces[MAX_IB_DEVS];
+
+flagcxResult_t flagcxIbMakeVDeviceInternal(int* d, flagcxNetVDeviceProps_t* props, int flagcxNIbDevs, int *flagcxNMergedIbDevs) {
+  if ((flagcxParamIbMergeNics() == 0) && props->ndevs > 1) {
+    INFO(FLAGCX_NET, "NET/IB : Skipping makeVDevice, flagcx_IB_MERGE_NICS=0");
+    return flagcxInvalidUsage;
+  }
+
+  if (props->ndevs == 0) {
+   WARN("NET/IB : Can't make virtual NIC with 0 devices");
+   return flagcxInvalidUsage;
+  }
+
+  if (*flagcxNMergedIbDevs == MAX_IB_DEVS) {
+    WARN("NET/IB : Cannot allocate any more virtual devices (%d)", MAX_IB_DEVS);
+    return flagcxInvalidUsage;
+  }
+
+  // Always count up number of merged devices
+  flagcxIbMergedDev* mDev = flagcxIbMergedDevs + *flagcxNMergedIbDevs;
+  mDev->vProps.ndevs = 0;
+  mDev->speed = 0;
+
+  for (int i = 0; i < props->ndevs; i++) {
+    flagcxIbDev* dev = flagcxIbDevs + props->devs[i];
+    if (mDev->vProps.ndevs == 2) return flagcxInvalidUsage; // FLAGCX_IB_MAX_DEVS_PER_NIC
+    mDev->vProps.devs[mDev->vProps.ndevs++] = props->devs[i];
+    mDev->speed += dev->speed;
+    // Each successive time, copy the name '+' new name
+    if (mDev->vProps.ndevs > 1) {
+      snprintf(mDev->devName + strlen(mDev->devName), sizeof(mDev->devName) - strlen(mDev->devName), "+%s", dev->devName);
+    // First time, copy the plain name
+    } else {
+      strncpy(mDev->devName, dev->devName, MAXNAMESIZE);
+     }
+   }
+
+  // Check link layers
+  flagcxIbDev* dev0 = flagcxIbDevs + props->devs[0];
+  for (int i = 1; i < props->ndevs; i++) {
+    if (props->devs[i] >= flagcxNIbDevs) {
+      WARN("NET/IB : Cannot use physical device %d, max %d", props->devs[i], flagcxNIbDevs);
+      return flagcxInvalidUsage;
+    }
+    flagcxIbDev* dev = flagcxIbDevs + props->devs[i];
+    if (dev->link != dev0->link) {
+      WARN("NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using flagcx_IB_HCA",
+        props->devs[0], dev0->devName, dev0->portNum, "IB", props->devs[i], dev->devName, dev->portNum, "IB"); 
+      return flagcxInvalidUsage;
+    }
+  }
+
+  *d = *flagcxNMergedIbDevs;
+  (*flagcxNMergedIbDevs)++;
+
+  INFO(FLAGCX_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, mDev->devName, mDev->speed, mDev->vProps.ndevs);
+  return flagcxSuccess;
+}
+static int flagcxIbMatchVfPath(char* path1, char* path2) {
+  // Merge multi-port NICs into the same PCI device
+  if (flagcxParamIbMergeVfs()) {
+    return strncmp(path1, path2, strlen(path1)-4) == 0;
+  } else {
+    return strncmp(path1, path2, strlen(path1)-1) == 0;
+  }
+}
+static void flagcxIbStatsFatalError(struct flagcxIbStats* stat){
+  __atomic_fetch_add(&stat->fatalErrorCount, 1, __ATOMIC_RELAXED);
+}
+static void flagcxIbQpFatalError(struct ibv_qp* qp) {
+  flagcxIbStatsFatalError((struct flagcxIbStats*)qp->qp_context);
+}
+static void flagcxIbCqFatalError(struct ibv_cq* cq) {
+  flagcxIbStatsFatalError((struct flagcxIbStats*)cq->cq_context);
+}
+static void flagcxIbDevFatalError(struct flagcxIbDev* dev) {
+  flagcxIbStatsFatalError(&dev->stats);
+}
+#define KNL_MODULE_LOADED(a) ((access(a, F_OK) == -1) ? 0 : 1)
+static void ibGdrSupportInitOnce() {
+  // Check for the nv_peer_mem module being loaded
+  flagcxIbGdrModuleLoaded = KNL_MODULE_LOADED("/sys/kernel/mm/memory_peers/nv_mem/version") ||
+                          KNL_MODULE_LOADED("/sys/kernel/mm/memory_peers/nv_mem_nc/version") ||
+                          KNL_MODULE_LOADED("/sys/module/nvidia_peermem/version");
+}
+
+/* for data direct nic, the device name is ends with suffix '_dma`.
+ * remove this suffix before passing name to libsharp */
+ void plugin_get_device_name(const char *input, char *output, size_t output_size) {
+  const char *suffix = "_dma";
+  size_t input_len = strlen(input);
+  size_t suffix_len = strlen(suffix);
+
+  if (input_len >= suffix_len && strcmp(input + input_len - suffix_len, suffix) == 0) {
+    size_t new_len = input_len - suffix_len;
+    if (new_len >= output_size) {
+      new_len = output_size - 1;
+    }
+    memcpy(output, input, new_len);
+    output[new_len] = '\0';
+  } else {
+    strncpy(output, input, output_size - 1);
+    output[output_size - 1] = '\0';
+  }
+}
+// Missing arrays and constants
+static int ibv_widths[] = {1, 2, 4, 8, 12};
+static int ibv_speeds[] = {2500, 5000, 10000, 14000, 25000, 50000, 100000, 200000};
+
+// Helper function
+static int first_bit_set(int value, int max_bits) {
+  for (int i = 0; i <= max_bits; i++) {
+    if (value & (1 << i)) return i;
+  }
+  return max_bits;
+}
+
+// Function implementations from ucx_adaptor.cc
+int flagcx_p2p_ib_width(int width)
+{
+  return ibv_widths[first_bit_set(width, sizeof(ibv_widths)/sizeof(int)-1)];
+}
+
+int flagcx_p2p_ib_speed(int speed)
+{
+  return ibv_speeds[first_bit_set(speed, sizeof(ibv_speeds)/sizeof(int)-1)];
+}
+
+flagcxResult_t flagcxIbStatsInit(struct flagcxIbStats* stat) {
+  __atomic_store_n(&stat->fatalErrorCount, 0, __ATOMIC_RELAXED);
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcx_p2p_ib_pci_path(flagcxIbDev *devs, int num_devs, char* dev_name, char** path, int* real_port)
+{
+  char device_path[PATH_MAX];
+  snprintf(device_path, PATH_MAX, "/sys/class/infiniband/%s/device", dev_name);
+  char* p = realpath(device_path, NULL);
+  if (p == NULL) {
+    WARN("Could not find real path of %s", device_path);
+  } else {
+    // Merge multi-port NICs into the same PCI device
+    p[strlen(p)-1] = '0';
+    // Also merge virtual functions (VF) into the same device
+    if (flagcxParamIbMergeVfs()) p[strlen(p)-3] = p[strlen(p)-4] = '0';
+    // Keep the real port aside (the ibv port is always 1 on recent cards)
+    *real_port = 0;
+    for (int d=0; d<num_devs; d++) {
+      if (flagcxIbMatchVfPath(p, flagcxIbDevs[d].pciPath)) (*real_port)++;
+    }
+    *path = p;
+  }
+  return flagcxSuccess;
+}
+
+static void* flagcxIbAsyncThreadMain(void* args) {
+  struct flagcxIbDev* dev = (struct flagcxIbDev*)args;
+  while (1) {
+    struct ibv_async_event event;
+    if (flagcxSuccess != flagcxWrapIbvGetAsyncEvent(dev->context, &event)) { break; }
+    char *str;
+    struct ibv_cq* cq __attribute__((unused)) = event.element.cq;    // only valid if CQ error
+    struct ibv_qp* qp __attribute__((unused)) = event.element.qp;    // only valid if QP error
+    struct ibv_srq* srq __attribute__((unused)) = event.element.srq; // only valid if SRQ error
+    if (flagcxSuccess != flagcxWrapIbvEventTypeStr(&str, event.event_type)) { break; }
+    switch (event.event_type) {
+    case IBV_EVENT_DEVICE_FATAL:
+      // the above is device fatal error
+      WARN("NET/IB : %s:%d async fatal event: %s", dev->devName, dev->portNum, str);
+      flagcxIbDevFatalError(dev);
+      break;
+    case IBV_EVENT_PORT_ACTIVE:
+    case IBV_EVENT_PORT_ERR:
+      WARN("NET/IB : %s:%d port event: %s", dev->devName, dev->portNum, str);
+      break;
+    case IBV_EVENT_CQ_ERR:
+      WARN("NET/IB : %s:%d CQ event: %s", dev->devName, dev->portNum, str);
+      break;
+    case IBV_EVENT_QP_FATAL:
+    case IBV_EVENT_QP_ACCESS_ERR:
+      WARN("NET/IB : %s:%d QP event: %s", dev->devName, dev->portNum, str);
+      break;
+    case IBV_EVENT_SRQ_ERR:
+      WARN("NET/IB : %s:%d SRQ event: %s", dev->devName, dev->portNum, str);
+      break;
+    default:
+      WARN("NET/IB : %s:%d unknown event: %s", dev->devName, dev->portNum, str);
+    }
+    if (flagcxSuccess != flagcxWrapIbvAckAsyncEvent(&event)) { break; }
+  }
+  return NULL;
+}
+
+
+
+
+
+#define UCXCHECK(cmd) do {                           \
+  ucs_status_t e = cmd;                              \
+  if( UCS_OK != e ) {                                \
+    WARN("Failed: UCX error %s:%d '%s'\n",           \
+        __FILE__,__LINE__, ucs_status_string(e));    \
+    return flagcxInternalError;                      \
+  }                                                  \
+} while(0)
+
+#define UCXCHECK_VOID(cmd) do {                      \
+  ucs_status_t e = cmd;                              \
+  if( UCS_OK != e ) {                                \
+    WARN("Failed: UCX error %s:%d '%s'\n",           \
+        __FILE__,__LINE__, ucs_status_string(e));    \
+  }                                                  \
+} while(0)
+
+// With flagcxNet_v11_t the FlagCX core initializes the network plugin per-communicator
+// rather than once for all communicators. However, the internal plugin implementation
+// still assumes the plugin is initialized only once across all communicators. The ref
+// counter makes sure the plugin internally initializes only once. When per communicator
+// context support is added to the plugin the ref counter can be removed.
+static int flagcxUcxRefCount = 0;
+
+
+FLAGCX_PARAM(UCXDisable, "UCX_DISABLE", 0);
+/* Exclude cuda-related UCX transports */
+FLAGCX_PARAM(UCXCudaDisable, "UCX_CUDA_DISABLE", 1);
+
+flagcxDebugLogger_t flagcxUcxPluginLogFunction;
+static const ucp_tag_t tag      = 0x8a000000;
+static const ucp_tag_t tagMask = (uint64_t)(-1);
+
+
+enum flagcxUCXCommState {
+  flagcxUCXCommStateStart = 0,
+  flagcxUCXCommStateConnect = 1,
+  flagcxUCXCommStateAccept = 3,
+};
+
+struct flagcxUCXCommStage {
+  enum flagcxUCXCommState state;
+  uint8_t iteration;
+  void* sock;
+  void* comm;
+};
+
+typedef struct flagcxUcxMhandle {
+  ucp_mem_h  ucp_memh;
+  ucp_rkey_h rkey;
+  int        mem_type;
+} flagcxUcxMhandle_t;
+
+flagcxResult_t flagcxUcxDevices(int* ndev) {
+  *ndev = flagcxNIbDevs;
+  return flagcxSuccess;
+}
+
+static __thread int flagcxUcxDmaSupportInitDev; // which device to init, must be thread local
+static void flagcxUcxDmaBufSupportInitOnce(){
+  flagcxResult_t res;
+  int dev_fail = 0;
+
+  // This is a physical device, not a virtual one, so select from ibDevs
+  flagcxIbMergedDev* mergedDev = flagcxIbMergedDevs + flagcxUcxDmaSupportInitDev;
+  flagcxIbDev* ibDev = flagcxIbDevs + mergedDev->vProps.devs[0];
+  struct ibv_pd* pd;
+  struct ibv_context* ctx = ibDev->context;
+  FLAGCXCHECKGOTO(flagcxWrapIbvAllocPd(&pd, ctx), res, failure);
+  // Test kernel DMA-BUF support with a dummy call (fd=-1)
+  (void)flagcxWrapDirectIbvRegMr(pd, 0ULL /*addr*/, 0ULL /*len*/, 0 /*access*/);
+  // ibv_reg_dmabuf_mr() will fail with EOPNOTSUPP/EPROTONOSUPPORT if not supported (EBADF otherwise)
+  dev_fail |= (errno == EOPNOTSUPP) || (errno == EPROTONOSUPPORT);
+  FLAGCXCHECKGOTO(flagcxWrapIbvDeallocPd(pd), res, failure);
+  // stop the search and goto failure
+  if (dev_fail) goto failure;
+  ibDev->dmaBufSupported = 1;
+  return;
+failure:
+  ibDev->dmaBufSupported = -1;
+  return;
+}
+flagcxResult_t flagcx_p2p_dmabuf_support(int dev) {
+  // init the device only once
+  flagcxUcxDmaSupportInitDev = dev;
+  pthread_once(&onces[dev].once, flagcxUcxDmaBufSupportInitOnce);
+  flagcxIbMergedDev* mergedDev = flagcxIbMergedDevs + flagcxUcxDmaSupportInitDev;
+  flagcxIbDev* ibDev = flagcxIbDevs + mergedDev->vProps.devs[0];
+  int dmaBufSupported = ibDev->dmaBufSupported;
+  if (dmaBufSupported == 1) return flagcxSuccess;
+  return flagcxSystemError;
+}
+flagcxResult_t flagcx_p2p_gdr_support()
+{
+  static pthread_once_t once = PTHREAD_ONCE_INIT;
+  pthread_once(&once, ibGdrSupportInitOnce);
+  if (!flagcxIbGdrModuleLoaded)
+    return flagcxSystemError;
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcx_p2p_ib_init(int *nDevs, int *nmDevs, flagcxIbDev *flagcxIbDevs, char *flagcxIbIfName, union flagcxSocketAddress *flagcxIbIfAddr, pthread_t *flagcxIbAsyncThread, flagcxDebugLogger_t logFunction)
+{
+    printf("liuheliuhe \n");
+  flagcxResult_t ret = flagcxSuccess;
+  int flagcxNIbDevs = *nDevs;
+  int flagcxNMergedIbDevs = *nmDevs;
+  flagcxUcxPluginLogFunction = logFunction;
+  if (flagcxNIbDevs == -1) {
+    for (int i=0; i< MAX_IB_DEVS; i++)
+      onces[i].once = PTHREAD_ONCE_INIT;
+    pthread_mutex_lock(&flagcx_p2p_lock);
+    flagcxWrapIbvForkInit();
+    if (flagcxNIbDevs == -1) {
+      int nIpIfs = 0;
+      flagcxNIbDevs = 0;
+      flagcxNMergedIbDevs = 0;
+      flagcxNSharpDevs = 0;
+      nIpIfs = flagcxFindInterfaces(flagcxIbIfName, flagcxIbIfAddr, MAX_IF_NAME_SIZE, 1);
+      if (nIpIfs != 1) {
+        WARN("NET/IB : No IP interface found.");
+        ret = flagcxInternalError;
+        goto fail;
+      }
+
+      // Detect IB cards
+      int nIbDevs;
+      struct ibv_device** devices;
+      // Check if user defined which IB device:port to use
+      const char* userIbEnv = flagcxGetEnv("FLAGCX_IB_HCA");
+      struct netIf userIfs[MAX_IB_DEVS];
+      int searchNot = userIbEnv && userIbEnv[0] == '^';
+      if (searchNot) userIbEnv++;
+      int searchExact = userIbEnv && userIbEnv[0] == '=';
+      if (searchExact) userIbEnv++;
+      int nUserIfs = parseStringList(userIbEnv, userIfs, MAX_IB_DEVS);
+
+      if (flagcxSuccess != flagcxWrapIbvGetDeviceList(&devices, &nIbDevs)) { ret = flagcxInternalError; goto fail; }
+      for (int d=0; d<nIbDevs && flagcxNIbDevs<MAX_IB_DEVS; d++) {
+        struct ibv_context * context;
+        if (flagcxSuccess != flagcxWrapIbvOpenDevice(&context, devices[d]) || context == NULL) {
+          WARN("NET/IB : Unable to open device %s", devices[d]->name);
+          continue;
+        }
+        enum flagcxIbProvider ibProvider = IB_PROVIDER_NONE;
+        char dataDirectDevicePath[PATH_MAX];
+        int dataDirectSupported = 0;
+        int skipNetDevForDataDirect = 0;
+        int nPorts = 0;
+        struct ibv_device_attr devAttr;
+        if (flagcxSuccess != flagcxWrapIbvQueryDevice(context, &devAttr)) {
+          WARN("NET/IB : Unable to query device %s", devices[d]->name);
+          if (flagcxSuccess != flagcxWrapIbvCloseDevice(context)) { ret = flagcxInternalError; goto fail; }
+          continue;
+        }
+        for (int port_num = 1; port_num <= devAttr.phys_port_cnt; port_num++) {
+          for (int dataDirect = skipNetDevForDataDirect; dataDirect < 1 + dataDirectSupported; ++dataDirect) {
+            struct ibv_port_attr portAttr;
+            uint32_t portSpeed;
+            if (flagcxSuccess != flagcxWrapIbvQueryPort(context, port_num, &portAttr)) {
+              WARN("NET/IB : Unable to query port_num %d", port_num);
+              continue;
+            }
+            if (portAttr.state != IBV_PORT_ACTIVE) continue;
+            if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND
+                && portAttr.link_layer != IBV_LINK_LAYER_ETHERNET) continue;
+
+            // check against user specified HCAs/ports
+            if (! (matchIfList(devices[d]->name, port_num, userIfs, nUserIfs, searchExact) ^ searchNot)) {
+              continue;
+            }
+            pthread_mutex_init(&flagcxIbDevs[flagcxNIbDevs].lock, NULL);
+            flagcxIbDevs[flagcxNIbDevs].device = d;
+            flagcxIbDevs[flagcxNIbDevs].ibProvider = ibProvider;
+            flagcxIbDevs[flagcxNIbDevs].guid = devAttr.sys_image_guid;
+            flagcxIbDevs[flagcxNIbDevs].portAttr = portAttr;
+            flagcxIbDevs[flagcxNIbDevs].portNum = port_num;
+            flagcxIbDevs[flagcxNIbDevs].link = portAttr.link_layer;
+            #if HAVE_STRUCT_IBV_PORT_ATTR_ACTIVE_SPEED_EX
+            portSpeed = portAttr.active_speed_ex ? portAttr.active_speed_ex : portAttr.active_speed;
+            #else
+            portSpeed = portAttr.active_speed;
+            #endif
+            flagcxIbDevs[flagcxNIbDevs].speed = flagcx_p2p_ib_speed(portSpeed) * flagcx_p2p_ib_width(portAttr.active_width);
+            flagcxIbDevs[flagcxNIbDevs].context = context;
+            flagcxIbDevs[flagcxNIbDevs].pdRefs = 0;
+            flagcxIbDevs[flagcxNIbDevs].pd = NULL;
+            if (!dataDirect) {
+              strncpy(flagcxIbDevs[flagcxNIbDevs].devName, devices[d]->name, MAXNAMESIZE);
+              FLAGCXCHECKGOTO(flagcx_p2p_ib_pci_path(flagcxIbDevs, flagcxNIbDevs, flagcxIbDevs[flagcxNIbDevs].devName, &flagcxIbDevs[flagcxNIbDevs].pciPath, &flagcxIbDevs[flagcxNIbDevs].realPort), ret, fail);
+            } else {
+              snprintf(flagcxIbDevs[flagcxNIbDevs].devName, MAXNAMESIZE, "%.*s_dma", 
+                       (int)(MAXNAMESIZE - 5), devices[d]->name);
+              flagcxIbDevs[flagcxNIbDevs].pciPath = (char*)malloc(PATH_MAX);
+              strncpy(flagcxIbDevs[flagcxNIbDevs].pciPath, dataDirectDevicePath, PATH_MAX);
+              flagcxIbDevs[flagcxNIbDevs].capsProvider.mlx5.dataDirect = 1;
+            }
+            flagcxIbDevs[flagcxNIbDevs].maxQp = devAttr.max_qp;
+            flagcxIbDevs[flagcxNIbDevs].mrCache.capacity = 0;
+            flagcxIbDevs[flagcxNIbDevs].mrCache.population = 0;
+            flagcxIbDevs[flagcxNIbDevs].mrCache.slots = NULL;
+            FLAGCXCHECK(flagcxIbStatsInit(&flagcxIbDevs[flagcxNIbDevs].stats));
+
+          // Enable ADAPTIVE_ROUTING by default on IB networks
+            // But allow it to be overloaded by an env parameter
+            flagcxIbDevs[flagcxNIbDevs].ar = (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) ? 1 : 0;
+            if (flagcxParamIbAdaptiveRouting() != -2) flagcxIbDevs[flagcxNIbDevs].ar = flagcxParamIbAdaptiveRouting();
+
+            flagcxIbDevs[flagcxNIbDevs].isSharpDev = 0;
+            if (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND)
+            {
+              flagcxIbDevs[flagcxNIbDevs].isSharpDev = 1;
+              flagcxIbDevs[flagcxNIbDevs].maxQp = flagcxParamSharpMaxComms();
+              flagcxNSharpDevs++;
+            }
+            TRACE(FLAGCX_NET,"NET/IB: [%d] %s:%s:%d/%s provider=%s speed=%d context=%p pciPath=%s ar=%d", d, devices[d]->name, devices[d]->dev_name, flagcxIbDevs[flagcxNIbDevs].portNum,
+              FLAGCX_IB_LLSTR(portAttr.link_layer), ibProviderName[flagcxIbDevs[flagcxNIbDevs].ibProvider], flagcxIbDevs[flagcxNIbDevs].speed, context, flagcxIbDevs[flagcxNIbDevs].pciPath, flagcxIbDevs[flagcxNIbDevs].ar);
+            if (flagcxIbAsyncThread != NULL) {
+              PTHREADCHECKGOTO(pthread_create(flagcxIbAsyncThread, NULL, flagcxIbAsyncThreadMain, flagcxIbDevs + flagcxNIbDevs), "pthread_create", ret, fail);
+              flagcxSetThreadName(*flagcxIbAsyncThread, "flagcx IbAsync %2d", flagcxNIbDevs);
+              PTHREADCHECKGOTO(pthread_detach(*flagcxIbAsyncThread), "pthread_detach", ret, fail); // will not be pthread_join()'d
+            }
+
+            // Add this plain physical device to the list of virtual devices
+            int vDev;
+            flagcxNetVDeviceProps_t vProps = {0};
+            vProps.ndevs = 1;
+            vProps.devs[0] = flagcxNIbDevs;
+            FLAGCXCHECK(flagcxIbMakeVDeviceInternal(&vDev, &vProps, flagcxNIbDevs, &flagcxNMergedIbDevs));
+
+            flagcxNIbDevs++;
+            nPorts++;
+          }
+        }
+        if (nPorts == 0 && flagcxSuccess != flagcxWrapIbvCloseDevice(context))  { ret = flagcxInternalError; goto fail; }
+      }
+      
+      if (nIbDevs && (flagcxSuccess != flagcxWrapIbvFreeDeviceList(devices))) { ret = flagcxInternalError; goto fail; };
+    }
+    if (flagcxNIbDevs == 0) {
+      INFO(FLAGCX_INIT|FLAGCX_NET, "NET/IB : No device found.");
+    }
+
+    // Print out all net devices to the user (in the same format as before)
+    char line[2048];
+    line[0] = '\0';
+    // Determine whether RELAXED_ORDERING is enabled and possible
+#ifdef HAVE_IB_PLUGIN
+    flagcxIbRelaxedOrderingEnabled = flagcxIbRelaxedOrderingCapable();
+#endif
+    for (int d = 0; d < flagcxNIbDevs; d++) {
+#ifdef HAVE_SHARP_PLUGIN
+            snprintf(line+strlen(line), sizeof(line)-strlen(line), " [%d]%s:%d/%s%s", d, flagcxIbDevs[d].devName,
+              flagcxIbDevs[d].portNum, FLAGCX_IB_LLSTR(flagcxIbDevs[d].link),
+              flagcxIbDevs[d].isSharpDev ? "/SHARP" : "");
+#else
+      snprintf(line+strlen(line), sizeof(line)-strlen(line), " [%d]%s:%d/%s", d, flagcxIbDevs[d].devName,
+        flagcxIbDevs[d].portNum, FLAGCX_IB_LLSTR(flagcxIbDevs[d].link));
+#endif
+    }
+    char addrline[SOCKET_NAME_MAXLEN+1];
+    INFO(FLAGCX_INIT|FLAGCX_NET, "NET/IB : Using%s %s; OOB %s:%s", line, 
+#ifdef HAVE_IB_PLUGIN
+      flagcxIbRelaxedOrderingEnabled ? "[RO]" : ""
+#else
+      ""
+#endif
+      ,
+      flagcxIbIfName, flagcxSocketToString(flagcxIbIfAddr, addrline, 1));
+    *nDevs = flagcxNIbDevs;
+    *nmDevs = flagcxNMergedIbDevs;
+    pthread_mutex_unlock(&flagcx_p2p_lock);
+  }
+exit:
+  return ret;
+fail:
+  pthread_mutex_unlock(&flagcx_p2p_lock);
+  goto exit;
+}
+flagcxResult_t flagcxIbGetPhysProperties(int dev, flagcxNetProperties_v8_t* props) {
+  struct flagcxIbDev* ibDev = flagcxIbDevs + dev;
+  pthread_mutex_lock(&ibDev->lock);
+  props->name = ibDev->devName;
+  props->speed = ibDev->speed;
+  props->pciPath = ibDev->pciPath;
+  props->guid = ibDev->guid;
+  props->ptrSupport   = FLAGCX_PTR_HOST;
+  if (flagcx_p2p_gdr_support() == flagcxSuccess) {
+    props->ptrSupport |= FLAGCX_PTR_CUDA; // GDR support via nv_peermem
+    INFO(FLAGCX_NET,"NET/IB : GPU Direct RDMA (nvidia-peermem) enabled for HCA %d '%s", dev, ibDev->devName);
+  }
+  props->regIsGlobal = 1;
+  if (flagcx_p2p_dmabuf_support(dev) == flagcxSuccess) {
+    props->ptrSupport |= FLAGCX_PTR_DMABUF; // GDR support via DMA-BUF
+    INFO(FLAGCX_NET,"NET/IB : GPU Direct RDMA (DMABUF) enabled for HCA %d '%s", dev, ibDev->devName);
+  }
+
+  props->latency      = 0; // Not set
+  props->port = ibDev->portNum + ibDev->realPort;
+  props->maxComms = ibDev->maxQp;
+  props->maxRecvs = FLAGCX_NET_IB_MAX_RECVS;
+  props->netDeviceType = FLAGCX_NET_DEVICE_HOST;
+  props->netDeviceVersion = FLAGCX_NET_DEVICE_INVALID_VERSION;
+  pthread_mutex_unlock(&ibDev->lock);
+  return flagcxSuccess;
+}
+flagcxResult_t flagcx_p2p_ib_get_properties(flagcxIbDev *devs, int flagcxNMergedIbDevs, int dev, flagcxNetProperties_v8_t* props)
+{
+  if (dev >= flagcxNMergedIbDevs) {
+    WARN("NET/IB : Requested properties for vNic %d, only %d vNics have been created", dev, flagcxNMergedIbDevs);
+    return flagcxInvalidUsage;
+  }
+  struct flagcxIbMergedDev* mergedDev = flagcxIbMergedDevs + dev;
+  // Take the rest of the properties from an arbitrary sub-device (should be the same)
+  FLAGCXCHECK(flagcxIbGetPhysProperties(mergedDev->vProps.devs[0], props));
+  props->name = mergedDev->devName;
+  props->speed = mergedDev->speed;
+//   memcpy(&props->vProps, &mergedDev->vProps, sizeof(flagcxNetVDeviceProps_v8_t));
+  return flagcxSuccess;
+}
+flagcxResult_t flagcxUcxGetProperties(int dev, void* props)
+{
+  return flagcx_p2p_ib_get_properties(flagcxIbDevs, flagcxNMergedIbDevs, dev, (flagcxNetProperties_v8_t*)props);
+}
+
+
+pthread_mutex_t flagcxUcxLock = PTHREAD_MUTEX_INITIALIZER;
+
+struct flagcxUcxEpList {
+  struct flagcxSocket *sock;
+  struct flagcxUcxEpList *next;
+};
+
+/**
+ * Connection descriptor. Used to store all opened connections.
+ */
+typedef struct ucx_worker {
+  ucp_worker_h   worker;   /* ucp worker associated with ctx */
+  ucp_context_h  ctx;      /* ucp_context bounded to specific device */
+  struct flagcxUcxEpList *eps;     /* oob conection to all endpoints that were opened on this worker */
+
+  int            count;    /* number of connections that uses this worker */
+  int            dev;      /* Managed device */
+  pthread_t      thread;   /* Owner thread */
+
+  struct ucx_worker *next;
+} ucx_worker_t;
+
+/**
+ * Listen handle that is sent from receiver to sender through OOB connection
+ */
+typedef struct flagcxUcxListenHandle {
+  union flagcxSocketAddress connectAddr; /* reciever socket address */
+  uint64_t magic;                      /* random number to help debugging */
+  ucp_tag_t               tag;         /* tag that is used to distiguish data that was sent to
+                                          this reciever. Required when shared worker is used. */
+  struct flagcxUCXCommStage stage;
+} flagcxUcxListenHandle_t;
+
+/**
+ * Listen commincator for UCX plugin.
+ */
+typedef struct flagcxUcxListenComm {
+  int           dev;    /* device number in flagcxIbDevs which will
+                         * be used to recieve data */
+  struct flagcxSocket sock;/* socket for OOB connection */
+  ucp_context_h ctx;    /* ucp_context associated with specific device dev */
+  ucx_worker_t *ucx_worker; /* ucx_worker created on ctx, worker can be shared between
+                           multiple connections */
+  ucp_tag_t     tag;    /* tag that is used to distiguish data that was sent to 
+                           this reciever. Required when shared worker is used.*/
+  struct flagcxUCXCommStage stage;
+} flagcxUcxListenComm_t;
+
+typedef struct flagcxUcxConnectMsg {
+  size_t addr_len;
+} flagcxUcxConnectMsg_t;
+
+struct flagcxUcxComm;
+
+/**
+ * Batch of UCX Requests from FlagCX perspective
+ */
+typedef struct flagcxUcxRequest {
+  struct flagcxUcxRequest *next;    /* Next request in the free list */
+  struct flagcxUcxComm    *comm;    /* Owning communicator */
+  ucp_worker_h        worker;  /* Worker for all requests */
+  int                 pending; /* How many requests are still pending */
+  int                 count;   /* How many requests are contained */
+  int                 size[FLAGCX_NET_IB_MAX_RECVS];
+} flagcxUcxRequest_t;
+
+static ucp_tag_t              flagcxUcxWorkerTags[MAX_IB_DEVS];
+static ucp_context_h          flagcxUcxCtx[MAX_IB_DEVS];
+static struct ucx_worker *flagcxUcxWorkers[MAX_IB_DEVS];
+static int ucx_workerCount = 0;
+
+typedef struct flagcxUcxGpuFlush {
+  int      enabled;
+  int      hostMem;
+  ucp_ep_h flush_ep;
+} flagcxUcxGpuFlush_t;
+
+/**
+ * Common data member for ucx_comm for send and receive
+ * Used to map/unmap memory in flagcxUcxRegMr/flagcxUcxDeregMr
+ */
+typedef struct flagcxUcxCtx {
+  ucp_context_h   flagcxUcxCtx;
+  flagcxUcxGpuFlush_t gpuFlush;
+} flagcxUcxCtx_t;
+
+/**
+ * Sender and Receiver communicator
+ */
+typedef struct flagcxUcxComm {
+  ucp_context_h   ctx;           /* ucp_context bounded to specific device */
+  flagcxUcxGpuFlush_t gpuFlush;      /* flushing handle */
+  ucx_worker_t *ucx_worker; /* ucp worker associated with ctx */
+  ucp_ep_h        ep;            /* ucp endpoint created on worker */
+  ucp_tag_t       tag;           /* datapath tag to filter out message that are not
+                                    belong to this connnection */
+  ucp_tag_t       ctag;          /* controlpath tag to filter out message that are not
+                                    belong to this connnection */
+  struct flagcxSocket sock;        /* socket for OOB connection */
+  int             ready;         /* indicates that receive communicator is fully initialized */
+  flagcxUcxRequest_t   reqs[MAX_REQUESTS]; /* max inflight requests */
+  flagcxUcxRequest_t   *free_req;     /* first request available */
+  flagcxUcxConnectMsg_t   *msg;          /* message to establish reverse connection */
+  void            *connect_req;  /* msg request */
+} flagcxUcxComm_t;
+
+static void send_handler_nbx(void *request, ucs_status_t status,
+                             void *user_data) {
+  int *pending = (int*)user_data;
+
+  assert(status == UCS_OK);
+  assert(*pending > 0);
+  (*pending)--;
+  ucp_request_free(request);
+}
+
+static void recv_handler_nbx(void *request, ucs_status_t status,
+                             const ucp_tag_recv_info_t *tag_info,
+                             void *user_data) {
+  send_handler_nbx(request, status, user_data);
+}
+
+static union flagcxSocketAddress flagcxUcxIfAddr;
+static char if_name[MAX_IF_NAME_SIZE];
+
+static flagcxResult_t flagcxUcxConfigNoCuda(ucp_config_t *config) {
+  char tmp[PATH_MAX];
+  const char *flagcxUcxTls;
+  ssize_t n;
+
+  flagcxUcxTls = getenv("FLAGCX_UCX_TLS");
+  if (flagcxUcxTls == NULL) {
+    flagcxUcxTls = getenv("UCX_TLS");
+  }
+
+  if (flagcxUcxTls == NULL) {
+    flagcxUcxTls = "^cuda";
+  } else if (flagcxUcxTls[0] == '^') {
+    /* Negative expression, make sure to keep cuda excluded */
+    n = snprintf(tmp, sizeof(tmp), "^cuda,%s", &flagcxUcxTls[1]);
+    if (n >= sizeof(tmp)) {
+      return flagcxInternalError;
+    }
+
+    flagcxUcxTls = tmp;
+  } else {
+    /* Positive expression cannot allow cuda-like transports */
+    if ((strstr(flagcxUcxTls, "cuda") != NULL) || (strstr(flagcxUcxTls, "gdr") != NULL)) {
+      WARN("Cannot use cuda/gdr transports as part of specified UCX_TLS");
+      return flagcxInternalError;
+    }
+  }
+
+  UCXCHECK(ucp_config_modify(config, "TLS", flagcxUcxTls));
+  UCXCHECK(ucp_config_modify(config, "RNDV_THRESH", "0"));
+  UCXCHECK(ucp_config_modify(config, "RNDV_SCHEME", "get_zcopy"));
+  UCXCHECK(
+      ucp_config_modify(config, "MEMTYPE_REG_WHOLE_ALLOC_TYPES", "unknown"));
+  return flagcxSuccess;
+}
+
+static flagcxResult_t flagcxUcxInitContext(ucp_context_h *ctx, int dev) {
+  ucp_params_t ucp_params;
+  ucp_config_t *config;
+  char         flagcxUcxDevName[PATH_MAX];
+  flagcxResult_t result;
+
+  if (flagcxUcxCtx[dev] == NULL) {
+    plugin_get_device_name(flagcxIbDevs[dev].devName, flagcxUcxDevName, 64);
+    snprintf(flagcxUcxDevName + strlen(flagcxUcxDevName), PATH_MAX - strlen(flagcxUcxDevName), ":%d",
+             flagcxIbDevs[dev].portNum);
+
+    UCXCHECK(ucp_config_read("FLAGCX", NULL, &config));
+    UCXCHECK(ucp_config_modify(config, "NET_DEVICES", flagcxUcxDevName));
+
+    if (flagcxParamUCXCudaDisable()) {
+      result = flagcxUcxConfigNoCuda(config);
+      if (result != flagcxSuccess) {
+        return result;
+      }
+    }
+
+    memset(&ucp_params, 0, sizeof(ucp_params));
+    ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES;
+    ucp_params.features   = UCP_FEATURE_TAG | UCP_FEATURE_RMA;
+
+    UCXCHECK(ucp_init(&ucp_params, config, &flagcxUcxCtx[dev]));
+    ucp_config_release(config);
+  }
+
+  *ctx = flagcxUcxCtx[dev];
+
+  return flagcxSuccess;
+}
+
+static flagcxResult_t flagcxUcxInitWorker(ucp_context_h ctx, ucp_worker_h *worker) {
+  ucp_worker_params_t worker_params;
+  ucp_worker_attr_t   worker_attr;
+
+  memset(&worker_params, 0, sizeof(worker_params));
+  worker_params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
+  worker_params.thread_mode = UCS_THREAD_MODE_MULTI;
+
+  UCXCHECK(ucp_worker_create(ctx, &worker_params, worker));
+
+  worker_attr.field_mask = UCP_WORKER_ATTR_FIELD_THREAD_MODE;
+  ucp_worker_query(*worker, &worker_attr);
+  if (worker_attr.thread_mode != UCS_THREAD_MODE_MULTI) {
+    INFO(FLAGCX_NET, "Thread mode multi is not supported");
+  }
+
+  return flagcxSuccess;
+}
+
+static flagcxResult_t flagcxUcxWorkerGetNetaddress(ucp_worker_h worker,
+                                              ucp_address_t **address,
+                                              size_t *address_length) {
+  ucp_worker_attr_t attr;
+
+  attr.field_mask    = UCP_WORKER_ATTR_FIELD_ADDRESS |
+                       UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS;
+  attr.address_flags = UCP_WORKER_ADDRESS_FLAG_NET_ONLY;
+
+  UCXCHECK(ucp_worker_query(worker, &attr));
+  *address = (ucp_address_t*)malloc(attr.address_length);
+  if (address == NULL) {
+    return flagcxSystemError;
+  }
+
+  memcpy(*address, attr.address, attr.address_length);
+  *address_length = attr.address_length;
+  free(attr.address);
+
+  return flagcxSuccess;
+}
+
+static flagcxResult_t flagcxUcxGetCtxAndWorker(int dev, ucp_context_h *ctx,
+                                           ucx_worker_t **ucx_worker,
+                                           ucp_tag_t *newtag) {
+  pthread_mutex_lock(&flagcxUcxLock);
+  flagcxResult_t result;
+
+  if (flagcxNIbDevs <= dev) {
+    WARN("Device index is too large");
+    goto err;
+  }
+
+  ucx_worker_t *w;
+  for (w = flagcxUcxWorkers[dev]; w != NULL; w = w->next) {
+    assert(w->dev == dev);
+    if (w->thread == pthread_self()) {
+      break;
+    }
+  }
+
+  if (w == NULL) {
+    w = (ucx_worker_t*)calloc(1, sizeof(*w));
+    if (w == NULL) {
+      WARN("Worker allocation failure");
+      goto err;
+    }
+
+    w->dev    = dev;
+    w->thread = pthread_self();
+    w->count  = 0;
+
+    result = flagcxUcxInitContext(&w->ctx, dev);
+    if (result != flagcxSuccess) {
+        return result;
+    }
+    flagcxUcxInitWorker(w->ctx, &w->worker);
+    ucx_workerCount++;
+
+    w->next = flagcxUcxWorkers[dev];
+    flagcxUcxWorkers[dev] = w;
+  }
+
+  *ctx        = w->ctx;
+  *ucx_worker = w;
+  if (newtag != NULL) {
+    *newtag = ++flagcxUcxWorkerTags[dev];
+  }
+
+  ucp_worker_progress(w->worker);
+  w->count++;
+  pthread_mutex_unlock(&flagcxUcxLock);
+  return flagcxSuccess;
+
+err:
+  pthread_mutex_unlock(&flagcxUcxLock);
+  return flagcxSystemError;
+}
+
+static flagcxResult_t flagcxUcxFreeWorker(ucx_worker_t *ucx_worker) {
+  int dev, dummy, done = 0;
+  struct flagcxUcxEpList *ep, *cur;
+  struct ucx_worker *next;
+  flagcxResult_t result;
+
+  pthread_mutex_lock(&flagcxUcxLock);
+  ucx_worker->count--;
+  if (ucx_worker->count == 0) {
+      ucx_workerCount--;
+      done = ucx_workerCount == 0;
+  }
+  pthread_mutex_unlock(&flagcxUcxLock);
+
+  if (!done) {
+    return flagcxSuccess;
+  }
+
+  for (dev = 0; dev < sizeof(flagcxUcxWorkers) / sizeof(*flagcxUcxWorkers); dev++) {
+    for (ucx_worker = flagcxUcxWorkers[dev]; ucx_worker != NULL; ucx_worker = next) {
+      next = ucx_worker->next;
+      assert(ucx_worker->count == 0);
+
+      ep = ucx_worker->eps;
+      while (ep) {
+        cur    = ep;
+        result = flagcxSocketRecv(ep->sock, &dummy, sizeof(int));
+        if (result != flagcxSuccess) {
+          WARN("Failed to receive close for worker cleanup (res:%d)", result);
+        }
+
+        ep = ep->next;
+        close(cur->sock->fd);
+        free(cur);
+      }
+      ucp_worker_destroy(ucx_worker->worker);
+      free(ucx_worker);
+    }
+
+    flagcxUcxWorkers[dev] = NULL;
+    if (flagcxUcxCtx[dev]) {
+      ucp_cleanup(flagcxUcxCtx[dev]);
+      flagcxUcxCtx[dev] = NULL;
+    }
+  }
+
+  return flagcxSuccess;
+}
+
+static flagcxResult_t flagcxUcxAddEp(ucx_worker_t *ucx_worker,
+                                    struct flagcxSocket *sock) {
+  struct flagcxUcxEpList *new_ep = (struct flagcxUcxEpList*)malloc(sizeof(struct flagcxUcxEpList));
+  if (new_ep == NULL) {
+    return flagcxSystemError;
+  }
+
+  new_ep->sock    = sock;
+  new_ep->next    = ucx_worker->eps;
+  ucx_worker->eps = new_ep;
+  return flagcxSuccess;
+}
+
+
+
+flagcxResult_t flagcxUcxInit() {
+  if (flagcxUcxRefCount++) return flagcxSuccess;
+  if (flagcxParamUCXDisable()) return flagcxInternalError;
+
+  for (int i = 0; i < sizeof(flagcxUcxWorkerTags) / sizeof(*flagcxUcxWorkerTags); i++) {
+    flagcxUcxWorkerTags[i] = tag;
+  }
+
+  // Initialize InfiniBand symbols first
+  if (flagcxWrapIbvSymbols() != flagcxSuccess) {
+    WARN("NET/UCX: Failed to initialize InfiniBand symbols");
+    return flagcxInternalError;
+  }
+
+  return flagcx_p2p_ib_init(&flagcxNIbDevs, &flagcxNMergedIbDevs, flagcxIbDevs, if_name,
+                          &flagcxUcxIfAddr, NULL, NULL);
+}
+
+flagcxResult_t flagcxUcxListen(int dev, void *handle, void **listen_comm) {
+  flagcxUcxListenHandle_t *my_handle = (flagcxUcxListenHandle_t*)handle;
+  flagcxUcxListenComm_t   *comm      = (flagcxUcxListenComm_t*)calloc(1, sizeof(*comm));
+
+  FLAGCX_STATIC_ASSERT(sizeof(flagcxUcxListenHandle_t) < FLAGCX_NET_HANDLE_MAXSIZE,
+                     "UCX listen handle size too large");
+  my_handle->magic = FLAGCX_SOCKET_MAGIC;
+  FLAGCXCHECK(flagcxSocketInit(&comm->sock, &flagcxUcxIfAddr, my_handle->magic, flagcxSocketTypeNetIb, NULL, 1));
+  FLAGCXCHECK(flagcxSocketListen(&comm->sock));
+  FLAGCXCHECK(flagcxSocketGetAddr(&comm->sock, &my_handle->connectAddr));
+  FLAGCXCHECK(flagcxUcxGetCtxAndWorker(dev, &comm->ctx, &comm->ucx_worker, &comm->tag));
+
+  comm->dev = dev;
+  my_handle->tag = comm->tag;
+  *listen_comm = comm;
+ 
+  return flagcxSuccess;
+}
+
+static void flagcxUcxRequestInit(flagcxUcxComm_t *comm) {
+  static const int entries = sizeof(comm->reqs) / sizeof(*comm->reqs);
+
+  comm->free_req = NULL;
+  for (int i = entries - 1; i >= 0; i--) {
+      comm->reqs[i].comm = comm;
+      comm->reqs[i].next = comm->free_req;
+      comm->free_req = &comm->reqs[i];
+  }
+}
+
+flagcxResult_t flagcxUcxConnect(int dev, void *handle, void **send_comm) {
+  flagcxUcxListenHandle_t     *recv_handle = (flagcxUcxListenHandle_t*)handle;
+  struct flagcxUCXCommStage *stage       = &recv_handle->stage;
+  flagcxUcxComm_t              *comm        = (flagcxUcxComm_t*)stage->comm;
+  ucp_address_t           *my_addr;
+  size_t                  local_addr_len;
+  int                     ready;
+
+  *send_comm = NULL;
+
+  if (stage->state == flagcxUCXCommStateConnect) goto flagcxUcxConnectCheck;
+
+  FLAGCXCHECK(flagcxIbMalloc((void**)&comm, sizeof(flagcxUcxComm_t)));
+  FLAGCXCHECK(flagcxSocketInit(&comm->sock, &recv_handle->connectAddr, recv_handle->magic, flagcxSocketTypeNetIb, NULL, 1));
+  stage->comm = comm;
+  stage->state = flagcxUCXCommStateConnect;
+  FLAGCXCHECK(flagcxSocketConnect(&comm->sock));
+  flagcxUcxRequestInit(comm);
+
+flagcxUcxConnectCheck:
+  /* since flagcxSocketConnect is async, we must check if connection is complete */
+  FLAGCXCHECK(flagcxSocketReady(&comm->sock, &ready));
+  if (!ready) return flagcxSuccess;
+
+  FLAGCXCHECK(flagcxUcxGetCtxAndWorker(dev, &comm->ctx, &comm->ucx_worker, &comm->ctag));
+  comm->tag              = recv_handle->tag;
+  comm->gpuFlush.enabled = 0;
+  FLAGCXCHECK(flagcxUcxWorkerGetNetaddress(comm->ucx_worker->worker, &my_addr, &local_addr_len));
+  FLAGCXCHECK(flagcxUcxAddEp(comm->ucx_worker, &comm->sock));
+  TRACE(FLAGCX_NET, "NET/UCX: Worker address length: %zu", local_addr_len);
+
+  FLAGCXCHECK(flagcxSocketSend(&comm->sock, &local_addr_len, sizeof(size_t)));
+  FLAGCXCHECK(flagcxSocketSend(&comm->sock, my_addr, local_addr_len));
+  FLAGCXCHECK(flagcxSocketSend(&comm->sock, &comm->ctag, sizeof(ucp_tag_t)));
+
+  *send_comm = comm;
+  free(my_addr);
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxUcxAccept(void *listen_comm, void **recv_comm)
+{
+  flagcxUcxListenComm_t  *l_comm = (flagcxUcxListenComm_t *)listen_comm;
+  struct flagcxUCXCommStage* stage = &l_comm->stage;
+  flagcxUcxComm_t         *r_comm = (flagcxUcxComm_t *)stage->comm;
+  size_t             peer_addr_len;
+  ucp_address_t      *peer_addr;
+  ucp_ep_params_t    ep_params;
+  int                ready;
+
+  *recv_comm = NULL;
+  if (stage->state == flagcxUCXCommStateAccept) goto flagcxUcxAcceptCheck;
+
+  FLAGCXCHECK(flagcxIbMalloc((void**)&r_comm, sizeof(flagcxUcxComm_t)));
+  stage->comm = r_comm;
+  stage->state = flagcxUCXCommStateAccept;
+  l_comm->sock.asyncFlag = 1;
+  r_comm->sock.asyncFlag = 1;
+
+  FLAGCXCHECK(flagcxSocketInit(&r_comm->sock, NULL, FLAGCX_SOCKET_MAGIC, flagcxSocketTypeUnknown, NULL, 0));
+  FLAGCXCHECK(flagcxSocketAccept(&r_comm->sock, &l_comm->sock));
+flagcxUcxAcceptCheck:
+  FLAGCXCHECK(flagcxSocketReady(&r_comm->sock, &ready));
+  if (!ready) return flagcxSuccess;
+
+  r_comm->ctx        = l_comm->ctx;
+  r_comm->ucx_worker = l_comm->ucx_worker;
+  r_comm->tag        = l_comm->tag;
+
+  flagcxUcxRequestInit(r_comm);
+
+  FLAGCXCHECK(flagcxSocketRecv(&r_comm->sock, &peer_addr_len, sizeof(size_t)));
+  peer_addr = (ucp_address_t*)malloc(peer_addr_len);
+  if (peer_addr == NULL) {
+    return flagcxSystemError;
+  }
+
+  FLAGCXCHECK(flagcxSocketRecv(&r_comm->sock, peer_addr, peer_addr_len));
+  ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
+  ep_params.address    = peer_addr;
+  UCXCHECK(ucp_ep_create(r_comm->ucx_worker->worker, &ep_params, &r_comm->ep));
+  FLAGCXCHECK(flagcxSocketRecv(&r_comm->sock, &r_comm->ctag, sizeof(ucp_tag_t)));
+
+  r_comm->gpuFlush.enabled = (flagcx_p2p_gdr_support() == flagcxSuccess);  
+  if (r_comm->gpuFlush.enabled) {
+    ucp_address_t *my_addr;
+    size_t        local_addr_len;
+
+    FLAGCXCHECK(flagcxUcxWorkerGetNetaddress(r_comm->ucx_worker->worker, &my_addr, &local_addr_len));
+    ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
+    ep_params.address    = my_addr;
+    UCXCHECK(ucp_ep_create(r_comm->ucx_worker->worker, &ep_params, &r_comm->gpuFlush.flush_ep));
+    free(my_addr);
+  }
+
+  free(peer_addr);
+  *recv_comm = r_comm;
+
+  return flagcxSuccess;
+}
+
+#define REG_ALIGN (4096)
+flagcxResult_t flagcxUcxRegMr(void* comm, void* data, size_t size, int type, void** mhandle) {
+  flagcxUcxCtx_t *ctx = (flagcxUcxCtx_t*)comm;
+  uint64_t  addr = (uint64_t)  data;
+  ucp_mem_map_params_t mmap_params;
+  flagcxUcxMhandle_t        *mh;
+  uint64_t             reg_addr, reg_size;
+  size_t               rkey_buf_size;
+  void                 *rkey_buf;
+  
+  FLAGCXCHECK(flagcxIbMalloc((void**)&mh, sizeof(flagcxUcxMhandle_t)));
+  reg_addr = addr & (~(REG_ALIGN - 1));
+  reg_size = addr + size - reg_addr;
+  reg_size = ROUNDUP(reg_size, REG_ALIGN);
+
+  mmap_params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                           UCP_MEM_MAP_PARAM_FIELD_LENGTH; 
+  mmap_params.address    = (void*)reg_addr;
+  mmap_params.length     = reg_size;  
+  mh->mem_type = (type == FLAGCX_PTR_HOST)? UCS_MEMORY_TYPE_HOST: UCS_MEMORY_TYPE_CUDA;
+  mmap_params.field_mask  |= UCP_MEM_MAP_PARAM_FIELD_MEMORY_TYPE; 
+  mmap_params.memory_type = (ucs_memory_type_t)mh->mem_type;
+
+  UCXCHECK(ucp_mem_map(ctx->flagcxUcxCtx, &mmap_params, &mh->ucp_memh));
+  if (ctx->gpuFlush.enabled) {
+    UCXCHECK(ucp_rkey_pack(ctx->flagcxUcxCtx, mh->ucp_memh, &rkey_buf, &rkey_buf_size));
+    UCXCHECK(ucp_ep_rkey_unpack(ctx->gpuFlush.flush_ep, rkey_buf, &mh->rkey));
+    ucp_rkey_buffer_release(rkey_buf);
+  }
+  
+  *mhandle = mh;
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxUcxDeregMr(void* comm, void* mhandle) {
+  flagcxUcxCtx_t     *ctx = (flagcxUcxCtx_t*)comm;
+  flagcxUcxMhandle_t *mh  = (flagcxUcxMhandle_t*)mhandle;
+
+  if (ctx->gpuFlush.enabled) {
+      ucp_rkey_destroy(mh->rkey);
+  }
+
+  ucp_mem_unmap(ctx->flagcxUcxCtx, mh->ucp_memh);
+  free(mhandle);
+
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxUcxRegMrDmaBuf(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle) {
+	return flagcxUcxRegMr(comm, data, size, type, mhandle);
+}
+
+static flagcxUcxRequest_t *flagcxUcxRequestGet(flagcxUcxComm_t *comm) {
+  flagcxUcxRequest_t *req = comm->free_req;
+
+  if (req == NULL) {
+    WARN("NET/UCX: unable to allocate FlagCX request");
+    return NULL;
+  }
+
+  comm->free_req = req->next;
+  req->worker  = comm->ucx_worker->worker;
+  req->pending = 0;
+  req->count   = 0;
+  return req;
+}
+
+static void flagcxUcxRequestRelease(flagcxUcxRequest_t *req) {
+    req->next = req->comm->free_req;
+    req->comm->free_req = req;
+}
+
+static void flagcxUcxRequestAdd(flagcxUcxRequest_t *req, int size) {
+  req->size[req->count] = size;
+  req->pending++;
+  req->count++;
+}
+
+static flagcxResult_t flagcxUcxSendCheck(flagcxUcxComm_t *comm) {
+  ucp_request_param_t params;
+  ucp_tag_message_h   msg_tag;
+  ucp_tag_recv_info_t info_tag;
+  ucp_ep_params_t     ep_params;
+  void                *ucp_req;
+  ucs_status_t        status;
+
+  ucp_worker_progress(comm->ucx_worker->worker);
+
+  if (comm->connect_req != NULL) {
+    goto out_check_status;
+  }
+
+  msg_tag = ucp_tag_probe_nb(comm->ucx_worker->worker, comm->ctag, tagMask, 1,
+                             &info_tag);
+  if (msg_tag == NULL) {
+    return flagcxSuccess;
+  }
+
+  comm->msg = (flagcxUcxConnectMsg_t*)malloc(info_tag.length);
+  if (comm->msg == NULL) {
+    return flagcxSystemError;
+  }
+
+  params.op_attr_mask = 0;
+  ucp_req = ucp_tag_msg_recv_nbx(comm->ucx_worker->worker, comm->msg,
+                                 info_tag.length, msg_tag, &params);
+  if (UCS_PTR_IS_ERR(ucp_req)) {
+    WARN("Unable to receive connect msg (%s)",
+         ucs_status_string(UCS_PTR_STATUS(ucp_req)));
+    free(comm->msg);
+    comm->msg = NULL;
+    return flagcxSystemError;
+  } else if (ucp_req == NULL) {
+    goto out_set_ready;
+  }
+
+  assert(comm->connect_req == NULL);
+  comm->connect_req = ucp_req;
+
+out_check_status:
+  status = ucp_request_check_status(comm->connect_req);
+  if (status == UCS_INPROGRESS) {
+    return flagcxSuccess;
+  }
+
+  if (status != UCS_OK) {
+    free(comm->msg);
+    comm->msg = NULL;
+    WARN("Send check requested returned error (%s)", ucs_status_string(status));
+    return flagcxSystemError;
+  }
+
+  ucp_request_free(comm->connect_req);
+  comm->connect_req = NULL;
+
+out_set_ready:
+  ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
+  ep_params.address    = (ucp_address_t*)(comm->msg + 1);
+  UCXCHECK(ucp_ep_create(comm->ucx_worker->worker, &ep_params, &comm->ep));
+  comm->ready = 1;
+  free(comm->msg);
+  comm->msg = NULL;
+
+  return flagcxSuccess;
+}
+
+static void flagcxUcxRecvSetReady(flagcxUcxComm_t *comm) {
+  free(comm->msg);
+  comm->msg   = NULL;
+  comm->ready = 1;
+}
+
+static void check_handler(void *request, ucs_status_t status, void *user_data) {
+  assert(status == UCS_OK);
+  flagcxUcxRecvSetReady((flagcxUcxComm_t*)user_data);
+  ucp_request_free(request);
+}
+
+flagcxResult_t flagcxUcxRecvCheck(flagcxUcxComm_t *comm) {
+  ucp_request_param_t params;
+  ucp_address_t       *my_addr;
+  size_t              local_addr_len;
+  size_t              msg_len;
+
+  if (comm->connect_req != NULL) {
+    goto done;
+  }
+
+  FLAGCXCHECK(flagcxUcxWorkerGetNetaddress(comm->ucx_worker->worker, &my_addr,
+                                      &local_addr_len));
+  flagcxUcxAddEp(comm->ucx_worker, &comm->sock);
+
+  msg_len             = sizeof(flagcxUcxConnectMsg_t) + local_addr_len;
+  comm->msg           = (flagcxUcxConnectMsg_t*)calloc(1, msg_len);
+  comm->msg->addr_len = local_addr_len;
+  memcpy(comm->msg + 1, my_addr, local_addr_len);
+
+  params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+                        UCP_OP_ATTR_FIELD_USER_DATA;
+  params.cb.send      = check_handler;
+  params.user_data    = comm;
+
+  assert(comm->connect_req == NULL);
+  comm->connect_req   = ucp_tag_send_nbx(comm->ep, comm->msg, msg_len,
+                                         comm->ctag, &params);
+  if (UCS_PTR_IS_ERR(comm->connect_req)) {
+    WARN("Unable to send connect message");
+    free(comm->msg);
+    return flagcxSystemError;
+  } else if (comm->connect_req == NULL) {
+    flagcxUcxRecvSetReady(comm);
+    return flagcxSuccess;
+  }
+
+done:
+  ucp_worker_progress(comm->ucx_worker->worker);
+  return flagcxSuccess;
+}
+
+static ucp_tag_t flagcxUcxUcpTag(ucp_tag_t comm_tag, uint64_t tag)
+{
+  assert(tag <= UINT32_MAX);
+  assert(comm_tag <= UINT32_MAX);
+  return comm_tag + (tag << 32);
+}
+
+flagcxResult_t flagcxUcxIsend(void *send_comm, void *data, size_t size,
+                                   int tag, void *mhandle, void* phandle, void **request)
+{
+  flagcxUcxComm_t         *comm = (flagcxUcxComm_t *)send_comm;
+  flagcxUcxMhandle_t      *mh   = (flagcxUcxMhandle_t*)mhandle;
+  flagcxUcxRequest_t      *req;
+  void               *ucp_req;
+  ucp_request_param_t params;
+
+  if (comm->ready == 0) {
+    FLAGCXCHECK(flagcxUcxSendCheck(comm));
+    if (comm->ready == 0) {
+      *request = NULL;
+      return flagcxSuccess;
+    }
+  }
+
+  req = flagcxUcxRequestGet(comm);
+  if (req == NULL) {
+    return flagcxInternalError;
+  }
+
+  flagcxUcxRequestAdd(req, size);
+
+  params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+                        UCP_OP_ATTR_FIELD_USER_DATA;
+  params.cb.send      = send_handler_nbx;
+  params.user_data    = &req->pending;
+  if (mh) {
+    params.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMH;
+    params.memh          = mh->ucp_memh;
+  }
+
+
+  ucp_req = ucp_tag_send_nbx(comm->ep, data, size,
+                             flagcxUcxUcpTag(comm->tag, tag), &params);
+  if (UCS_PTR_IS_ERR(ucp_req)) {
+    WARN("ucx_isend: unable to send message (%s)",
+         ucs_status_string(UCS_PTR_STATUS(ucp_req)));
+    return flagcxSystemError;
+  } else if (ucp_req == NULL) {
+    req->pending--;
+  }
+
+  *request = req;
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxUcxIrecv(void *recv_comm, int n, void **data,
+                                   size_t *sizes, int *tags, void **mhandle,
+                                   void** phandles, void **request)
+{
+  flagcxUcxComm_t         *comm = (flagcxUcxComm_t*)recv_comm;
+  flagcxUcxMhandle_t      **mh  = (flagcxUcxMhandle_t**)mhandle;
+  void               *ucp_req;
+  flagcxUcxRequest_t      *req;
+  ucp_request_param_t params;
+
+  if (comm->ready == 0) {
+    FLAGCXCHECK(flagcxUcxRecvCheck(comm));
+    if (comm->ready == 0) {
+      *request = NULL;
+      return flagcxSuccess;
+    }
+  }
+
+  if (n > FLAGCX_NET_IB_MAX_RECVS) {
+    WARN("ucx_irecv: posting %d but max is %d", n, FLAGCX_NET_IB_MAX_RECVS);
+    return flagcxInternalError;
+  }
+
+  req = flagcxUcxRequestGet(comm);
+  if (req == NULL) {
+    return flagcxInternalError;
+  }
+
+  params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+                        UCP_OP_ATTR_FIELD_USER_DATA;
+  params.cb.recv      = recv_handler_nbx;
+  params.user_data    = &req->pending;
+
+  for (int i = 0; i < n; i++) {
+    flagcxUcxRequestAdd(req, sizes[i]);
+
+    if (mh[i]) {
+      params.op_attr_mask |= UCP_OP_ATTR_FIELD_MEMH;
+      params.memh          = mh[i]->ucp_memh;
+    } else {
+      params.op_attr_mask &= ~UCP_OP_ATTR_FIELD_MEMH;
+    }
+
+    ucp_req = ucp_tag_recv_nbx(comm->ucx_worker->worker, data[i], sizes[i],
+                               flagcxUcxUcpTag(comm->tag, tags[i]), tagMask,
+                               &params);
+    if (UCS_PTR_IS_ERR(ucp_req)) {
+      WARN("ucx_irecv: unable to post receive %d/%d (%s)", i, n,
+           ucs_status_string(UCS_PTR_STATUS(ucp_req)));
+      return flagcxSystemError;
+    } else if (ucp_req == NULL) {
+      req->pending--;
+    }
+  }
+
+  *request = req;
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxUcxIflush(void *recv_comm, int n, void **data, int *sizes,
+                             void **mhandle, void **request) {
+  int last            = -1;
+  int size            = 1;
+  flagcxUcxComm_t    *comm = (flagcxUcxComm_t *)recv_comm;
+  flagcxUcxMhandle_t **mh  = (flagcxUcxMhandle_t**)mhandle;
+  flagcxUcxRequest_t *req;
+  void *ucp_req;
+  ucp_request_param_t params;
+
+  *request = NULL;
+  for (int i=0; i<n; i++) if (sizes[i]) last = i;
+  if (comm->gpuFlush.enabled == 0 || last == -1) return flagcxSuccess;
+
+  req = flagcxUcxRequestGet(comm);
+  if (req == NULL) {
+    return flagcxInternalError;
+  }
+
+  flagcxUcxRequestAdd(req, size);
+
+  params.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+                        UCP_OP_ATTR_FIELD_USER_DATA;
+  params.cb.send      = send_handler_nbx;
+  params.user_data    = &req->pending;
+  ucp_req = ucp_get_nbx(comm->gpuFlush.flush_ep, &comm->gpuFlush.hostMem, size,
+                        (uint64_t)data[last], mh[last]->rkey, &params);
+  if (UCS_PTR_IS_ERR(ucp_req)) {
+    WARN("ucx_iflush: unable to read data (%s)",
+         ucs_status_string(UCS_PTR_STATUS(ucp_req)));
+    return flagcxSystemError;
+  } else if (ucp_req == NULL) {
+    req->pending--;
+  }
+
+  *request = req;
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxUcxTest(void *request, int *done, int *size) {
+  flagcxUcxRequest_t *req = (flagcxUcxRequest_t*)request;
+  unsigned p;
+
+  while (req->pending > 0) {
+    p = ucp_worker_progress(req->worker);
+    if (!p) {
+      *done = 0;
+      return flagcxSuccess;
+    }
+  }
+
+  *done = 1;
+  if (size != NULL) {
+    /* Posted receives have completed */
+    memcpy(size, req->size, sizeof(*size) * req->count);
+  }
+
+  flagcxUcxRequestRelease(req);
+  return flagcxSuccess;
+}
+
+static void wait_close(ucp_worker_h worker, void *ucp_req) {
+  ucs_status_t status;
+
+  if (UCS_PTR_IS_PTR(ucp_req)) {
+    do {
+      ucp_worker_progress(worker);
+      status = ucp_request_check_status(ucp_req);
+    } while(status == UCS_INPROGRESS);
+    ucp_request_free(ucp_req);
+  } else if (ucp_req != NULL) {
+    WARN("Failed to close UCX endpoint");
+  }
+}
+
+flagcxResult_t flagcxUcxCloseSend(void *send_comm) {
+  flagcxUcxComm_t *comm = (flagcxUcxComm_t*)send_comm;
+  void *close_req;
+
+  if (comm) {
+    if (comm->ep) {
+      close_req = ucp_ep_close_nb(comm->ep, UCP_EP_CLOSE_MODE_FLUSH);
+      wait_close(comm->ucx_worker->worker, close_req);
+      int close = 1;
+      FLAGCXCHECK(flagcxSocketSend(&comm->sock, &close, sizeof(int)));
+    }
+    flagcxUcxFreeWorker(comm->ucx_worker);
+    free(comm);
+  }
+
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxUcxCloseRecv(void *recv_comm) {
+  flagcxUcxComm_t *comm = (flagcxUcxComm_t*)recv_comm;
+  void *close_req;
+
+  if (comm) {
+    if (comm->gpuFlush.enabled) {
+      close_req = ucp_ep_close_nb(comm->gpuFlush.flush_ep, UCP_EP_CLOSE_MODE_FLUSH);
+      wait_close(comm->ucx_worker->worker, close_req);
+    }
+    if (comm->ep) {
+      close_req = ucp_ep_close_nb(comm->ep, UCP_EP_CLOSE_MODE_FLUSH);
+      wait_close(comm->ucx_worker->worker, close_req);
+      int close=1;
+      FLAGCXCHECK(flagcxSocketSend(&comm->sock, &close, sizeof(int)));
+    }
+    flagcxUcxFreeWorker(comm->ucx_worker);
+    free(comm);
+  }
+
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxUcxCloseListen(void *listen_comm) {
+  flagcxUcxListenComm_t *comm = (flagcxUcxListenComm_t *)listen_comm;
+
+  if (comm) {
+    close(comm->sock.fd);
+    free(comm);
+  }
+  
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxUcxFinalize(void* ctx) {
+  flagcxUcxRefCount--;
+  return flagcxSuccess;
+}
+
+// Additional functions needed for the adaptor interface
+flagcxResult_t flagcxUcxGetDevFromName(char *name, int *dev) {
+  // Simple implementation - find device by name
+  for (int i = 0; i < flagcxNIbDevs; i++) {
+    if (strcmp(flagcxIbDevs[i].devName, name) == 0) {
+      *dev = i;
+      return flagcxSuccess;
+    }
+  }
+  return flagcxSystemError;
+}
+// UCX network adaptor structure
+struct flagcxNetAdaptor flagcxNetUcx = {
+    // Basic functions
+    "UCX", flagcxUcxInit, flagcxUcxDevices, flagcxUcxGetProperties,
+    NULL, // reduceSupport
+    NULL, // getDeviceMr
+    NULL, // irecvConsumed
+
+    // Setup functions
+    flagcxUcxListen, // listen
+    flagcxUcxConnect, // connect
+    flagcxUcxAccept, // accept
+    flagcxUcxCloseSend, // closeSend
+    flagcxUcxCloseRecv, // closeRecv
+    flagcxUcxCloseListen, // closeListen
+
+    // Memory region functions
+    flagcxUcxRegMr, // regMr
+    flagcxUcxRegMrDmaBuf, // regMrDmaBuf
+    flagcxUcxDeregMr, // deregMr
+
+    // Two-sided functions
+    flagcxUcxIsend, // isend
+    flagcxUcxIrecv, // irecv
+    flagcxUcxIflush, // iflush
+    flagcxUcxTest, // test
+
+    // One-sided functions
+    NULL, // write - TODO: Implement
+    NULL, // read - TODO: Implement
+    NULL, // signal - TODO: Implement
+
+    // Device name lookup
+    flagcxUcxGetDevFromName  // getDevFromName
+};
+
+#endif // USE_UCX

--- a/flagcx/core/c2c_algo.cc
+++ b/flagcx/core/c2c_algo.cc
@@ -36,7 +36,9 @@ size_t getC2cCommPatternHash(size_t count, size_t rootClusterId,
   std::size_t h4 = std::hash<size_t>()(redOp);
   std::size_t h5 = std::hash<size_t>()((size_t)((uintptr_t)comm));
   return (static_cast<size_t>(h1 ^ (h2 << 1) ^ (h3 << 2) ^ (h4 << 3) ^
-                             (h5 << 4)) << 4) + static_cast<size_t>(commOp);
+                              (h5 << 4))
+          << 4) +
+         static_cast<size_t>(commOp);
 }
 
 flagcxInterRankBufferInfoManager::flagcxInterRankBufferInfoManager(

--- a/flagcx/core/comm.h
+++ b/flagcx/core/comm.h
@@ -177,7 +177,6 @@ struct flagcxHeteroComm {
   struct flagcxInterServerTopo *interServerTopo;
 
   struct flagcxNetAdaptor *netAdaptor;
-  flagcxCollNet_t *flagcxCollNet;
   struct bootstrapState *bootstrap;
   // Bitmasks for flagcxTransportP2pSetup
   uint64_t *connectSend;

--- a/flagcx/core/comm.h
+++ b/flagcx/core/comm.h
@@ -10,9 +10,9 @@
 #include "bootstrap.h"
 #include "device.h"
 #include "flagcx_net.h"
-#include "tuner.h" // adaptor/include/tuner.h
 #include "info.h"
 #include "register.h"
+#include "tuner.h" // adaptor/include/tuner.h
 #include "type.h"
 #include <stdint.h>
 

--- a/flagcx/core/flagcx_net.h
+++ b/flagcx/core/flagcx_net.h
@@ -365,10 +365,11 @@ typedef struct {
   flagcxResult_t (*makeVDevice)(int *d, flagcxNetVDeviceProps_v9_t *props);
 } flagcxCollNet_v9_t;
 
+#define FLAGCX_NET_MAX_DEVS_PER_NIC 4
 typedef struct {
   int ndevs;
-  int devs[FLAGCX_NET_MAX_DEVS_PER_NIC_V9];
-} flagcxNetVDeviceProps_v8_t;
+  int devs[FLAGCX_NET_MAX_DEVS_PER_NIC];
+} flagcxNetVDeviceProps_t;
 typedef struct {
   char *name;      // Used mostly for logging.
   char *pciPath;   // Path to the PCI device in /sys.

--- a/flagcx/core/flagcx_net.h
+++ b/flagcx/core/flagcx_net.h
@@ -366,6 +366,10 @@ typedef struct {
 } flagcxCollNet_v9_t;
 
 typedef struct {
+  int ndevs;
+  int devs[FLAGCX_NET_MAX_DEVS_PER_NIC_V9];
+} flagcxNetVDeviceProps_v8_t;
+typedef struct {
   char *name;      // Used mostly for logging.
   char *pciPath;   // Path to the PCI device in /sys.
   uint64_t guid;   // Unique identifier for the NIC chip. Important for

--- a/flagcx/core/flagcx_tuner.cc
+++ b/flagcx/core/flagcx_tuner.cc
@@ -1,15 +1,15 @@
+#include "flagcx_tuner.h"
+#include "check.h"
+#include "param.h"
 #include <map>
 #include <vector>
-#include "flagcx_tuner.h"
-#include "param.h"
-#include "check.h"
 
 // Status of a communicator tracked by a tuner
 enum TunerCommStatus {
-  TunerCommStatusUnset = 0, // initial state
-  TunerCommStatusActive = 1, // active and ready to use
+  TunerCommStatusUnset = 0,    // initial state
+  TunerCommStatusActive = 1,   // active and ready to use
   TunerCommStatusDisabled = 2, // disabled temporarily and can be re-enabled
-  TunerCommStatusError = 3, // error happened
+  TunerCommStatusError = 3,    // error happened
   TunerCommStatusDestroyed = 4 // destroyed
 };
 
@@ -18,36 +18,44 @@ struct TunerContext {
   std::map<struct flagcxCommTag, TunerCommStatus> commsStatusMap;
   std::vector<struct flagcxEnvConfig> configList;
   flagcxDebugLogger_t logger = NULL;
-  struct flagcxCommTag envTag = {.tag = ""}; // envTag specified by FLAGCX_USE_COMM_TAG environment
+  struct flagcxCommTag envTag = {
+      .tag = ""};     // envTag specified by FLAGCX_USE_COMM_TAG environment
   int envTagIdx = -1; // the index of envTag in configList
 };
 
 static struct flagcxEnvConfig config1 = {
-  .commTag = "defaultConfig1",
-  .envCount = 1,
-  .envs = {{.type = FLAGCX_ENV_TYPE_CREATION, .name = "NCCL_P2P_NVL_CHUNKSIZE", .value = "1024", .defaultValue = "524288"}}
-};
+    .commTag = "defaultConfig1",
+    .envCount = 1,
+    .envs = {{.type = FLAGCX_ENV_TYPE_CREATION,
+              .name = "NCCL_P2P_NVL_CHUNKSIZE",
+              .value = "1024",
+              .defaultValue = "524288"}}};
 
 static struct flagcxEnvConfig config2 = {
-  .commTag = "defaultConfig2",
-  .envCount = 1,
-  .envs = {{.type = FLAGCX_ENV_TYPE_CREATION, .name = "NCCL_P2P_NVL_CHUNKSIZE", .value = "524288", .defaultValue = "524288"}}
-};
+    .commTag = "defaultConfig2",
+    .envCount = 1,
+    .envs = {{.type = FLAGCX_ENV_TYPE_CREATION,
+              .name = "NCCL_P2P_NVL_CHUNKSIZE",
+              .value = "524288",
+              .defaultValue = "524288"}}};
 
-bool operator<(const struct flagcxCommTag& lhs, const struct flagcxCommTag& rhs) {
+bool operator<(const struct flagcxCommTag &lhs,
+               const struct flagcxCommTag &rhs) {
   return strcmp(lhs.tag, rhs.tag) < 0;
 }
 
-bool operator==(const struct flagcxCommTag& lhs, const struct flagcxCommTag& rhs) {
-    return strcmp(lhs.tag, rhs.tag) == 0;
+bool operator==(const struct flagcxCommTag &lhs,
+                const struct flagcxCommTag &rhs) {
+  return strcmp(lhs.tag, rhs.tag) == 0;
 }
 
 // A helper function set envs filtered by envType mask
-static flagcxResult_t setEnvConfig(const struct flagcxEnvConfig& cfg, uint32_t mask) {
+static flagcxResult_t setEnvConfig(const struct flagcxEnvConfig &cfg,
+                                   uint32_t mask) {
   for (int i = 0; i < cfg.envCount; i++) {
-    const auto & item = cfg.envs[i];
+    const auto &item = cfg.envs[i];
     if (item.type & mask) {
-      if(setenv(item.name, item.value, 1) != 0) {
+      if (setenv(item.name, item.value, 1) != 0) {
         return flagcxInternalError;
       }
     }
@@ -56,11 +64,12 @@ static flagcxResult_t setEnvConfig(const struct flagcxEnvConfig& cfg, uint32_t m
 }
 
 flagcxResult_t flagcxTunerInit(size_t nRanks, size_t nNodes,
-                              flagcxDebugLogger_t logFunction, void **context) {
-  struct TunerContext* ctx = new struct TunerContext;
-  //TODO: read config from file.
-  //ctx->configList.push_back(config1);
-  (void) config1;
+                               flagcxDebugLogger_t logFunction,
+                               void **context) {
+  struct TunerContext *ctx = new struct TunerContext;
+  // TODO: read config from file.
+  // ctx->configList.push_back(config1);
+  (void)config1;
   ctx->configList.push_back(config2);
   ctx->logger = logFunction;
   *context = ctx;
@@ -72,7 +81,8 @@ flagcxResult_t flagcxTunerInit(size_t nRanks, size_t nNodes,
     for (size_t i = 0; i < ctx->configList.size(); ++i) {
       if (ctx->envTag == ctx->configList[i].commTag) {
         ctx->envTagIdx = i;
-        INFO(FLAGCX_INIT, "Communicator tag set by environment to %s.", ctx->envTag.tag);
+        INFO(FLAGCX_INIT, "Communicator tag set by environment to %s.",
+             ctx->envTag.tag);
         break;
       }
     }
@@ -80,44 +90,47 @@ flagcxResult_t flagcxTunerInit(size_t nRanks, size_t nNodes,
   return flagcxSuccess;
 }
 
-flagcxResult_t flagcxTunerGetCandidateNumber(void* context, uint32_t* nCandidates) {
-  struct TunerContext* ctx = static_cast<struct TunerContext*>(context);
+flagcxResult_t flagcxTunerGetCandidateNumber(void *context,
+                                             uint32_t *nCandidates) {
+  struct TunerContext *ctx = static_cast<struct TunerContext *>(context);
   *nCandidates = ctx->configList.size();
   return flagcxSuccess;
 }
 
-flagcxResult_t flagcxTunerSetCandidate(void* context, uint32_t index,
-                                      struct flagcxCommTag* commTag) {
-  struct TunerContext* ctx = static_cast<struct TunerContext*>(context);
+flagcxResult_t flagcxTunerSetCandidate(void *context, uint32_t index,
+                                       struct flagcxCommTag *commTag) {
+  struct TunerContext *ctx = static_cast<struct TunerContext *>(context);
   if (index >= ctx->configList.size()) {
-      WARN("invalid index, index %u must less than config size %zu.",
-            index, ctx->configList.size());
-      return flagcxInvalidArgument;
+    WARN("invalid index, index %u must less than config size %zu.", index,
+         ctx->configList.size());
+    return flagcxInvalidArgument;
   }
   // Set env for that communicator index
-  const auto & curCfg = ctx->configList[index];
+  const auto &curCfg = ctx->configList[index];
   FLAGCXCHECK(setEnvConfig(curCfg, FLAGCX_ENV_TYPE_CREATION));
   ctx->commsStatusMap[curCfg.commTag] = TunerCommStatusActive;
   *commTag = curCfg.commTag;
   return flagcxSuccess;
 }
 
-flagcxResult_t flagcxTunerGetCollInfo(void* context, flagcxCommOp_t collType,
+flagcxResult_t flagcxTunerGetCollInfo(void *context, flagcxCommOp_t collType,
                                       size_t nBytes, int numPipeOps,
-                                      float** collCostTable, int regBuff,
-                                      struct flagcxCommTag* commTag) {
-  struct TunerContext* ctx = static_cast<struct TunerContext*>(context);
+                                      float **collCostTable, int regBuff,
+                                      struct flagcxCommTag *commTag) {
+  struct TunerContext *ctx = static_cast<struct TunerContext *>(context);
   // Use env comm tag when possible.
   if (ctx->envTagIdx != -1) {
-    FLAGCXCHECK(setEnvConfig(ctx->configList[ctx->envTagIdx], FLAGCX_ENV_TYPE_COLL));
+    FLAGCXCHECK(
+        setEnvConfig(ctx->configList[ctx->envTagIdx], FLAGCX_ENV_TYPE_COLL));
     *commTag = ctx->envTag;
-    INFO(FLAGCX_COLL, "Use Communicator tag %s set by environment.", commTag->tag);
+    INFO(FLAGCX_COLL, "Use Communicator tag %s set by environment.",
+         commTag->tag);
     return flagcxSuccess;
   }
-  // TODO: Implement logic to select the best communicator based on performance metrics.
-  // Currently, selects the first active communicator found.
+  // TODO: Implement logic to select the best communicator based on performance
+  // metrics. Currently, selects the first active communicator found.
   for (size_t i = 0; i < ctx->configList.size(); ++i) {
-    const auto & cfg = ctx->configList[i];
+    const auto &cfg = ctx->configList[i];
     const auto it = ctx->commsStatusMap.find(cfg.commTag);
     if (it != ctx->commsStatusMap.end() &&
         it->second == TunerCommStatusActive) {
@@ -131,16 +144,14 @@ flagcxResult_t flagcxTunerGetCollInfo(void* context, flagcxCommOp_t collType,
 }
 
 flagcxResult_t flagcxTunerDestroy(void *context) {
-  struct TunerContext* ctx = static_cast<struct TunerContext*>(context);
+  struct TunerContext *ctx = static_cast<struct TunerContext *>(context);
   delete ctx;
   return flagcxSuccess;
 }
 
-
-flagcxTuner_t internalTuner = {
-    "internal tuner",
-    flagcxTunerInit,
-    flagcxTunerGetCandidateNumber,
-    flagcxTunerSetCandidate,
-    flagcxTunerGetCollInfo,
-    flagcxTunerDestroy};
+flagcxTuner_t internalTuner = {"internal tuner",
+                               flagcxTunerInit,
+                               flagcxTunerGetCandidateNumber,
+                               flagcxTunerSetCandidate,
+                               flagcxTunerGetCollInfo,
+                               flagcxTunerDestroy};

--- a/flagcx/core/flagcx_tuner.h
+++ b/flagcx/core/flagcx_tuner.h
@@ -3,8 +3,10 @@
 
 #include "tuner.h"
 
-bool operator<(const struct flagcxCommTag& lhs, const struct flagcxCommTag& rhs);
-bool operator==(const struct flagcxCommTag& lhs, const struct flagcxCommTag& rhs);
+bool operator<(const struct flagcxCommTag &lhs,
+               const struct flagcxCommTag &rhs);
+bool operator==(const struct flagcxCommTag &lhs,
+                const struct flagcxCommTag &rhs);
 
 extern flagcxTuner_t internalTuner;
 #endif // end of FLAGCX_TUNER_H_

--- a/flagcx/core/global_comm.h
+++ b/flagcx/core/global_comm.h
@@ -5,8 +5,8 @@
 #include "flagcx.h"
 #include "tuner.h" // adaptor/tuner.h
 
-#include <vector>
 #include <map>
+#include <vector>
 
 /* Opaque handle to flagcxInnerComm */
 typedef struct flagcxInnerComm *flagcxInnerComm_t;
@@ -50,7 +50,8 @@ struct flagcxComm {
   std::vector<flagcxVendorType> clusterVendorMap;
   struct flagcxTuner *tuner;
   void *tunerContext;
-  std::map<struct flagcxCommTag, flagcxInnerComm_t> homoCommMap; // key: commTag returned by tuner
+  std::map<struct flagcxCommTag, flagcxInnerComm_t>
+      homoCommMap; // key: commTag returned by tuner
 };
 
 #endif // end include guard

--- a/flagcx/core/ib_common.h
+++ b/flagcx/core/ib_common.h
@@ -9,6 +9,7 @@
 #ifndef FLAGCX_IB_COMMON_H_
 #define FLAGCX_IB_COMMON_H_
 
+#include "flagcx_net.h"
 #include "ibvcore.h"
 #include <pthread.h>
 #include <stdint.h>
@@ -54,11 +55,7 @@ struct flagcxIbStats {
   int fatalErrorCount;
 };
 
-// Common device properties structure
-typedef struct {
-  int ndevs;
-  int devs[FLAGCX_IB_MAX_DEVS_PER_NIC];
-} flagcxNetVDeviceProps_t;
+// Common device properties structure is now defined in flagcx_net.h
 
 // Unified IB device structure (combines features from both adaptors)
 struct flagcxIbDev {
@@ -96,7 +93,7 @@ struct flagcxIbMergedDev {
   int ndevs;
   int devs[FLAGCX_IB_MAX_DEVS_PER_NIC];
 
-  // Structured fields (used by UCX)
+  // Structured fields (used by UCX) - now uses flagcx_net.h definition
   flagcxNetVDeviceProps_t vProps;
 
   // Common fields

--- a/flagcx/core/ib_common.h
+++ b/flagcx/core/ib_common.h
@@ -9,17 +9,18 @@
 #ifndef FLAGCX_IB_COMMON_H_
 #define FLAGCX_IB_COMMON_H_
 
-#include <stdint.h>
-#include <pthread.h>
 #include "ibvcore.h"
+#include <pthread.h>
+#include <stdint.h>
 
 // Common constants for IB adaptors
 #define MAXNAMESIZE 64
 #define MAX_IB_DEVS 32
 #define FLAGCX_IB_MAX_DEVS_PER_NIC 2
 #define FLAGCX_NET_MAX_DEVS_PER_NIC 4
-#define MAX_MERGED_DEV_NAME (MAXNAMESIZE*FLAGCX_IB_MAX_DEVS_PER_NIC)+FLAGCX_IB_MAX_DEVS_PER_NIC
-#define MAX_IB_VDEVS MAX_IB_DEVS*8
+#define MAX_MERGED_DEV_NAME                                                    \
+  (MAXNAMESIZE * FLAGCX_IB_MAX_DEVS_PER_NIC) + FLAGCX_IB_MAX_DEVS_PER_NIC
+#define MAX_IB_VDEVS MAX_IB_DEVS * 8
 
 // Common enums and constants
 enum flagcxIbProvider {
@@ -28,11 +29,8 @@ enum flagcxIbProvider {
   IB_PROVIDER_MLX4 = 2
 };
 
-static const char* ibProviderName[] __attribute__((unused)) = {
-  "NONE",
-  "MLX5", 
-  "MLX4"
-};
+static const char *ibProviderName[]
+    __attribute__((unused)) = {"NONE", "MLX5", "MLX4"};
 
 // Common parameter function declarations
 extern int64_t flagcxParamIbMergeVfs(void);
@@ -97,10 +95,10 @@ struct flagcxIbMergedDev {
   // Direct fields (used by IBRC)
   int ndevs;
   int devs[FLAGCX_IB_MAX_DEVS_PER_NIC];
-  
+
   // Structured fields (used by UCX)
   flagcxNetVDeviceProps_t vProps;
-  
+
   // Common fields
   int speed;
   char devName[MAX_MERGED_DEV_NAME];

--- a/flagcx/core/ib_common.h
+++ b/flagcx/core/ib_common.h
@@ -1,0 +1,113 @@
+/*************************************************************************
+ * Copyright (c) 2024, FlagCX Inc.
+ * All rights reserved.
+ *
+ * This file contains common InfiniBand structures and constants
+ * shared between IBRC and UCX adaptors.
+ ************************************************************************/
+
+#ifndef FLAGCX_IB_COMMON_H_
+#define FLAGCX_IB_COMMON_H_
+
+#include <stdint.h>
+#include <pthread.h>
+#include "ibvcore.h"
+
+// Common constants for IB adaptors
+#define MAXNAMESIZE 64
+#define MAX_IB_DEVS 32
+#define FLAGCX_IB_MAX_DEVS_PER_NIC 2
+#define FLAGCX_NET_MAX_DEVS_PER_NIC 4
+#define MAX_MERGED_DEV_NAME (MAXNAMESIZE*FLAGCX_IB_MAX_DEVS_PER_NIC)+FLAGCX_IB_MAX_DEVS_PER_NIC
+#define MAX_IB_VDEVS MAX_IB_DEVS*8
+
+// Common enums and constants
+enum flagcxIbProvider {
+  IB_PROVIDER_NONE = 0,
+  IB_PROVIDER_MLX5 = 1,
+  IB_PROVIDER_MLX4 = 2
+};
+
+static const char* ibProviderName[] __attribute__((unused)) = {
+  "NONE",
+  "MLX5", 
+  "MLX4"
+};
+
+// Common parameter function declarations
+extern int64_t flagcxParamIbMergeVfs(void);
+extern int64_t flagcxParamIbAdaptiveRouting(void);
+extern int64_t flagcxParamIbMergeNics(void);
+
+// Common IB structures
+struct flagcxIbMr {
+  uintptr_t addr;
+  size_t pages;
+  int refs;
+  struct ibv_mr *mr;
+};
+
+struct flagcxIbMrCache {
+  struct flagcxIbMr *slots;
+  int capacity, population;
+};
+
+struct flagcxIbStats {
+  int fatalErrorCount;
+};
+
+// Common device properties structure
+typedef struct {
+  int ndevs;
+  int devs[FLAGCX_IB_MAX_DEVS_PER_NIC];
+} flagcxNetVDeviceProps_t;
+
+// Unified IB device structure (combines features from both adaptors)
+struct flagcxIbDev {
+  pthread_mutex_t lock;
+  int device;
+  int ibProvider;
+  uint64_t guid;
+  struct ibv_port_attr portAttr;
+  int portNum;
+  int link;
+  int speed;
+  struct ibv_context *context;
+  int pdRefs;
+  struct ibv_pd *pd;
+  char devName[MAXNAMESIZE];
+  char *pciPath;
+  int realPort;
+  int maxQp;
+  struct flagcxIbMrCache mrCache;
+  struct flagcxIbStats stats;
+  int ar; // ADAPTIVE_ROUTING
+  int isSharpDev;
+  struct {
+    struct {
+      int dataDirect;
+    } mlx5;
+  } capsProvider;
+  int dmaBufSupported;
+} __attribute__((aligned(64)));
+
+// Unified merged device structure (used by both IBRC and UCX)
+// Contains both direct fields (for IBRC) and structured fields (for UCX)
+struct flagcxIbMergedDev {
+  // Direct fields (used by IBRC)
+  int ndevs;
+  int devs[FLAGCX_IB_MAX_DEVS_PER_NIC];
+  
+  // Structured fields (used by UCX)
+  flagcxNetVDeviceProps_t vProps;
+  
+  // Common fields
+  int speed;
+  char devName[MAX_MERGED_DEV_NAME];
+} __attribute__((aligned(64)));
+
+// Global arrays (declared as extern, defined in adaptor files)
+extern struct flagcxIbDev flagcxIbDevs[MAX_IB_DEVS];
+extern struct flagcxIbMergedDev flagcxIbMergedDevs[MAX_IB_VDEVS];
+
+#endif // FLAGCX_IB_COMMON_H_

--- a/flagcx/core/net.cc
+++ b/flagcx/core/net.cc
@@ -10,15 +10,12 @@ static pthread_mutex_t netLock = PTHREAD_MUTEX_INITIALIZER;
 // Use adaptor system for all network types
 struct flagcxNetAdaptor *flagcxNetAdaptors[3] = {
     nullptr, getUnifiedNetAdaptor(IBRC), getUnifiedNetAdaptor(SOCKET)};
-flagcxCollNet_t *flagcxCollNets[3] = {nullptr, nullptr, nullptr};
 enum flagcxNetState {
   flagcxNetStateInit = 0,
   flagcxNetStateEnabled = 1,
   flagcxNetStateDisabled = 2
 };
 enum flagcxNetState flagcxNetStates[3] = {
-    flagcxNetStateInit, flagcxNetStateInit, flagcxNetStateInit};
-enum flagcxNetState flagcxCollNetStates[3] = {
     flagcxNetStateInit, flagcxNetStateInit, flagcxNetStateInit};
 
 flagcxResult_t flagcxNetCheckDeviceVersion(struct flagcxHeteroComm *comm,
@@ -72,21 +69,6 @@ static flagcxResult_t netGetState(int i, enum flagcxNetState *state) {
   return flagcxSuccess;
 }
 
-static flagcxResult_t collNetGetState(int i, enum flagcxNetState *state) {
-  pthread_mutex_lock(&netLock);
-  if (flagcxCollNetStates[i] == flagcxNetStateInit) {
-    int ndev;
-    if (flagcxCollNets[i]->init(flagcxDebugLog) != flagcxSuccess)
-      flagcxCollNetStates[i] = flagcxNetStateDisabled;
-    else if (flagcxCollNets[i]->devices(&ndev) != flagcxSuccess || ndev <= 0)
-      flagcxCollNetStates[i] = flagcxNetStateDisabled;
-    else
-      flagcxCollNetStates[i] = flagcxNetStateEnabled;
-  }
-  *state = flagcxCollNetStates[i];
-  pthread_mutex_unlock(&netLock);
-  return flagcxSuccess;
-}
 
 flagcxResult_t flagcxNetInit(struct flagcxHeteroComm *comm) {
   // Initialize main communication network
@@ -119,16 +101,10 @@ flagcxResult_t flagcxNetInit(struct flagcxHeteroComm *comm) {
       comm->netAdaptor = flagcxNetAdaptors[i];
       ok = true;
 
-      if (flagcxCollNets[i]) {
-        FLAGCXCHECK(collNetGetState(i, &state));
-        if (state == flagcxNetStateEnabled) {
-          comm->flagcxCollNet = flagcxCollNets[i];
-        }
-      }
       break;
     }
   } else {
-    // Normal network selection order (IBRC first, then socket)
+    // Normal network selection order (IBRC/UCX first, then socket)
     for (int i = 0; i < 3; i++) {
       if (flagcxNetAdaptors[i] == nullptr)
         continue;
@@ -146,12 +122,6 @@ flagcxResult_t flagcxNetInit(struct flagcxHeteroComm *comm) {
       comm->netAdaptor = flagcxNetAdaptors[i];
       ok = true;
 
-      if (flagcxCollNets[i]) {
-        FLAGCXCHECK(collNetGetState(i, &state));
-        if (state == flagcxNetStateEnabled) {
-          comm->flagcxCollNet = flagcxCollNets[i];
-        }
-      }
       break;
     }
   }

--- a/flagcx/core/net.cc
+++ b/flagcx/core/net.cc
@@ -69,7 +69,6 @@ static flagcxResult_t netGetState(int i, enum flagcxNetState *state) {
   return flagcxSuccess;
 }
 
-
 flagcxResult_t flagcxNetInit(struct flagcxHeteroComm *comm) {
   // Initialize main communication network
   const char *netName;

--- a/flagcx/core/net.h
+++ b/flagcx/core/net.h
@@ -11,11 +11,13 @@
 #include "comm.h"
 #include "flagcx_net.h"
 #include <socket.h>
+#include "ib_common.h"
 
 typedef char flagcxNetHandle_t[FLAGCX_NET_HANDLE_MAXSIZE];
 
 #define REGMRBUFFERSIZE (64ULL * 1024 * 1024)
 #define CHUNKSIZE (4ULL * 1024 * 1024)
+#define FLAGCX_MAX_NET_SIZE_BYTES (1*1024*1024*1024*1024L)
 #define MAXSTEPS (REGMRBUFFERSIZE / CHUNKSIZE)
 static_assert((MAXSTEPS & (MAXSTEPS - 1)) == 0, "send step must a power of 2");
 
@@ -36,7 +38,6 @@ struct sendNetResources {
   struct flagcxRecvMem *recvMem;
 
   struct flagcxNetAdaptor *netAdaptor;
-  flagcxCollNet_t *flagcxCollNet;
   int tpRank;
   int tpLocalRank;
   int tpRemoteRank;
@@ -68,7 +69,6 @@ struct recvNetResources {
   struct flagcxRecvMem *recvMem;
 
   struct flagcxNetAdaptor *netAdaptor;
-  flagcxCollNet_t *flagcxCollNet;
   int tpRank;
   int tpLocalRank;
   int tpRemoteRank;

--- a/flagcx/core/net.h
+++ b/flagcx/core/net.h
@@ -10,14 +10,14 @@
 #include "check.h"
 #include "comm.h"
 #include "flagcx_net.h"
-#include <socket.h>
 #include "ib_common.h"
+#include <socket.h>
 
 typedef char flagcxNetHandle_t[FLAGCX_NET_HANDLE_MAXSIZE];
 
 #define REGMRBUFFERSIZE (64ULL * 1024 * 1024)
 #define CHUNKSIZE (4ULL * 1024 * 1024)
-#define FLAGCX_MAX_NET_SIZE_BYTES (1*1024*1024*1024*1024L)
+#define FLAGCX_MAX_NET_SIZE_BYTES (1 * 1024 * 1024 * 1024 * 1024L)
 #define MAXSTEPS (REGMRBUFFERSIZE / CHUNKSIZE)
 static_assert((MAXSTEPS & (MAXSTEPS - 1)) == 0, "send step must a power of 2");
 

--- a/flagcx/core/proxy.h
+++ b/flagcx/core/proxy.h
@@ -297,7 +297,6 @@ struct flagcxProxyState {
   bool allocP2pNetLLBuffers;
   bool dmaBufSupport;
   struct flagcxNetAdaptor *netAdaptor;
-  flagcxCollNet_t *flagcxCollNet;
   volatile uint32_t *abortFlag;
   // Service threads
   pthread_t thread;

--- a/flagcx/service/check.h
+++ b/flagcx/service/check.h
@@ -161,4 +161,14 @@
     }                                                                          \
   } while (0)
 
+// Type definitions
+#define PTHREADCHECKGOTO(statement, name, RES, label)                          \
+  do {                                                                         \
+    int retval = (statement);                                                  \
+    if (retval != 0) {                                                         \
+      WARN("Call to " name " failed: %s", strerror(retval));                   \
+      RES = flagcxSystemError;                                                 \
+      goto label;                                                              \
+    }                                                                          \
+  } while (0)
 #endif


### PR DESCRIPTION
- Introduced UCX adaptor in `ucx_adaptor.cc` with necessary functions for initialization, connection, and memory registration.
- Updated `Makefile` to include UCX configuration options.
- Refactored existing IBRC adaptor code to share common structures and constants in `ib_common.h`.
- Modified network initialization to support UCX alongside existing adaptors.
- Removed unused `flagcxCollNet` references from various structures to streamline the codebase.