### PR TITLE
[CRL] Remove redundant initialization

### DIFF
--- a/flagcx/core/flagcx_kernel_host.cc
+++ b/flagcx/core/flagcx_kernel_host.cc
@@ -45,8 +45,8 @@ flagcxResult_t flagcxFifo::flagcxFifoInit() {
 }
 
 flagcxResult_t flagcxFifo::flagcxFifoReset() {
-  INFO(FLAGCX_KERNEL, "flagcxFifoReset called");
-  buffer[flagcxFifoIdxTerminate] = 0;
+  TRACE(FLAGCX_KERNEL, "flagcxFifoReset called");
+  __atomic_store_n(buffer + flagcxFifoIdxTerminate, 0, __ATOMIC_RELEASE);
   return flagcxSuccess;
 }
 

--- a/flagcx/core/flagcx_kernel_host.cc
+++ b/flagcx/core/flagcx_kernel_host.cc
@@ -46,11 +46,7 @@ flagcxResult_t flagcxFifo::flagcxFifoInit() {
 
 flagcxResult_t flagcxFifo::flagcxFifoReset() {
   INFO(FLAGCX_KERNEL, "flagcxFifoReset called");
-  buffer[flagcxFifoIdxConsumed] = 0;
-  buffer[flagcxFifoIdxProduced] = 0;
   buffer[flagcxFifoIdxTerminate] = 0;
-  memset((void *)(buffer + flagcxFifoIdxData), 0,
-         flagcxParamKernelFifoCapacity() * sizeof(flagcxDeviceTrigger));
   return flagcxSuccess;
 }
 

--- a/flagcx/core/flagcx_kernel_host.cc
+++ b/flagcx/core/flagcx_kernel_host.cc
@@ -44,6 +44,16 @@ flagcxResult_t flagcxFifo::flagcxFifoInit() {
   return flagcxSuccess;
 }
 
+flagcxResult_t flagcxFifo::flagcxFifoReset() {
+  INFO(FLAGCX_KERNEL, "flagcxFifoReset called");
+  buffer[flagcxFifoIdxConsumed] = 0;
+  buffer[flagcxFifoIdxProduced] = 0;
+  buffer[flagcxFifoIdxTerminate] = 0;
+  memset((void *)(buffer + flagcxFifoIdxData), 0,
+         flagcxParamKernelFifoCapacity() * sizeof(flagcxDeviceTrigger));
+  return flagcxSuccess;
+}
+
 flagcxResult_t flagcxFifo::flagcxFifoDestroy() {
   INFO(FLAGCX_KERNEL, "flagcxFifoDestroy called");
   FLAGCXCHECK(deviceAdaptor->deviceFree((void *)buffer, flagcxMemHost, NULL));

--- a/flagcx/core/init.cc
+++ b/flagcx/core/init.cc
@@ -15,6 +15,7 @@
 #include "topo.h"
 #include "transport.h"
 #include "type.h"
+#include "uni_runner_impl.h"
 #include "utils.h"
 #include <algorithm>
 #include <string.h>
@@ -359,6 +360,9 @@ static flagcxResult_t flagcxCommInitRankFunc(struct flagcxAsyncJob *job_) {
   INFO(FLAGCX_INIT, "start initTransportsRank");
   FLAGCXCHECKGOTO(initTransportsRank(comm, NULL), res, fail);
 
+  INFO(FLAGCX_INIT, "start initUniRunner");
+  FLAGCXCHECKGOTO(initUniRunner(comm), res, fail);
+
 exit:
   return res;
 fail:
@@ -458,6 +462,8 @@ flagcxResult_t flagcxHeteroCommDestroy(flagcxHeteroComm_t comm) {
   for (int i = 0; i < MAXCHANNELS; i++) {
     free(comm->proxyState->proxyOps[i].consPeers);
   }
+
+  FLAGCXCHECK(cleanupUniRunner(comm));
 
   free(comm->connectSend);
   free(comm->connectRecv);

--- a/flagcx/core/init.cc
+++ b/flagcx/core/init.cc
@@ -15,7 +15,6 @@
 #include "topo.h"
 #include "transport.h"
 #include "type.h"
-#include "uni_runner_impl.h"
 #include "utils.h"
 #include <algorithm>
 #include <string.h>
@@ -360,9 +359,6 @@ static flagcxResult_t flagcxCommInitRankFunc(struct flagcxAsyncJob *job_) {
   INFO(FLAGCX_INIT, "start initTransportsRank");
   FLAGCXCHECKGOTO(initTransportsRank(comm, NULL), res, fail);
 
-  INFO(FLAGCX_INIT, "start initUniRunner");
-  FLAGCXCHECKGOTO(initUniRunner(comm), res, fail);
-
 exit:
   return res;
 fail:
@@ -462,8 +458,6 @@ flagcxResult_t flagcxHeteroCommDestroy(flagcxHeteroComm_t comm) {
   for (int i = 0; i < MAXCHANNELS; i++) {
     free(comm->proxyState->proxyOps[i].consPeers);
   }
-
-  FLAGCXCHECK(cleanupUniRunner(comm));
 
   free(comm->connectSend);
   free(comm->connectRecv);

--- a/flagcx/include/flagcx_kernel.h
+++ b/flagcx/include/flagcx_kernel.h
@@ -118,6 +118,7 @@ public:
   ~flagcxFifo() {}
   flagcxResult_t flagcxFifoInit();
   flagcxResult_t flagcxRedFifoInit();
+  flagcxResult_t flagcxFifoReset();
   flagcxResult_t flagcxFifoDestroy();
   flagcxResult_t flagcxRedFifoDestroy();
 };

--- a/flagcx/runner/include/uni_runner_impl.h
+++ b/flagcx/runner/include/uni_runner_impl.h
@@ -101,6 +101,8 @@ typedef struct {
   void markInUse(int index);
   // Mark event at index as available
   void markAvailable(int index);
+  // Reset all events to available
+  void reset();
 } uniRunnerP2pEventBitmap;
 
 typedef struct {

--- a/flagcx/runner/include/uni_runner_impl.h
+++ b/flagcx/runner/include/uni_runner_impl.h
@@ -106,7 +106,6 @@ typedef struct {
 typedef struct {
   pthread_t thread;
   flagcxFifo_t fifo;
-  flagcxStream_t commStream;
   flagcxStream_t redStream;
   flagcxStream_t cpyStream;
 
@@ -143,32 +142,37 @@ flagcxResult_t initUniRunnerStateDummy(flagcxUniRunnerState *runnerState);
 flagcxResult_t initUniRunnerStateLocRed(flagcxUniRunnerState *runnerState,
                                         const void *sendbuff, void *recvbuff,
                                         size_t count, flagcxDataType_t datatype,
-                                        flagcxRedOp_t op, flagcxComm_t comm);
+                                        flagcxRedOp_t op,
+                                        flagcxHeteroComm_t comm);
 flagcxResult_t initUniRunnerStateRingAG(flagcxUniRunnerState *runnerState,
                                         const void *sendbuff, void *recvbuff,
                                         size_t count, flagcxDataType_t datatype,
-                                        flagcxRedOp_t op, flagcxComm_t comm);
+                                        flagcxRedOp_t op,
+                                        flagcxHeteroComm_t comm);
 flagcxResult_t initUniRunnerStateRingAR(flagcxUniRunnerState *runnerState,
                                         const void *sendbuff, void *recvbuff,
                                         size_t count, flagcxDataType_t datatype,
-                                        flagcxRedOp_t op, flagcxComm_t comm);
+                                        flagcxRedOp_t op,
+                                        flagcxHeteroComm_t comm);
 flagcxResult_t initUniRunnerStateSlicedAR(flagcxUniRunnerState *runnerState,
                                           const void *sendbuff, void *recvbuff,
                                           size_t count,
                                           flagcxDataType_t datatype,
-                                          flagcxRedOp_t op, flagcxComm_t comm);
+                                          flagcxRedOp_t op,
+                                          flagcxHeteroComm_t comm);
 flagcxResult_t initUniRunnerStateRingRS(flagcxUniRunnerState *runnerState,
                                         const void *sendbuff, void *recvbuff,
                                         void *scratchbuff, size_t count,
                                         flagcxDataType_t datatype,
-                                        flagcxRedOp_t op, flagcxComm_t comm);
+                                        flagcxRedOp_t op,
+                                        flagcxHeteroComm_t comm);
 flagcxResult_t initUniRunnerStateTreeRed(flagcxUniRunnerState *runnerState,
                                          const void *sendbuff, void *recvbuff,
                                          void *scratchbuff, size_t count,
                                          flagcxDataType_t datatype,
                                          flagcxRedOp_t op, int root,
-                                         flagcxComm_t comm);
-flagcxResult_t initUniRunner(flagcxComm_t comm, flagcxStream_t stream);
-flagcxResult_t cleanupUniRunner(flagcxComm_t comm);
-flagcxResult_t runUniRunner(flagcxComm_t comm);
+                                         flagcxHeteroComm_t comm);
+flagcxResult_t initUniRunner(flagcxHeteroComm_t comm);
+flagcxResult_t cleanupUniRunner(flagcxHeteroComm_t comm);
+flagcxResult_t runUniRunner(flagcxHeteroComm_t comm, flagcxStream_t stream);
 #endif // FLAGCX_UNIRUNNER_IMPL_H_

--- a/flagcx/runner/uni_runner.cc
+++ b/flagcx/runner/uni_runner.cc
@@ -22,6 +22,7 @@ flagcxResult_t uniRunnerReduce(const void *sendbuff, void *recvbuff,
   FLAGCXCHECK(deviceAdaptor->deviceMalloc(
       &scratchbuff, 2 * count * getFlagcxDataTypeSize(datatype),
       flagcxMemDevice, stream));
+  FLAGCXCHECKGOTO(initUniRunner(hcomm), res, out);
   FLAGCXCHECKGOTO(initUniRunnerStateTreeRed(runnerState, sendbuff, recvbuff,
                                             scratchbuff, count, datatype, op,
                                             root, hcomm),
@@ -29,6 +30,7 @@ flagcxResult_t uniRunnerReduce(const void *sendbuff, void *recvbuff,
   FLAGCXCHECKGOTO(runUniRunner(hcomm, stream), res, out);
 out:
   FLAGCXCHECK(deviceAdaptor->deviceFree(scratchbuff, flagcxMemDevice, stream));
+  FLAGCXCHECK(cleanupUniRunner(hcomm));
   return res;
 }
 
@@ -98,6 +100,7 @@ flagcxResult_t uniRunnerAllReduce(const void *sendbuff, void *recvbuff,
   flagcxResult_t res = flagcxSuccess;
   flagcxHeteroComm_t hcomm = comm->heteroComm;
   flagcxUniRunnerState *runnerState = &hcomm->proxyState->uniRunnerState;
+  FLAGCXCHECK(initUniRunner(hcomm));
   if (flagcxParamUniRunnerUseLocRed()) {
     /* initialize uniRunnerState for reduce test */
     FLAGCXCHECKGOTO(initUniRunnerStateLocRed(runnerState, sendbuff, recvbuff,
@@ -121,6 +124,7 @@ flagcxResult_t uniRunnerAllReduce(const void *sendbuff, void *recvbuff,
   }
   FLAGCXCHECK(runUniRunner(hcomm, stream));
 out:
+  FLAGCXCHECK(cleanupUniRunner(hcomm));
   return res;
 }
 
@@ -136,6 +140,7 @@ flagcxResult_t uniRunnerReduceScatter(const void *sendbuff, void *recvbuff,
   FLAGCXCHECK(deviceAdaptor->deviceMalloc(
       &scratchbuff, recvcount * comm->nranks * getFlagcxDataTypeSize(datatype),
       flagcxMemDevice, stream));
+  FLAGCXCHECKGOTO(initUniRunner(hcomm), res, out);
   FLAGCXCHECKGOTO(initUniRunnerStateRingRS(runnerState, sendbuff, recvbuff,
                                            scratchbuff, recvcount, datatype, op,
                                            hcomm),
@@ -143,6 +148,7 @@ flagcxResult_t uniRunnerReduceScatter(const void *sendbuff, void *recvbuff,
   FLAGCXCHECKGOTO(runUniRunner(hcomm, stream), res, out);
 out:
   FLAGCXCHECK(deviceAdaptor->deviceFree(scratchbuff, flagcxMemDevice, stream));
+  FLAGCXCHECK(cleanupUniRunner(hcomm));
   return res;
 }
 

--- a/flagcx/runner/uni_runner.cc
+++ b/flagcx/runner/uni_runner.cc
@@ -22,15 +22,13 @@ flagcxResult_t uniRunnerReduce(const void *sendbuff, void *recvbuff,
   FLAGCXCHECK(deviceAdaptor->deviceMalloc(
       &scratchbuff, 2 * count * getFlagcxDataTypeSize(datatype),
       flagcxMemDevice, stream));
-  FLAGCXCHECKGOTO(initUniRunner(comm, stream), res, out);
   FLAGCXCHECKGOTO(initUniRunnerStateTreeRed(runnerState, sendbuff, recvbuff,
                                             scratchbuff, count, datatype, op,
-                                            root, comm),
+                                            root, hcomm),
                   res, out);
-  FLAGCXCHECKGOTO(runUniRunner(comm), res, out);
+  FLAGCXCHECKGOTO(runUniRunner(hcomm, stream), res, out);
 out:
   FLAGCXCHECK(deviceAdaptor->deviceFree(scratchbuff, flagcxMemDevice, stream));
-  FLAGCXCHECK(cleanupUniRunner(comm));
   return res;
 }
 
@@ -100,31 +98,29 @@ flagcxResult_t uniRunnerAllReduce(const void *sendbuff, void *recvbuff,
   flagcxResult_t res = flagcxSuccess;
   flagcxHeteroComm_t hcomm = comm->heteroComm;
   flagcxUniRunnerState *runnerState = &hcomm->proxyState->uniRunnerState;
-  FLAGCXCHECK(initUniRunner(comm, stream));
   if (flagcxParamUniRunnerUseLocRed()) {
     /* initialize uniRunnerState for reduce test */
     FLAGCXCHECKGOTO(initUniRunnerStateLocRed(runnerState, sendbuff, recvbuff,
-                                             count, datatype, op, comm),
+                                             count, datatype, op, hcomm),
                     res, out);
   } else if (flagcxParamUniRunnerUseRingAG()) {
     /* initialize uniRunnerState for p2p test */
     FLAGCXCHECKGOTO(initUniRunnerStateRingAG(runnerState, sendbuff, recvbuff,
-                                             count, datatype, op, comm),
+                                             count, datatype, op, hcomm),
                     res, out);
   } else if (flagcxParamUniRunnerUseSlicedAR()) {
     /* initialize uniRunnerState for sliced AllReduce */
     FLAGCXCHECKGOTO(initUniRunnerStateSlicedAR(runnerState, sendbuff, recvbuff,
-                                               count, datatype, op, comm),
+                                               count, datatype, op, hcomm),
                     res, out);
   } else {
     /* initialize uniRunnerState for ring AllReduce */
     FLAGCXCHECKGOTO(initUniRunnerStateRingAR(runnerState, sendbuff, recvbuff,
-                                             count, datatype, op, comm),
+                                             count, datatype, op, hcomm),
                     res, out);
   }
-  FLAGCXCHECK(runUniRunner(comm));
+  FLAGCXCHECK(runUniRunner(hcomm, stream));
 out:
-  FLAGCXCHECK(cleanupUniRunner(comm));
   return res;
 }
 
@@ -140,15 +136,13 @@ flagcxResult_t uniRunnerReduceScatter(const void *sendbuff, void *recvbuff,
   FLAGCXCHECK(deviceAdaptor->deviceMalloc(
       &scratchbuff, recvcount * comm->nranks * getFlagcxDataTypeSize(datatype),
       flagcxMemDevice, stream));
-  FLAGCXCHECKGOTO(initUniRunner(comm, stream), res, out);
   FLAGCXCHECKGOTO(initUniRunnerStateRingRS(runnerState, sendbuff, recvbuff,
                                            scratchbuff, recvcount, datatype, op,
-                                           comm),
+                                           hcomm),
                   res, out);
-  FLAGCXCHECKGOTO(runUniRunner(comm), res, out);
+  FLAGCXCHECKGOTO(runUniRunner(hcomm, stream), res, out);
 out:
   FLAGCXCHECK(deviceAdaptor->deviceFree(scratchbuff, flagcxMemDevice, stream));
-  FLAGCXCHECK(cleanupUniRunner(comm));
   return res;
 }
 

--- a/flagcx/runner/uni_runner_impl.cc
+++ b/flagcx/runner/uni_runner_impl.cc
@@ -82,9 +82,10 @@ flagcxResult_t initUniRunnerStateDummy(flagcxUniRunnerState *runnerState) {
 flagcxResult_t initUniRunnerStateLocRed(flagcxUniRunnerState *runnerState,
                                         const void *sendbuff, void *recvbuff,
                                         size_t count, flagcxDataType_t datatype,
-                                        flagcxRedOp_t op, flagcxComm_t comm) {
+                                        flagcxRedOp_t op,
+                                        flagcxHeteroComm_t comm) {
   int rank = comm->rank;
-  int nranks = comm->nranks;
+  int nranks = comm->nRanks;
   int numSlices = runnerState->uniRunnerNSlices;
 
   if (nranks < 2) {
@@ -93,7 +94,7 @@ flagcxResult_t initUniRunnerStateLocRed(flagcxUniRunnerState *runnerState,
 
   TRACE(FLAGCX_UNIRUNNER,
         "rank %d initUniRunnerStateLocRed called, count=%lu, numSlices=%d",
-        comm->rank, count, numSlices);
+        rank, count, numSlices);
 
   size_t typeSize = getFlagcxDataTypeSize(datatype);
 
@@ -159,9 +160,10 @@ flagcxResult_t initUniRunnerStateLocRed(flagcxUniRunnerState *runnerState,
 flagcxResult_t initUniRunnerStateRingAG(flagcxUniRunnerState *runnerState,
                                         const void *sendbuff, void *recvbuff,
                                         size_t count, flagcxDataType_t datatype,
-                                        flagcxRedOp_t op, flagcxComm_t comm) {
+                                        flagcxRedOp_t op,
+                                        flagcxHeteroComm_t comm) {
   int rank = comm->rank;
-  int nranks = comm->nranks;
+  int nranks = comm->nRanks;
   int numSlices = runnerState->uniRunnerNSlices;
 
   if (nranks < 1) {
@@ -190,8 +192,8 @@ flagcxResult_t initUniRunnerStateRingAG(flagcxUniRunnerState *runnerState,
   }
 
   TRACE(FLAGCX_UNIRUNNER,
-        "rank %d initUniRunnerStateP2p called, count=%lu, numSlices=%d",
-        comm->rank, count, numSlices);
+        "rank %d initUniRunnerStateP2p called, count=%lu, numSlices=%d", rank,
+        count, numSlices);
 
   int nextRank = (rank + 1) % nranks;
   int prevRank = (rank - 1 + nranks) % nranks;
@@ -349,9 +351,10 @@ flagcxResult_t initUniRunnerStateRingAG(flagcxUniRunnerState *runnerState,
 flagcxResult_t initUniRunnerStateRingAR(flagcxUniRunnerState *runnerState,
                                         const void *sendbuff, void *recvbuff,
                                         size_t count, flagcxDataType_t datatype,
-                                        flagcxRedOp_t op, flagcxComm_t comm) {
+                                        flagcxRedOp_t op,
+                                        flagcxHeteroComm_t comm) {
   int rank = comm->rank;
-  int nranks = comm->nranks;
+  int nranks = comm->nRanks;
   int numSlices = runnerState->uniRunnerNSlices;
 
   if (nranks < 1) {
@@ -381,7 +384,7 @@ flagcxResult_t initUniRunnerStateRingAR(flagcxUniRunnerState *runnerState,
 
   TRACE(FLAGCX_UNIRUNNER,
         "rank %d initUniRunnerStateRingAR called, count=%lu, numSlices=%d",
-        comm->rank, count, numSlices);
+        rank, count, numSlices);
 
   int nextRank = (rank + 1) % nranks;
   int prevRank = (rank - 1 + nranks) % nranks;
@@ -662,9 +665,10 @@ flagcxResult_t initUniRunnerStateSlicedAR(flagcxUniRunnerState *runnerState,
                                           const void *sendbuff, void *recvbuff,
                                           size_t count,
                                           flagcxDataType_t datatype,
-                                          flagcxRedOp_t op, flagcxComm_t comm) {
+                                          flagcxRedOp_t op,
+                                          flagcxHeteroComm_t comm) {
   int rank = comm->rank;
-  int nranks = comm->nranks;
+  int nranks = comm->nRanks;
 
   if (nranks < 1) {
     return flagcxInvalidArgument;
@@ -696,7 +700,7 @@ flagcxResult_t initUniRunnerStateSlicedAR(flagcxUniRunnerState *runnerState,
       runnerState->uniRunnerNRedSlices = 1;
     } else {
       runnerState->uniRunnerNRedSlices =
-          ceil((float)count / comm->nranks / runnerState->uniRunnerNSlices /
+          ceil((float)count / nranks / runnerState->uniRunnerNSlices /
                runnerState->uniRunnerRedSliceSize);
     }
     TRACE(FLAGCX_UNIRUNNER, "uniRunnerNRedSlices auto set to %lu",
@@ -708,7 +712,7 @@ flagcxResult_t initUniRunnerStateSlicedAR(flagcxUniRunnerState *runnerState,
   TRACE(FLAGCX_UNIRUNNER,
         "rank %d initUniRunnerStateSlicedAR called, count=%lu, numSlices=%d, "
         "numRedSlices=%d",
-        comm->rank, count, numSlices, numRedSlices);
+        rank, count, numSlices, numRedSlices);
 
   int nextRank = (rank + 1) % nranks;
   int prevRank = (rank - 1 + nranks) % nranks;
@@ -1010,9 +1014,10 @@ flagcxResult_t initUniRunnerStateRingRS(flagcxUniRunnerState *runnerState,
                                         const void *sendbuff, void *recvbuff,
                                         void *scratchbuff, size_t count,
                                         flagcxDataType_t datatype,
-                                        flagcxRedOp_t op, flagcxComm_t comm) {
+                                        flagcxRedOp_t op,
+                                        flagcxHeteroComm_t comm) {
   int rank = comm->rank;
-  int nranks = comm->nranks;
+  int nranks = comm->nRanks;
 
   if (nranks < 1) {
     return flagcxInvalidArgument;
@@ -1044,7 +1049,7 @@ flagcxResult_t initUniRunnerStateRingRS(flagcxUniRunnerState *runnerState,
       runnerState->uniRunnerNRedSlices = 1;
     } else {
       runnerState->uniRunnerNRedSlices =
-          ceil((float)count / comm->nranks / runnerState->uniRunnerNSlices /
+          ceil((float)count / nranks / runnerState->uniRunnerNSlices /
                runnerState->uniRunnerRedSliceSize);
     }
     TRACE(FLAGCX_UNIRUNNER, "uniRunnerNRedSlices auto set to %lu",
@@ -1056,7 +1061,7 @@ flagcxResult_t initUniRunnerStateRingRS(flagcxUniRunnerState *runnerState,
   TRACE(FLAGCX_UNIRUNNER,
         "rank %d initUniRunnerStateRingRS called, recvcount=%lu, numSlices=%d, "
         "numRedSlices=%d",
-        comm->rank, count, numSlices, numRedSlices);
+        rank, count, numSlices, numRedSlices);
 
   int nextRank = (rank + 1) % nranks;
   int prevRank = (rank - 1 + nranks) % nranks;
@@ -1268,9 +1273,9 @@ flagcxResult_t initUniRunnerStateTreeRed(flagcxUniRunnerState *runnerState,
                                          void *scratchbuff, size_t count,
                                          flagcxDataType_t datatype,
                                          flagcxRedOp_t op, int root,
-                                         flagcxComm_t comm) {
+                                         flagcxHeteroComm_t comm) {
   int rank = comm->rank;
-  int nranks = comm->nranks;
+  int nranks = comm->nRanks;
   int algoRank = (rank - root + nranks) % nranks; // Rotate ranks so root is 0
 
   if (nranks < 1) {
@@ -1303,7 +1308,7 @@ flagcxResult_t initUniRunnerStateTreeRed(flagcxUniRunnerState *runnerState,
       runnerState->uniRunnerNRedSlices = 1;
     } else {
       runnerState->uniRunnerNRedSlices =
-          ceil((float)count / comm->nranks / runnerState->uniRunnerNSlices /
+          ceil((float)count / nranks / runnerState->uniRunnerNSlices /
                runnerState->uniRunnerRedSliceSize);
     }
     TRACE(FLAGCX_UNIRUNNER, "uniRunnerNRedSlices auto set to %lu",
@@ -1336,7 +1341,7 @@ flagcxResult_t initUniRunnerStateTreeRed(flagcxUniRunnerState *runnerState,
   TRACE(FLAGCX_UNIRUNNER,
         "rank %d (algoRank %d) initUniRunnerStateTreeReduce called, count=%lu, "
         "numSlices=%d, numRedSlices=%d, recvSteps %d, sendSteps %d",
-        comm->rank, algoRank, count, numSlices, numRedSlices, recvNodesPerSlice,
+        rank, algoRank, count, numSlices, numRedSlices, recvNodesPerSlice,
         sendNodesPerSlice);
 
   runnerState->numDagNodes = numNodes;
@@ -1612,7 +1617,8 @@ static flagcxResult_t cleanupP2pEvents(flagcxUniRunnerState *runnerState) {
 }
 
 static flagcxResult_t launchP2pOps(flagcxUniRunnerState *runnerState,
-                                   flagcxHeteroComm_t comm, int eventIdx) {
+                                   flagcxHeteroComm_t comm, int eventIdx,
+                                   flagcxStream_t stream) {
   // Dequeue
   uniRunnerDagNode *current =
       flagcxIntruQueueDequeue(&runnerState->p2pReadyQueue);
@@ -1630,20 +1636,18 @@ static flagcxResult_t launchP2pOps(flagcxUniRunnerState *runnerState,
       struct uniRunnerP2pOpData *op = &ops[i];
       if (op->type == flagcxDevicePrimSend) {
         FLAGCXCHECK(flagcxHeteroSend(op->addr, op->count, op->datatype,
-                                     op->peerRank, comm,
-                                     runnerState->commStream));
+                                     op->peerRank, comm, stream));
       } else if (op->type == flagcxDevicePrimRecv) {
         FLAGCXCHECK(flagcxHeteroRecv(op->addr, op->count, op->datatype,
-                                     op->peerRank, comm,
-                                     runnerState->commStream));
+                                     op->peerRank, comm, stream));
       }
     }
     FLAGCXCHECK(flagcxHeteroGroupEnd());
 
     // Record event
-    FLAGCXCHECK(deviceAdaptor->eventRecord(event, runnerState->commStream));
+    FLAGCXCHECK(deviceAdaptor->eventRecord(event, stream));
     TRACE(FLAGCX_UNIRUNNER, "rank %d p2p event %d recorded on stream 0x%016lx",
-          comm->rank, eventIdx, (uintptr_t)runnerState->commStream);
+          comm->rank, eventIdx, (uintptr_t)stream);
 
     current->nodeData.p2p.eventIdx = eventIdx;
   } else if (current->nodeType == uniRunnerDagNodeTypeCpy) {
@@ -1687,7 +1691,8 @@ static flagcxResult_t enqueueReadyQueue(flagcxUniRunnerState *runnerState,
 
 // Process ready queue: write triggers to FIFO and move to inflight
 static flagcxResult_t processReadyQueue(flagcxUniRunnerState *runnerState,
-                                        flagcxHeteroComm_t comm) {
+                                        flagcxHeteroComm_t comm,
+                                        flagcxStream_t stream) {
   // process p2pReadyQueue
   while (!flagcxIntruQueueEmpty(&runnerState->p2pReadyQueue)) {
     int eventIdx = runnerState->getEvent();
@@ -1695,7 +1700,7 @@ static flagcxResult_t processReadyQueue(flagcxUniRunnerState *runnerState,
       sched_yield();
       break; // No available event, skip for now
     }
-    FLAGCXCHECK(launchP2pOps(runnerState, comm, eventIdx));
+    FLAGCXCHECK(launchP2pOps(runnerState, comm, eventIdx, stream));
   }
 
   // process redReadyQueue
@@ -1793,9 +1798,8 @@ static flagcxResult_t processInflightQueue(flagcxUniRunnerState *runnerState) {
   return flagcxSuccess;
 }
 
-flagcxResult_t initUniRunner(flagcxComm_t comm, flagcxStream_t stream) {
-  flagcxHeteroComm_t hcomm = comm->heteroComm;
-  flagcxUniRunnerState *runnerState = &hcomm->proxyState->uniRunnerState;
+flagcxResult_t initUniRunner(flagcxHeteroComm_t comm) {
+  flagcxUniRunnerState *runnerState = &comm->proxyState->uniRunnerState;
 
   runnerState->p2pEventPoolSize = flagcxParamP2pEventPoolSize();
   runnerState->uniRunnerNSlices = flagcxParamUniRunnerNSlices();
@@ -1805,15 +1809,15 @@ flagcxResult_t initUniRunner(flagcxComm_t comm, flagcxStream_t stream) {
   runnerState->uniRunnerRedSliceSize = flagcxParamUniRunnerRedSliceSize();
 
   // Set device context
-  FLAGCXCHECK(deviceAdaptor->setDevice(hcomm->cudaDev));
+  FLAGCXCHECK(deviceAdaptor->setDevice(comm->cudaDev));
 
   // Create FIFO
   runnerState->fifo = new flagcxFifo();
   FLAGCXCHECK(runnerState->fifo->flagcxRedFifoInit());
-  // hcomm->proxyState->uniRunnerState.fifo->buffer is the host pointer
-  // hcomm->uniRunnerFifoBuffer stores the device pointer to fifo buffer
+  // comm->proxyState->uniRunnerState.fifo->buffer is the host pointer
+  // comm->uniRunnerFifoBuffer stores the device pointer to fifo buffer
   FLAGCXCHECK(deviceAdaptor->hostGetDevicePointer(
-      &hcomm->uniRunnerFifoBuffer, (void *)runnerState->fifo->buffer));
+      &comm->uniRunnerFifoBuffer, (void *)runnerState->fifo->buffer));
 
   // Initialize queues
   flagcxIntruQueueConstruct(&runnerState->p2pReadyQueue);
@@ -1832,20 +1836,18 @@ flagcxResult_t initUniRunner(flagcxComm_t comm, flagcxStream_t stream) {
   FLAGCXCHECK(deviceAdaptor->streamCreate(&cpyStream));
   runnerState->redStream = redStream;
   runnerState->cpyStream = cpyStream;
-  runnerState->commStream = stream;
 
   return flagcxSuccess;
 }
 
-flagcxResult_t cleanupUniRunner(flagcxComm_t comm) {
-  flagcxHeteroComm_t hcomm = comm->heteroComm;
-  flagcxStream_t redStream = hcomm->proxyState->uniRunnerState.redStream;
-  flagcxStream_t cpyStream = hcomm->proxyState->uniRunnerState.cpyStream;
+flagcxResult_t cleanupUniRunner(flagcxHeteroComm_t comm) {
+  flagcxStream_t redStream = comm->proxyState->uniRunnerState.redStream;
+  flagcxStream_t cpyStream = comm->proxyState->uniRunnerState.cpyStream;
 
   // Clean up DAG scheduler
-  FLAGCXCHECK(cleanupDagScheduler(&hcomm->proxyState->uniRunnerState));
+  FLAGCXCHECK(cleanupDagScheduler(&comm->proxyState->uniRunnerState));
   // Clean up P2P events
-  FLAGCXCHECK(cleanupP2pEvents(&hcomm->proxyState->uniRunnerState));
+  FLAGCXCHECK(cleanupP2pEvents(&comm->proxyState->uniRunnerState));
 
   // Destroy streams
   FLAGCXCHECK(deviceAdaptor->streamSynchronize(redStream));
@@ -1854,23 +1856,22 @@ flagcxResult_t cleanupUniRunner(flagcxComm_t comm) {
   FLAGCXCHECK(deviceAdaptor->streamDestroy(cpyStream));
 
   // Destroy fifo
-  FLAGCXCHECK(hcomm->proxyState->uniRunnerState.fifo->flagcxRedFifoDestroy());
-  delete hcomm->proxyState->uniRunnerState.fifo;
-  hcomm->uniRunnerFifoBuffer = NULL;
+  FLAGCXCHECK(comm->proxyState->uniRunnerState.fifo->flagcxRedFifoDestroy());
+  delete comm->proxyState->uniRunnerState.fifo;
+  comm->uniRunnerFifoBuffer = NULL;
 
   return flagcxSuccess;
 }
 
-flagcxResult_t runUniRunner(flagcxComm_t comm) {
-  flagcxHeteroComm_t hcomm = comm->heteroComm;
-  flagcxFifo_t fifo = hcomm->proxyState->uniRunnerState.fifo;
-  flagcxUniRunnerState *runnerState = &hcomm->proxyState->uniRunnerState;
+flagcxResult_t runUniRunner(flagcxHeteroComm_t comm, flagcxStream_t stream) {
+  flagcxFifo_t fifo = comm->proxyState->uniRunnerState.fifo;
+  flagcxUniRunnerState *runnerState = &comm->proxyState->uniRunnerState;
   TRACE(FLAGCX_UNIRUNNER, "runUniRunner called");
 
 #ifdef COMPILE_KERNEL_HOST
   // Launch collective kernel
   flagcxLaunchCollectiveKernel(
-      hcomm->uniRunnerFifoBuffer, runnerState->uniRunnerNThreads,
+      comm->uniRunnerFifoBuffer, runnerState->uniRunnerNThreads,
       runnerState->uniRunnerNBlocks, runnerState->redStream);
 #endif
 
@@ -1891,14 +1892,14 @@ flagcxResult_t runUniRunner(flagcxComm_t comm) {
     }
 
     // Step 1: Process ready queue - write triggers to FIFO
-    FLAGCXCHECK(processReadyQueue(runnerState, hcomm));
+    FLAGCXCHECK(processReadyQueue(runnerState, comm, stream));
 
     // Step 2: Process inflight queue - check completion and update dependencies
     FLAGCXCHECK(processInflightQueue(runnerState));
   }
   deviceAdaptor->streamSynchronize(runnerState->redStream);
   deviceAdaptor->streamSynchronize(runnerState->cpyStream);
-  deviceAdaptor->streamSynchronize(runnerState->commStream);
+  deviceAdaptor->streamSynchronize(stream);
 
   return flagcxSuccess;
 }

--- a/flagcx/runner/uni_runner_impl.cc
+++ b/flagcx/runner/uni_runner_impl.cc
@@ -1875,7 +1875,6 @@ flagcxResult_t runUniRunner(flagcxHeteroComm_t comm, flagcxStream_t stream) {
   TRACE(FLAGCX_UNIRUNNER, "runUniRunner called");
 
   fifo->flagcxFifoReset();
-  runnerState->p2pEventMap.reset();
 
 #ifdef COMPILE_KERNEL_HOST
   // Launch collective kernel

--- a/flagcx/runner/uni_runner_impl.cc
+++ b/flagcx/runner/uni_runner_impl.cc
@@ -60,6 +60,12 @@ void uniRunnerP2pEventBitmap::markAvailable(int index) {
   bits[wordIdx] &= ~(1ULL << bitIdx);
 }
 
+// Reset all events to available
+void uniRunnerP2pEventBitmap::reset() {
+  memset(bits, 0, (size + 63) / 64 * sizeof(uint64_t));
+  nextIdx = 0;
+}
+
 int flagcxUniRunnerState::getEvent() {
   int idx = p2pEventMap.getAvailable();
   if (idx != -1) {
@@ -1867,6 +1873,9 @@ flagcxResult_t runUniRunner(flagcxHeteroComm_t comm, flagcxStream_t stream) {
   flagcxFifo_t fifo = comm->proxyState->uniRunnerState.fifo;
   flagcxUniRunnerState *runnerState = &comm->proxyState->uniRunnerState;
   TRACE(FLAGCX_UNIRUNNER, "runUniRunner called");
+
+  fifo->flagcxFifoReset();
+  runnerState->p2pEventMap.reset();
 
 #ifdef COMPILE_KERNEL_HOST
   // Launch collective kernel

--- a/flagcx/runner/uni_runner_impl.cc
+++ b/flagcx/runner/uni_runner_impl.cc
@@ -1874,8 +1874,6 @@ flagcxResult_t runUniRunner(flagcxHeteroComm_t comm, flagcxStream_t stream) {
   flagcxUniRunnerState *runnerState = &comm->proxyState->uniRunnerState;
   TRACE(FLAGCX_UNIRUNNER, "runUniRunner called");
 
-  fifo->flagcxFifoReset();
-
 #ifdef COMPILE_KERNEL_HOST
   // Launch collective kernel
   flagcxLaunchCollectiveKernel(


### PR DESCRIPTION
### PR Category
<!-- One of [ UIL (User Interface Layer) | CRL (Communication Runtime Layer) | PAL (Portable Abstraction Layer) | CICD | Others ] -->

CRL

### PR Types
<!-- One of [ New Features | Bug Fixes | Optimizations | Deprecations | Test Case | Docs | Others ] -->

Optimizations

### PR Description
<!-- Describe what you’ve done -->

* Move the uniRunner initialization and clean-up outside of the collective algorithm init function to eliminate re-initialization overhead.
* Other minor uniRunner function refactor.