### PR TITLE
[CRL] Fix P2P Zerocopy P2pRmtAddr Calculation Error

### DIFF
--- a/flagcx/core/group.cc
+++ b/flagcx/core/group.cc
@@ -387,7 +387,8 @@ static flagcxResult_t groupLaunch(struct flagcxAsyncJob *job_) {
               // Pass the remote address to sender for zero-copy
               // peerRmtAddr is the remote address itself (cast as uintptr_t*)
               if (op->args.regBufFlag && peerRmtAddr) {
-                op->args.p2pRmtAddr = (void *)((uintptr_t)peerRmtAddr + regOffset);
+                op->args.p2pRmtAddr =
+                    (void *)((uintptr_t)peerRmtAddr + regOffset);
               }
             } else if (op->connection->transport == TRANSPORT_NET) {
               op->args.chunkSize = flagcxNetChunkSize;


### PR DESCRIPTION
### PR Category
CRL
### PR Types
Bug Fixes

### PR Description
regOffset = userbuff - regRecord->addr, so correct peerRmtAddr should use peerRmtAddr + regOffset