### PR TITLE
fix vars initialization issue in FlagCX tuner

### DIFF
--- a/flagcx/adaptor/tuner/tuner.cc
+++ b/flagcx/adaptor/tuner/tuner.cc
@@ -1,11 +1,12 @@
 #include "tuner/tuner_util.h"
 
 #ifdef USE_NVIDIA_ADAPTOR
-std::vector<EnvVar> vars = ncclTunerVars;
+std::vector<EnvVar> &vars = ncclTunerVars;
 #elif USE_METAX_ADAPTOR
-std::vector<EnvVar> vars = mcclTunerVars;
+std::vector<EnvVar> &vars = mcclTunerVars;
 #elif USE_KUNLUNXIN_ADAPTOR
-std::vector<EnvVar> vars = xcclTunerVars;
+std::vector<EnvVar> &vars = xcclTunerVars;
 #else
-std::vector<EnvVar> vars = {};
+std::vector<EnvVar> emptyVars = {};
+std::vector<EnvVar> &vars = emptyVars;
 #endif

--- a/flagcx/adaptor/tuner/tuner_util.h
+++ b/flagcx/adaptor/tuner/tuner_util.h
@@ -23,6 +23,6 @@ static void safeStrCopy(char *dst, size_t dstSize, const std::string &src);
 extern std::vector<EnvVar> ncclTunerVars;
 extern std::vector<EnvVar> mcclTunerVars;
 extern std::vector<EnvVar> xcclTunerVars;
-extern std::vector<EnvVar> vars;
+extern std::vector<EnvVar> &vars;
 
 #endif // end include guard


### PR DESCRIPTION
### PR Category
<!-- One of [ UIL (User Interface Layer) | CRL (Communication Runtime Layer) | PAL (Portable Abstraction Layer) | CICD | Others ] -->
PAL
### PR Types
<!-- One of [ New Features | Bug Fixes | Optimizations | Deprecations | Test Case | Docs | Others ] -->
Bug Fixes
### PR Description
<!-- Describe what you’ve done -->
This PR fixes the issue with empty `vars` vector in flagcx tuner. In the current implementation `vars` is initialized via copy by value; for example, `std::vector<EnvVar> vars = xcclTunerVars;`. However, since `xcclTunerVars` is defined in another translation unit, when we do `std::vector<EnvVar> vars = xcclTunerVars;`, `xcclTunerVars` might not be fully initialized yet, causing `vars` to be an empty vector.
The new implementation uses reference to make sure that `vars` has the same content as the underlying tunerVars at runtime.