### PR TITLE
ensure hipAdaptor match the latest definition of deviceAdaptor

### DIFF
--- a/flagcx/adaptor/device/hip_adaptor.cc
+++ b/flagcx/adaptor/device/hip_adaptor.cc
@@ -320,6 +320,8 @@ struct flagcxDeviceAdaptor hipAdaptor {
       hipAdaptorDeviceMemset, hipAdaptorDeviceMalloc, hipAdaptorDeviceFree,
       hipAdaptorSetDevice, hipAdaptorGetDevice, hipAdaptorGetDeviceCount,
       hipAdaptorGetVendor,
+      NULL, // flagcxResult_t (*hostGetDevicePointer)(void **pDevice, void
+            // *pHost);
       // GDR functions
       NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
       NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
@@ -369,6 +371,8 @@ struct flagcxDeviceAdaptor hipAdaptor {
                                              // *handleOut, void *buffer,
                                              // size_t size, unsigned long long
                                              // flags);
+      NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
+            // start, flagcxEvent_t end);
 };
 
 #endif // USE_AMD_ADAPTOR


### PR DESCRIPTION
### PR Category
<!-- One of [ UIL (User Interface Layer) | CRL (Communication Runtime Layer) | PAL (Portable Abstraction Layer) | CICD | Others ] -->
PAL
### PR Types
<!-- One of [ New Features | Bug Fixes | Optimizations | Deprecations | Test Case | Docs | Others ] -->
Bug Fixes
### PR Description
<!-- Describe what you’ve done -->
The current implementation of hipAdaptor is outdated with regard to the latest deviceAdaptor definition. This PR fixes this issue. This partly fixes issue https://github.com/flagos-ai/FlagCX/issues/348