### PR TITLE
Pin FlagCX workflows to repository runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test-in-container:
-    runs-on: self-hosted
+    runs-on: [self-hosted, cx-build]
     container:
       image:  localhost:5000/flagscale:cuda12.4.1-cudnn9.5.0-python3.12-torch2.6.0-time2505241715
       options: --gpus all --privileged --ipc=host --ulimit memlock=-1 --ulimit stack=67108864

--- a/.github/workflows/torch-api-test.yml
+++ b/.github/workflows/torch-api-test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   torch-api-test:
-    runs-on: self-hosted
+    runs-on: [self-hosted, cx-build]
     container:
       image: localhost:5000/flagscale:cuda12.8.1-cudnn9.7.1-python3.12-torch2.7.0-time2507111538
       #localhost:5000/flagscale:cuda12.4.1-cudnn9.5.0-python3.12-torch2.6.0-time2505241715

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   unit-test:
-    runs-on: self-hosted
+    runs-on: [self-hosted, cx-build]
     container:
       image: localhost:5000/flagscale:cuda12.4.1-cudnn9.5.0-python3.12-torch2.6.0-time2505241715
       options:  --gpus all  --privileged --ipc=host --ulimit memlock=-1 --ulimit stack=67108864


### PR DESCRIPTION
### PR Category

CI/CD

### PR Types

CI/CD

### PR Description

This PR is an attempt to pin the FlagCX specific workflows to the repository runner.
It is a temporary solution to avoid conflicts on the organizational runner, e.g. `h20`.