### PR TITLE
init depbot for GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions-minor:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
### PR Category
CICD

### PR Types
Try to init Depend bot for GHA component version bump up 

### PR Description
Consider CVE-2025-30066 as GHA supply chain attack, at least we need enable Dependency bot to auto bump up version or hint us there is any new version on pipeline component. Start notice and eye on security.