### PR TITLE
fix compilation issue caused by missing vars definition

### DIFF
--- a/flagcx/adaptor/tuner/default_tuner.cc
+++ b/flagcx/adaptor/tuner/default_tuner.cc
@@ -1,0 +1,5 @@
+#include "tuner/tuner_util.h"
+
+#ifndef USE_NVIDIA_ADAPTOR
+std::vector<EnvVar> vars = {};
+#endif


### PR DESCRIPTION
This PR fixes the compilation issue caused by missing `vars` definition in FlagCX's tuner component. Currently, tuner only works on Nvidia platform, so `vars` is only defined in `nccl_tuner.cc`. This PR adds a `default_tuner.cc` file, which provides a default `vars` definition to avoid undefined symbol error during compilation on other platforms