### PR TITLE
[CRL] Align one-sided RMA with NCCL: chained put+signal

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -57,7 +57,7 @@ This document provides a comprehensive reference for all environment variables u
 | `FLAGCX_KERNEL_FIFO_CAPACITY` | Default | Kernel FIFO capacity |
 | `FLAGCX_REDUCE_FIFO_CAPACITY` | Default | Reduce operation FIFO capacity |
 | `FLAGCX_DMABUF_ENABLE` | 0 | When set to 1, enables DMA-BUF support for memory registration |
-| `FLAGCX_ENABLE_ONE_SIDE_REGISTER` | 0 | When set to 1, enables one-sided memory registration |
+
 
 ---
 

--- a/flagcx/adaptor/device/cann_adaptor.cc
+++ b/flagcx/adaptor/device/cann_adaptor.cc
@@ -254,58 +254,80 @@ flagcxResult_t cannAdaptorLaunchHostFunc(flagcxStream_t stream,
   return flagcxSuccess;
 }
 
-struct flagcxDeviceAdaptor cannAdaptor {
-  "CANN",
-      // Basic functions
-      cannAdaptorDeviceSynchronize, cannAdaptorDeviceMemcpy,
-      cannAdaptorDeviceMemset, cannAdaptorDeviceMalloc, cannAdaptorDeviceFree,
-      cannAdaptorSetDevice, cannAdaptorGetDevice, cannAdaptorGetDeviceCount,
-      cannAdaptorGetVendor, NULL,
-      // GDR functions
-      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-      cannAdaptorGdrMemAlloc, cannAdaptorGdrMemFree,
-      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-            // *memHandle);
-      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-            // sz);
-      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-      // Stream functions
-      cannAdaptorStreamCreate, cannAdaptorStreamDestroy, cannAdaptorStreamCopy,
-      cannAdaptorStreamFree, cannAdaptorStreamSynchronize,
-      cannAdaptorStreamQuery, cannAdaptorStreamWaitEvent,
-      // Event functions
-      cannAdaptorEventCreate, cannAdaptorEventDestroy, cannAdaptorEventRecord,
-      cannAdaptorEventSynchronize, cannAdaptorEventQuery,
-      // IpcMemHandle functions
-      cannAdaptorIpcMemHandleCreate, cannAdaptorIpcMemHandleGet,
-      cannAdaptorIpcMemHandleOpen, cannAdaptorIpcMemHandleClose,
-      cannAdaptorIpcMemHandleFree,
-      // Kernel launch
-      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-            // share_mem, void *stream, void *memHandle);
-      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-      NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream, void
-            // *args);
-      // Others
-      NULL, // flagcxResult_t (*getDeviceProperties)(struct flagcxDevProps
-            // *props, int dev);
-      NULL, // flagcxResult_t (*getDevicePciBusId)(char
-            // *pciBusId, int len, int dev);
-      NULL, // flagcxResult_t
-            // (*getDeviceByPciBusId)(int
-            // *dev, const char *pciBusId);
-      cannAdaptorLaunchHostFunc,
-      // DMA buffer
-      NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-            // void *buffer, size_t size, unsigned long long flags);
-      NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
-            // start, flagcxEvent_t end);
+static flagcxResult_t cannAdaptorStreamWaitValue64(flagcxStream_t, void *,
+                                                   uint64_t, int) {
+  return flagcxNotSupported;
+}
+
+struct flagcxDeviceAdaptor cannAdaptor{
+    "CANN",
+    // Basic functions
+    cannAdaptorDeviceSynchronize,
+    cannAdaptorDeviceMemcpy,
+    cannAdaptorDeviceMemset,
+    cannAdaptorDeviceMalloc,
+    cannAdaptorDeviceFree,
+    cannAdaptorSetDevice,
+    cannAdaptorGetDevice,
+    cannAdaptorGetDeviceCount,
+    cannAdaptorGetVendor,
+    NULL,
+    // GDR functions
+    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+    cannAdaptorGdrMemAlloc,
+    cannAdaptorGdrMemFree,
+    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+          // *memHandle);
+    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+          // sz);
+    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+    // Stream functions
+    cannAdaptorStreamCreate,
+    cannAdaptorStreamDestroy,
+    cannAdaptorStreamCopy,
+    cannAdaptorStreamFree,
+    cannAdaptorStreamSynchronize,
+    cannAdaptorStreamQuery,
+    cannAdaptorStreamWaitEvent,
+    // Event functions
+    cannAdaptorEventCreate,
+    cannAdaptorEventDestroy,
+    cannAdaptorEventRecord,
+    cannAdaptorEventSynchronize,
+    cannAdaptorEventQuery,
+    // IpcMemHandle functions
+    cannAdaptorIpcMemHandleCreate,
+    cannAdaptorIpcMemHandleGet,
+    cannAdaptorIpcMemHandleOpen,
+    cannAdaptorIpcMemHandleClose,
+    cannAdaptorIpcMemHandleFree,
+    // Kernel launch
+    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+          // share_mem, void *stream, void *memHandle);
+    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+    NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream, void
+          // *args);
+    // Others
+    NULL, // flagcxResult_t (*getDeviceProperties)(struct flagcxDevProps
+          // *props, int dev);
+    NULL, // flagcxResult_t (*getDevicePciBusId)(char
+          // *pciBusId, int len, int dev);
+    NULL, // flagcxResult_t
+          // (*getDeviceByPciBusId)(int
+          // *dev, const char *pciBusId);
+    cannAdaptorLaunchHostFunc,
+    // DMA buffer
+    NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
+    NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
+          // void *buffer, size_t size, unsigned long long flags);
+    NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
+          // start, flagcxEvent_t end);
+    cannAdaptorStreamWaitValue64,
 };
 
 #endif // USE_ASCEND_ADAPTOR

--- a/flagcx/adaptor/device/cann_adaptor.cc
+++ b/flagcx/adaptor/device/cann_adaptor.cc
@@ -259,75 +259,59 @@ static flagcxResult_t cannAdaptorStreamWaitValue64(flagcxStream_t, void *,
   return flagcxNotSupported;
 }
 
-struct flagcxDeviceAdaptor cannAdaptor{
-    "CANN",
-    // Basic functions
-    cannAdaptorDeviceSynchronize,
-    cannAdaptorDeviceMemcpy,
-    cannAdaptorDeviceMemset,
-    cannAdaptorDeviceMalloc,
-    cannAdaptorDeviceFree,
-    cannAdaptorSetDevice,
-    cannAdaptorGetDevice,
-    cannAdaptorGetDeviceCount,
-    cannAdaptorGetVendor,
-    NULL,
-    // GDR functions
-    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-    cannAdaptorGdrMemAlloc,
-    cannAdaptorGdrMemFree,
-    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-          // *memHandle);
-    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-          // sz);
-    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-    // Stream functions
-    cannAdaptorStreamCreate,
-    cannAdaptorStreamDestroy,
-    cannAdaptorStreamCopy,
-    cannAdaptorStreamFree,
-    cannAdaptorStreamSynchronize,
-    cannAdaptorStreamQuery,
-    cannAdaptorStreamWaitEvent,
-    // Event functions
-    cannAdaptorEventCreate,
-    cannAdaptorEventDestroy,
-    cannAdaptorEventRecord,
-    cannAdaptorEventSynchronize,
-    cannAdaptorEventQuery,
-    // IpcMemHandle functions
-    cannAdaptorIpcMemHandleCreate,
-    cannAdaptorIpcMemHandleGet,
-    cannAdaptorIpcMemHandleOpen,
-    cannAdaptorIpcMemHandleClose,
-    cannAdaptorIpcMemHandleFree,
-    // Kernel launch
-    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-          // share_mem, void *stream, void *memHandle);
-    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-    NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream, void
-          // *args);
-    // Others
-    NULL, // flagcxResult_t (*getDeviceProperties)(struct flagcxDevProps
-          // *props, int dev);
-    NULL, // flagcxResult_t (*getDevicePciBusId)(char
-          // *pciBusId, int len, int dev);
-    NULL, // flagcxResult_t
-          // (*getDeviceByPciBusId)(int
-          // *dev, const char *pciBusId);
-    cannAdaptorLaunchHostFunc,
-    // DMA buffer
-    NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-    NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-          // void *buffer, size_t size, unsigned long long flags);
-    NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
-          // start, flagcxEvent_t end);
-    cannAdaptorStreamWaitValue64,
+struct flagcxDeviceAdaptor cannAdaptor {
+  "CANN",
+      // Basic functions
+      cannAdaptorDeviceSynchronize, cannAdaptorDeviceMemcpy,
+      cannAdaptorDeviceMemset, cannAdaptorDeviceMalloc, cannAdaptorDeviceFree,
+      cannAdaptorSetDevice, cannAdaptorGetDevice, cannAdaptorGetDeviceCount,
+      cannAdaptorGetVendor, NULL,
+      // GDR functions
+      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+      cannAdaptorGdrMemAlloc, cannAdaptorGdrMemFree,
+      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+            // *memHandle);
+      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+            // sz);
+      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+      // Stream functions
+      cannAdaptorStreamCreate, cannAdaptorStreamDestroy, cannAdaptorStreamCopy,
+      cannAdaptorStreamFree, cannAdaptorStreamSynchronize,
+      cannAdaptorStreamQuery, cannAdaptorStreamWaitEvent,
+      // Event functions
+      cannAdaptorEventCreate, cannAdaptorEventDestroy, cannAdaptorEventRecord,
+      cannAdaptorEventSynchronize, cannAdaptorEventQuery,
+      // IpcMemHandle functions
+      cannAdaptorIpcMemHandleCreate, cannAdaptorIpcMemHandleGet,
+      cannAdaptorIpcMemHandleOpen, cannAdaptorIpcMemHandleClose,
+      cannAdaptorIpcMemHandleFree,
+      // Kernel launch
+      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+            // share_mem, void *stream, void *memHandle);
+      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+      NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream, void
+            // *args);
+      // Others
+      NULL, // flagcxResult_t (*getDeviceProperties)(struct flagcxDevProps
+            // *props, int dev);
+      NULL, // flagcxResult_t (*getDevicePciBusId)(char
+            // *pciBusId, int len, int dev);
+      NULL, // flagcxResult_t
+            // (*getDeviceByPciBusId)(int
+            // *dev, const char *pciBusId);
+      cannAdaptorLaunchHostFunc,
+      // DMA buffer
+      NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
+      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
+            // void *buffer, size_t size, unsigned long long flags);
+      NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
+            // start, flagcxEvent_t end);
+      cannAdaptorStreamWaitValue64,
 };
 
 #endif // USE_ASCEND_ADAPTOR

--- a/flagcx/adaptor/device/cuda_adaptor.cc
+++ b/flagcx/adaptor/device/cuda_adaptor.cc
@@ -450,63 +450,92 @@ flagcxResult_t cudaAdaptorEventElapsedTime(float *ms, flagcxEvent_t start,
   }
 }
 
-struct flagcxDeviceAdaptor cudaAdaptor {
-  "CUDA",
-      // Basic functions
-      cudaAdaptorDeviceSynchronize, cudaAdaptorDeviceMemcpy,
-      cudaAdaptorDeviceMemset, cudaAdaptorDeviceMalloc, cudaAdaptorDeviceFree,
-      cudaAdaptorSetDevice, cudaAdaptorGetDevice, cudaAdaptorGetDeviceCount,
-      cudaAdaptorGetVendor, cudaAdaptorHostGetDevicePointer,
-      // GDR functions
-      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-      cudaAdaptorGdrMemAlloc, cudaAdaptorGdrMemFree,
-      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-            // *memHandle);
-      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-            // sz);
-      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-      // Stream functions
-      cudaAdaptorStreamCreate, cudaAdaptorStreamDestroy, cudaAdaptorStreamCopy,
-      cudaAdaptorStreamFree, cudaAdaptorStreamSynchronize,
-      cudaAdaptorStreamQuery, cudaAdaptorStreamWaitEvent,
-      // Event functions
-      cudaAdaptorEventCreate, cudaAdaptorEventDestroy, cudaAdaptorEventRecord,
-      cudaAdaptorEventSynchronize, cudaAdaptorEventQuery,
-      // IpcMemHandle functions
-      cudaAdaptorIpcMemHandleCreate, cudaAdaptorIpcMemHandleGet,
-      cudaAdaptorIpcMemHandleOpen, cudaAdaptorIpcMemHandleClose,
-      cudaAdaptorIpcMemHandleFree,
-      // Kernel launch
-      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-            // share_mem, void *stream, void *memHandle);
-      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-      cudaAdaptorLaunchDeviceFunc, // flagcxResult_t
-                                   // (*launchDeviceFunc)(flagcxStream_t stream,
-                                   // void *args);
-      // Others
-      cudaAdaptorGetDeviceProperties, // flagcxResult_t
-                                      // (*getDeviceProperties)(struct
-                                      // flagcxDevProps *props, int dev);
-      cudaAdaptorGetDevicePciBusId, // flagcxResult_t (*getDevicePciBusId)(char
+static flagcxResult_t cudaAdaptorStreamWaitValue64(flagcxStream_t stream,
+                                                   void *addr, uint64_t value,
+                                                   int flags) {
+  if (stream == NULL || addr == NULL)
+    return flagcxInvalidArgument;
+  CUstream cuStream = (CUstream)(stream->base);
+  CUresult err = cuStreamWaitValue64(cuStream, (CUdeviceptr)addr, value,
+                                     CU_STREAM_WAIT_VALUE_GEQ);
+  return (err == CUDA_SUCCESS) ? flagcxSuccess : flagcxUnhandledDeviceError;
+}
+
+struct flagcxDeviceAdaptor cudaAdaptor{
+    "CUDA",
+    // Basic functions
+    cudaAdaptorDeviceSynchronize,
+    cudaAdaptorDeviceMemcpy,
+    cudaAdaptorDeviceMemset,
+    cudaAdaptorDeviceMalloc,
+    cudaAdaptorDeviceFree,
+    cudaAdaptorSetDevice,
+    cudaAdaptorGetDevice,
+    cudaAdaptorGetDeviceCount,
+    cudaAdaptorGetVendor,
+    cudaAdaptorHostGetDevicePointer,
+    // GDR functions
+    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+    cudaAdaptorGdrMemAlloc,
+    cudaAdaptorGdrMemFree,
+    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+          // *memHandle);
+    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+          // sz);
+    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+    // Stream functions
+    cudaAdaptorStreamCreate,
+    cudaAdaptorStreamDestroy,
+    cudaAdaptorStreamCopy,
+    cudaAdaptorStreamFree,
+    cudaAdaptorStreamSynchronize,
+    cudaAdaptorStreamQuery,
+    cudaAdaptorStreamWaitEvent,
+    // Event functions
+    cudaAdaptorEventCreate,
+    cudaAdaptorEventDestroy,
+    cudaAdaptorEventRecord,
+    cudaAdaptorEventSynchronize,
+    cudaAdaptorEventQuery,
+    // IpcMemHandle functions
+    cudaAdaptorIpcMemHandleCreate,
+    cudaAdaptorIpcMemHandleGet,
+    cudaAdaptorIpcMemHandleOpen,
+    cudaAdaptorIpcMemHandleClose,
+    cudaAdaptorIpcMemHandleFree,
+    // Kernel launch
+    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+          // share_mem, void *stream, void *memHandle);
+    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+    cudaAdaptorLaunchDeviceFunc, // flagcxResult_t
+                                 // (*launchDeviceFunc)(flagcxStream_t stream,
+                                 // void *args);
+    // Others
+    cudaAdaptorGetDeviceProperties, // flagcxResult_t
+                                    // (*getDeviceProperties)(struct
+                                    // flagcxDevProps *props, int dev);
+    cudaAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
                                     // *pciBusId, int len, int dev);
-      cudaAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                      // (*getDeviceByPciBusId)(int
-                                      // *dev, const char *pciBusId);
-      cudaAdaptorLaunchHostFunc,
-      // DMA buffer
-      cudaAdaptorDmaSupport, // flagcxResult_t (*dmaSupport)(bool
-                             // *dmaBufferSupport);
-      cudaAdaptorMemGetHandleForAddressRange, // flagcxResult_t
-                                              // (*memGetHandleForAddressRange)(void
-                                              // *handleOut, void *buffer,
-                                              // size_t size, unsigned long long
-                                              // flags);
-      cudaAdaptorEventElapsedTime, // flagcxResult_t
+    cudaAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                    // (*getDeviceByPciBusId)(int
+                                    // *dev, const char *pciBusId);
+    cudaAdaptorLaunchHostFunc,
+    // DMA buffer
+    cudaAdaptorDmaSupport,                  // flagcxResult_t (*dmaSupport)(bool
+                                            // *dmaBufferSupport);
+    cudaAdaptorMemGetHandleForAddressRange, // flagcxResult_t
+                                            // (*memGetHandleForAddressRange)(void
+                                            // *handleOut, void *buffer,
+                                            // size_t size, unsigned long long
+                                            // flags);
+    cudaAdaptorEventElapsedTime, // flagcxResult_t
+    // Stream memory operations (one-sided signal polling)
+    cudaAdaptorStreamWaitValue64,
 };
 
 #endif // USE_NVIDIA_ADAPTOR

--- a/flagcx/adaptor/device/cuda_adaptor.cc
+++ b/flagcx/adaptor/device/cuda_adaptor.cc
@@ -453,6 +453,7 @@ flagcxResult_t cudaAdaptorEventElapsedTime(float *ms, flagcxEvent_t start,
 static flagcxResult_t cudaAdaptorStreamWaitValue64(flagcxStream_t stream,
                                                    void *addr, uint64_t value,
                                                    int flags) {
+  (void)flags;
   if (stream == NULL || addr == NULL)
     return flagcxInvalidArgument;
   CUstream cuStream = (CUstream)(stream->base);
@@ -461,81 +462,65 @@ static flagcxResult_t cudaAdaptorStreamWaitValue64(flagcxStream_t stream,
   return (err == CUDA_SUCCESS) ? flagcxSuccess : flagcxUnhandledDeviceError;
 }
 
-struct flagcxDeviceAdaptor cudaAdaptor{
-    "CUDA",
-    // Basic functions
-    cudaAdaptorDeviceSynchronize,
-    cudaAdaptorDeviceMemcpy,
-    cudaAdaptorDeviceMemset,
-    cudaAdaptorDeviceMalloc,
-    cudaAdaptorDeviceFree,
-    cudaAdaptorSetDevice,
-    cudaAdaptorGetDevice,
-    cudaAdaptorGetDeviceCount,
-    cudaAdaptorGetVendor,
-    cudaAdaptorHostGetDevicePointer,
-    // GDR functions
-    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-    cudaAdaptorGdrMemAlloc,
-    cudaAdaptorGdrMemFree,
-    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-          // *memHandle);
-    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-          // sz);
-    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-    // Stream functions
-    cudaAdaptorStreamCreate,
-    cudaAdaptorStreamDestroy,
-    cudaAdaptorStreamCopy,
-    cudaAdaptorStreamFree,
-    cudaAdaptorStreamSynchronize,
-    cudaAdaptorStreamQuery,
-    cudaAdaptorStreamWaitEvent,
-    // Event functions
-    cudaAdaptorEventCreate,
-    cudaAdaptorEventDestroy,
-    cudaAdaptorEventRecord,
-    cudaAdaptorEventSynchronize,
-    cudaAdaptorEventQuery,
-    // IpcMemHandle functions
-    cudaAdaptorIpcMemHandleCreate,
-    cudaAdaptorIpcMemHandleGet,
-    cudaAdaptorIpcMemHandleOpen,
-    cudaAdaptorIpcMemHandleClose,
-    cudaAdaptorIpcMemHandleFree,
-    // Kernel launch
-    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-          // share_mem, void *stream, void *memHandle);
-    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-    cudaAdaptorLaunchDeviceFunc, // flagcxResult_t
-                                 // (*launchDeviceFunc)(flagcxStream_t stream,
-                                 // void *args);
-    // Others
-    cudaAdaptorGetDeviceProperties, // flagcxResult_t
-                                    // (*getDeviceProperties)(struct
-                                    // flagcxDevProps *props, int dev);
-    cudaAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
+struct flagcxDeviceAdaptor cudaAdaptor {
+  "CUDA",
+      // Basic functions
+      cudaAdaptorDeviceSynchronize, cudaAdaptorDeviceMemcpy,
+      cudaAdaptorDeviceMemset, cudaAdaptorDeviceMalloc, cudaAdaptorDeviceFree,
+      cudaAdaptorSetDevice, cudaAdaptorGetDevice, cudaAdaptorGetDeviceCount,
+      cudaAdaptorGetVendor, cudaAdaptorHostGetDevicePointer,
+      // GDR functions
+      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+      cudaAdaptorGdrMemAlloc, cudaAdaptorGdrMemFree,
+      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+            // *memHandle);
+      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+            // sz);
+      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+      // Stream functions
+      cudaAdaptorStreamCreate, cudaAdaptorStreamDestroy, cudaAdaptorStreamCopy,
+      cudaAdaptorStreamFree, cudaAdaptorStreamSynchronize,
+      cudaAdaptorStreamQuery, cudaAdaptorStreamWaitEvent,
+      // Event functions
+      cudaAdaptorEventCreate, cudaAdaptorEventDestroy, cudaAdaptorEventRecord,
+      cudaAdaptorEventSynchronize, cudaAdaptorEventQuery,
+      // IpcMemHandle functions
+      cudaAdaptorIpcMemHandleCreate, cudaAdaptorIpcMemHandleGet,
+      cudaAdaptorIpcMemHandleOpen, cudaAdaptorIpcMemHandleClose,
+      cudaAdaptorIpcMemHandleFree,
+      // Kernel launch
+      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+            // share_mem, void *stream, void *memHandle);
+      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+      cudaAdaptorLaunchDeviceFunc, // flagcxResult_t
+                                   // (*launchDeviceFunc)(flagcxStream_t stream,
+                                   // void *args);
+      // Others
+      cudaAdaptorGetDeviceProperties, // flagcxResult_t
+                                      // (*getDeviceProperties)(struct
+                                      // flagcxDevProps *props, int dev);
+      cudaAdaptorGetDevicePciBusId, // flagcxResult_t (*getDevicePciBusId)(char
                                     // *pciBusId, int len, int dev);
-    cudaAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                    // (*getDeviceByPciBusId)(int
-                                    // *dev, const char *pciBusId);
-    cudaAdaptorLaunchHostFunc,
-    // DMA buffer
-    cudaAdaptorDmaSupport,                  // flagcxResult_t (*dmaSupport)(bool
-                                            // *dmaBufferSupport);
-    cudaAdaptorMemGetHandleForAddressRange, // flagcxResult_t
-                                            // (*memGetHandleForAddressRange)(void
-                                            // *handleOut, void *buffer,
-                                            // size_t size, unsigned long long
-                                            // flags);
-    cudaAdaptorEventElapsedTime, // flagcxResult_t
-    // Stream memory operations (one-sided signal polling)
-    cudaAdaptorStreamWaitValue64,
+      cudaAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                      // (*getDeviceByPciBusId)(int
+                                      // *dev, const char *pciBusId);
+      cudaAdaptorLaunchHostFunc,
+      // DMA buffer
+      cudaAdaptorDmaSupport, // flagcxResult_t (*dmaSupport)(bool
+                             // *dmaBufferSupport);
+      cudaAdaptorMemGetHandleForAddressRange, // flagcxResult_t
+                                              // (*memGetHandleForAddressRange)(void
+                                              // *handleOut, void *buffer,
+                                              // size_t size, unsigned long long
+                                              // flags);
+      cudaAdaptorEventElapsedTime, // flagcxResult_t
+      // Stream memory operations (one-sided signal polling)
+      cudaAdaptorStreamWaitValue64,
 };
 
 #endif // USE_NVIDIA_ADAPTOR

--- a/flagcx/adaptor/device/ducuda_adaptor.cc
+++ b/flagcx/adaptor/device/ducuda_adaptor.cc
@@ -323,64 +323,84 @@ flagcxResult_t ducudaAdaptorGetDeviceByPciBusId(int *dev,
   return flagcxSuccess;
 }
 
-struct flagcxDeviceAdaptor ducudaAdaptor {
-  "DUCUDA",
-      // Basic functions
-      ducudaAdaptorDeviceSynchronize, ducudaAdaptorDeviceMemcpy,
-      ducudaAdaptorDeviceMemset, ducudaAdaptorDeviceMalloc,
-      ducudaAdaptorDeviceFree, ducudaAdaptorSetDevice, ducudaAdaptorGetDevice,
-      ducudaAdaptorGetDeviceCount, ducudaAdaptorGetVendor, NULL,
-      // GDR functions
-      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-      ducudaAdaptorGdrMemAlloc, ducudaAdaptorGdrMemFree,
-      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-            // *memHandle);
-      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-            // sz);
-      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-      // Stream functions
-      ducudaAdaptorStreamCreate, ducudaAdaptorStreamDestroy,
-      ducudaAdaptorStreamCopy, ducudaAdaptorStreamFree,
-      ducudaAdaptorStreamSynchronize, ducudaAdaptorStreamQuery,
-      ducudaAdaptorStreamWaitEvent,
-      // Event functions
-      ducudaAdaptorEventCreate, ducudaAdaptorEventDestroy,
-      ducudaAdaptorEventRecord, ducudaAdaptorEventSynchronize,
-      ducudaAdaptorEventQuery,
-      // IpcMemHandle functions
-      ducudaAdaptorIpcMemHandleCreate, ducudaAdaptorIpcMemHandleGet,
-      ducudaAdaptorIpcMemHandleOpen, ducudaAdaptorIpcMemHandleClose,
-      ducudaAdaptorIpcMemHandleFree,
-      // Kernel launch
-      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-            // share_mem, void *stream, void *memHandle);
-      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-      NULL, // flagcxResult_t
-            // (*launchDeviceFunc)(flagcxStream_t stream,
-            // void *args);
-      // Others
-      ducudaAdaptorGetDeviceProperties, // flagcxResult_t
-                                        // (*getDeviceProperties)(struct
-                                        // flagcxDevProps *props, int dev);
-      ducudaAdaptorGetDevicePciBusId,   // flagcxResult_t
-                                        // (*getDevicePciBusId)(char *pciBusId,
-                                        // int len, int dev);
-      ducudaAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                        // (*getDeviceByPciBusId)(
-                                        // int
-                                        // *dev, const char *pciBusId);
-      ducudaAdaptorLaunchHostFunc,
-      // DMA buffer
-      NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-            // void *buffer, size_t size, unsigned long long flags);
-      NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
-            // start, flagcxEvent_t end);
+static flagcxResult_t ducudaAdaptorStreamWaitValue64(flagcxStream_t, void *,
+                                                     uint64_t, int) {
+  return flagcxNotSupported;
+}
+
+struct flagcxDeviceAdaptor ducudaAdaptor{
+    "DUCUDA",
+    // Basic functions
+    ducudaAdaptorDeviceSynchronize,
+    ducudaAdaptorDeviceMemcpy,
+    ducudaAdaptorDeviceMemset,
+    ducudaAdaptorDeviceMalloc,
+    ducudaAdaptorDeviceFree,
+    ducudaAdaptorSetDevice,
+    ducudaAdaptorGetDevice,
+    ducudaAdaptorGetDeviceCount,
+    ducudaAdaptorGetVendor,
+    NULL,
+    // GDR functions
+    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+    ducudaAdaptorGdrMemAlloc,
+    ducudaAdaptorGdrMemFree,
+    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+          // *memHandle);
+    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+          // sz);
+    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+    // Stream functions
+    ducudaAdaptorStreamCreate,
+    ducudaAdaptorStreamDestroy,
+    ducudaAdaptorStreamCopy,
+    ducudaAdaptorStreamFree,
+    ducudaAdaptorStreamSynchronize,
+    ducudaAdaptorStreamQuery,
+    ducudaAdaptorStreamWaitEvent,
+    // Event functions
+    ducudaAdaptorEventCreate,
+    ducudaAdaptorEventDestroy,
+    ducudaAdaptorEventRecord,
+    ducudaAdaptorEventSynchronize,
+    ducudaAdaptorEventQuery,
+    // IpcMemHandle functions
+    ducudaAdaptorIpcMemHandleCreate,
+    ducudaAdaptorIpcMemHandleGet,
+    ducudaAdaptorIpcMemHandleOpen,
+    ducudaAdaptorIpcMemHandleClose,
+    ducudaAdaptorIpcMemHandleFree,
+    // Kernel launch
+    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+          // share_mem, void *stream, void *memHandle);
+    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+    NULL, // flagcxResult_t
+          // (*launchDeviceFunc)(flagcxStream_t stream,
+          // void *args);
+    // Others
+    ducudaAdaptorGetDeviceProperties, // flagcxResult_t
+                                      // (*getDeviceProperties)(struct
+                                      // flagcxDevProps *props, int dev);
+    ducudaAdaptorGetDevicePciBusId,   // flagcxResult_t
+                                      // (*getDevicePciBusId)(char *pciBusId,
+                                      // int len, int dev);
+    ducudaAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                      // (*getDeviceByPciBusId)(
+                                      // int
+                                      // *dev, const char *pciBusId);
+    ducudaAdaptorLaunchHostFunc,
+    // DMA buffer
+    NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
+    NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
+          // void *buffer, size_t size, unsigned long long flags);
+    NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
+          // start, flagcxEvent_t end);
+    ducudaAdaptorStreamWaitValue64,
 };
 
 #endif // USE_DU_ADAPTOR

--- a/flagcx/adaptor/device/ducuda_adaptor.cc
+++ b/flagcx/adaptor/device/ducuda_adaptor.cc
@@ -328,79 +328,65 @@ static flagcxResult_t ducudaAdaptorStreamWaitValue64(flagcxStream_t, void *,
   return flagcxNotSupported;
 }
 
-struct flagcxDeviceAdaptor ducudaAdaptor{
-    "DUCUDA",
-    // Basic functions
-    ducudaAdaptorDeviceSynchronize,
-    ducudaAdaptorDeviceMemcpy,
-    ducudaAdaptorDeviceMemset,
-    ducudaAdaptorDeviceMalloc,
-    ducudaAdaptorDeviceFree,
-    ducudaAdaptorSetDevice,
-    ducudaAdaptorGetDevice,
-    ducudaAdaptorGetDeviceCount,
-    ducudaAdaptorGetVendor,
-    NULL,
-    // GDR functions
-    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-    ducudaAdaptorGdrMemAlloc,
-    ducudaAdaptorGdrMemFree,
-    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-          // *memHandle);
-    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-          // sz);
-    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-    // Stream functions
-    ducudaAdaptorStreamCreate,
-    ducudaAdaptorStreamDestroy,
-    ducudaAdaptorStreamCopy,
-    ducudaAdaptorStreamFree,
-    ducudaAdaptorStreamSynchronize,
-    ducudaAdaptorStreamQuery,
-    ducudaAdaptorStreamWaitEvent,
-    // Event functions
-    ducudaAdaptorEventCreate,
-    ducudaAdaptorEventDestroy,
-    ducudaAdaptorEventRecord,
-    ducudaAdaptorEventSynchronize,
-    ducudaAdaptorEventQuery,
-    // IpcMemHandle functions
-    ducudaAdaptorIpcMemHandleCreate,
-    ducudaAdaptorIpcMemHandleGet,
-    ducudaAdaptorIpcMemHandleOpen,
-    ducudaAdaptorIpcMemHandleClose,
-    ducudaAdaptorIpcMemHandleFree,
-    // Kernel launch
-    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-          // share_mem, void *stream, void *memHandle);
-    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-    NULL, // flagcxResult_t
-          // (*launchDeviceFunc)(flagcxStream_t stream,
-          // void *args);
-    // Others
-    ducudaAdaptorGetDeviceProperties, // flagcxResult_t
-                                      // (*getDeviceProperties)(struct
-                                      // flagcxDevProps *props, int dev);
-    ducudaAdaptorGetDevicePciBusId,   // flagcxResult_t
-                                      // (*getDevicePciBusId)(char *pciBusId,
-                                      // int len, int dev);
-    ducudaAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                      // (*getDeviceByPciBusId)(
-                                      // int
-                                      // *dev, const char *pciBusId);
-    ducudaAdaptorLaunchHostFunc,
-    // DMA buffer
-    NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-    NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-          // void *buffer, size_t size, unsigned long long flags);
-    NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
-          // start, flagcxEvent_t end);
-    ducudaAdaptorStreamWaitValue64,
+struct flagcxDeviceAdaptor ducudaAdaptor {
+  "DUCUDA",
+      // Basic functions
+      ducudaAdaptorDeviceSynchronize, ducudaAdaptorDeviceMemcpy,
+      ducudaAdaptorDeviceMemset, ducudaAdaptorDeviceMalloc,
+      ducudaAdaptorDeviceFree, ducudaAdaptorSetDevice, ducudaAdaptorGetDevice,
+      ducudaAdaptorGetDeviceCount, ducudaAdaptorGetVendor, NULL,
+      // GDR functions
+      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+      ducudaAdaptorGdrMemAlloc, ducudaAdaptorGdrMemFree,
+      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+            // *memHandle);
+      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+            // sz);
+      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+      // Stream functions
+      ducudaAdaptorStreamCreate, ducudaAdaptorStreamDestroy,
+      ducudaAdaptorStreamCopy, ducudaAdaptorStreamFree,
+      ducudaAdaptorStreamSynchronize, ducudaAdaptorStreamQuery,
+      ducudaAdaptorStreamWaitEvent,
+      // Event functions
+      ducudaAdaptorEventCreate, ducudaAdaptorEventDestroy,
+      ducudaAdaptorEventRecord, ducudaAdaptorEventSynchronize,
+      ducudaAdaptorEventQuery,
+      // IpcMemHandle functions
+      ducudaAdaptorIpcMemHandleCreate, ducudaAdaptorIpcMemHandleGet,
+      ducudaAdaptorIpcMemHandleOpen, ducudaAdaptorIpcMemHandleClose,
+      ducudaAdaptorIpcMemHandleFree,
+      // Kernel launch
+      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+            // share_mem, void *stream, void *memHandle);
+      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+      NULL, // flagcxResult_t
+            // (*launchDeviceFunc)(flagcxStream_t stream,
+            // void *args);
+      // Others
+      ducudaAdaptorGetDeviceProperties, // flagcxResult_t
+                                        // (*getDeviceProperties)(struct
+                                        // flagcxDevProps *props, int dev);
+      ducudaAdaptorGetDevicePciBusId,   // flagcxResult_t
+                                        // (*getDevicePciBusId)(char *pciBusId,
+                                        // int len, int dev);
+      ducudaAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                        // (*getDeviceByPciBusId)(
+                                        // int
+                                        // *dev, const char *pciBusId);
+      ducudaAdaptorLaunchHostFunc,
+      // DMA buffer
+      NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
+      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
+            // void *buffer, size_t size, unsigned long long flags);
+      NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
+            // start, flagcxEvent_t end);
+      ducudaAdaptorStreamWaitValue64,
 };
 
 #endif // USE_DU_ADAPTOR

--- a/flagcx/adaptor/device/hip_adaptor.cc
+++ b/flagcx/adaptor/device/hip_adaptor.cc
@@ -313,66 +313,87 @@ flagcxResult_t hipAdaptorMemGetHandleForAddressRange(void *handleOut,
   return flagcxNotSupported;
 }
 
-struct flagcxDeviceAdaptor hipAdaptor {
-  "HIP",
-      // Basic functions
-      hipAdaptorDeviceSynchronize, hipAdaptorDeviceMemcpy,
-      hipAdaptorDeviceMemset, hipAdaptorDeviceMalloc, hipAdaptorDeviceFree,
-      hipAdaptorSetDevice, hipAdaptorGetDevice, hipAdaptorGetDeviceCount,
-      hipAdaptorGetVendor,
-      NULL, // flagcxResult_t (*hostGetDevicePointer)(void **pDevice, void
-            // *pHost);
-      // GDR functions
-      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-      hipAdaptorGdrMemAlloc, hipAdaptorGdrMemFree,
-      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-            // *memHandle);
-      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-            // sz);
-      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-      // Stream functions
-      hipAdaptorStreamCreate, hipAdaptorStreamDestroy, hipAdaptorStreamCopy,
-      hipAdaptorStreamFree, hipAdaptorStreamSynchronize, hipAdaptorStreamQuery,
-      hipAdaptorStreamWaitEvent,
-      // Event functions
-      hipAdaptorEventCreate, hipAdaptorEventDestroy, hipAdaptorEventRecord,
-      hipAdaptorEventSynchronize, hipAdaptorEventQuery,
-      // IpcMemHandle functions
-      hipAdaptorIpcMemHandleCreate, hipAdaptorIpcMemHandleGet,
-      hipAdaptorIpcMemHandleOpen, hipAdaptorIpcMemHandleClose,
-      hipAdaptorIpcMemHandleFree,
-      // Kernel launch
-      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-            // share_mem, void *stream, void *memHandle);
-      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-      hipAdaptorLaunchDeviceFunc, // flagcxResult_t
-                                  // (*launchDeviceFunc)(flagcxStream_t stream,
-                                  // void *args);
-      // Others
-      hipAdaptorGetDeviceProperties, // flagcxResult_t
-                                     // (*getDeviceProperties)(struct
-                                     // flagcxDevProps *props, int dev);
-      hipAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
-                                     // *pciBusId, int len, int dev);
-      hipAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                     // (*getDeviceByPciBusId)(int
-                                     // *dev, const char *pciBusId);
-      hipAdaptorLaunchHostFunc,
-      // DMA buffer
-      hipAdaptorDmaSupport, // flagcxResult_t (*dmaSupport)(bool
-                            // *dmaBufferSupport);
-      hipAdaptorMemGetHandleForAddressRange, // flagcxResult_t
-                                             // (*memGetHandleForAddressRange)(void
-                                             // *handleOut, void *buffer,
-                                             // size_t size, unsigned long long
-                                             // flags);
-      NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
-            // start, flagcxEvent_t end);
+static flagcxResult_t hipAdaptorStreamWaitValue64(flagcxStream_t, void *,
+                                                  uint64_t, int) {
+  return flagcxNotSupported;
+}
+
+struct flagcxDeviceAdaptor hipAdaptor{
+    "HIP",
+    // Basic functions
+    hipAdaptorDeviceSynchronize,
+    hipAdaptorDeviceMemcpy,
+    hipAdaptorDeviceMemset,
+    hipAdaptorDeviceMalloc,
+    hipAdaptorDeviceFree,
+    hipAdaptorSetDevice,
+    hipAdaptorGetDevice,
+    hipAdaptorGetDeviceCount,
+    hipAdaptorGetVendor,
+    NULL, // flagcxResult_t (*hostGetDevicePointer)(void **pDevice, void
+          // *pHost);
+    // GDR functions
+    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+    hipAdaptorGdrMemAlloc,
+    hipAdaptorGdrMemFree,
+    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+          // *memHandle);
+    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+          // sz);
+    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+    // Stream functions
+    hipAdaptorStreamCreate,
+    hipAdaptorStreamDestroy,
+    hipAdaptorStreamCopy,
+    hipAdaptorStreamFree,
+    hipAdaptorStreamSynchronize,
+    hipAdaptorStreamQuery,
+    hipAdaptorStreamWaitEvent,
+    // Event functions
+    hipAdaptorEventCreate,
+    hipAdaptorEventDestroy,
+    hipAdaptorEventRecord,
+    hipAdaptorEventSynchronize,
+    hipAdaptorEventQuery,
+    // IpcMemHandle functions
+    hipAdaptorIpcMemHandleCreate,
+    hipAdaptorIpcMemHandleGet,
+    hipAdaptorIpcMemHandleOpen,
+    hipAdaptorIpcMemHandleClose,
+    hipAdaptorIpcMemHandleFree,
+    // Kernel launch
+    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+          // share_mem, void *stream, void *memHandle);
+    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+    hipAdaptorLaunchDeviceFunc, // flagcxResult_t
+                                // (*launchDeviceFunc)(flagcxStream_t stream,
+                                // void *args);
+    // Others
+    hipAdaptorGetDeviceProperties, // flagcxResult_t
+                                   // (*getDeviceProperties)(struct
+                                   // flagcxDevProps *props, int dev);
+    hipAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
+                                   // *pciBusId, int len, int dev);
+    hipAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                   // (*getDeviceByPciBusId)(int
+                                   // *dev, const char *pciBusId);
+    hipAdaptorLaunchHostFunc,
+    // DMA buffer
+    hipAdaptorDmaSupport,                  // flagcxResult_t (*dmaSupport)(bool
+                                           // *dmaBufferSupport);
+    hipAdaptorMemGetHandleForAddressRange, // flagcxResult_t
+                                           // (*memGetHandleForAddressRange)(void
+                                           // *handleOut, void *buffer,
+                                           // size_t size, unsigned long long
+                                           // flags);
+    NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
+          // start, flagcxEvent_t end);
+    hipAdaptorStreamWaitValue64,
 };
 
 #endif // USE_AMD_ADAPTOR

--- a/flagcx/adaptor/device/hip_adaptor.cc
+++ b/flagcx/adaptor/device/hip_adaptor.cc
@@ -318,82 +318,67 @@ static flagcxResult_t hipAdaptorStreamWaitValue64(flagcxStream_t, void *,
   return flagcxNotSupported;
 }
 
-struct flagcxDeviceAdaptor hipAdaptor{
-    "HIP",
-    // Basic functions
-    hipAdaptorDeviceSynchronize,
-    hipAdaptorDeviceMemcpy,
-    hipAdaptorDeviceMemset,
-    hipAdaptorDeviceMalloc,
-    hipAdaptorDeviceFree,
-    hipAdaptorSetDevice,
-    hipAdaptorGetDevice,
-    hipAdaptorGetDeviceCount,
-    hipAdaptorGetVendor,
-    NULL, // flagcxResult_t (*hostGetDevicePointer)(void **pDevice, void
-          // *pHost);
-    // GDR functions
-    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-    hipAdaptorGdrMemAlloc,
-    hipAdaptorGdrMemFree,
-    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-          // *memHandle);
-    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-          // sz);
-    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-    // Stream functions
-    hipAdaptorStreamCreate,
-    hipAdaptorStreamDestroy,
-    hipAdaptorStreamCopy,
-    hipAdaptorStreamFree,
-    hipAdaptorStreamSynchronize,
-    hipAdaptorStreamQuery,
-    hipAdaptorStreamWaitEvent,
-    // Event functions
-    hipAdaptorEventCreate,
-    hipAdaptorEventDestroy,
-    hipAdaptorEventRecord,
-    hipAdaptorEventSynchronize,
-    hipAdaptorEventQuery,
-    // IpcMemHandle functions
-    hipAdaptorIpcMemHandleCreate,
-    hipAdaptorIpcMemHandleGet,
-    hipAdaptorIpcMemHandleOpen,
-    hipAdaptorIpcMemHandleClose,
-    hipAdaptorIpcMemHandleFree,
-    // Kernel launch
-    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-          // share_mem, void *stream, void *memHandle);
-    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-    hipAdaptorLaunchDeviceFunc, // flagcxResult_t
-                                // (*launchDeviceFunc)(flagcxStream_t stream,
-                                // void *args);
-    // Others
-    hipAdaptorGetDeviceProperties, // flagcxResult_t
-                                   // (*getDeviceProperties)(struct
-                                   // flagcxDevProps *props, int dev);
-    hipAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
-                                   // *pciBusId, int len, int dev);
-    hipAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                   // (*getDeviceByPciBusId)(int
-                                   // *dev, const char *pciBusId);
-    hipAdaptorLaunchHostFunc,
-    // DMA buffer
-    hipAdaptorDmaSupport,                  // flagcxResult_t (*dmaSupport)(bool
-                                           // *dmaBufferSupport);
-    hipAdaptorMemGetHandleForAddressRange, // flagcxResult_t
-                                           // (*memGetHandleForAddressRange)(void
-                                           // *handleOut, void *buffer,
-                                           // size_t size, unsigned long long
-                                           // flags);
-    NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
-          // start, flagcxEvent_t end);
-    hipAdaptorStreamWaitValue64,
+struct flagcxDeviceAdaptor hipAdaptor {
+  "HIP",
+      // Basic functions
+      hipAdaptorDeviceSynchronize, hipAdaptorDeviceMemcpy,
+      hipAdaptorDeviceMemset, hipAdaptorDeviceMalloc, hipAdaptorDeviceFree,
+      hipAdaptorSetDevice, hipAdaptorGetDevice, hipAdaptorGetDeviceCount,
+      hipAdaptorGetVendor,
+      NULL, // flagcxResult_t (*hostGetDevicePointer)(void **pDevice, void
+            // *pHost);
+      // GDR functions
+      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+      hipAdaptorGdrMemAlloc, hipAdaptorGdrMemFree,
+      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+            // *memHandle);
+      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+            // sz);
+      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+      // Stream functions
+      hipAdaptorStreamCreate, hipAdaptorStreamDestroy, hipAdaptorStreamCopy,
+      hipAdaptorStreamFree, hipAdaptorStreamSynchronize, hipAdaptorStreamQuery,
+      hipAdaptorStreamWaitEvent,
+      // Event functions
+      hipAdaptorEventCreate, hipAdaptorEventDestroy, hipAdaptorEventRecord,
+      hipAdaptorEventSynchronize, hipAdaptorEventQuery,
+      // IpcMemHandle functions
+      hipAdaptorIpcMemHandleCreate, hipAdaptorIpcMemHandleGet,
+      hipAdaptorIpcMemHandleOpen, hipAdaptorIpcMemHandleClose,
+      hipAdaptorIpcMemHandleFree,
+      // Kernel launch
+      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+            // share_mem, void *stream, void *memHandle);
+      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+      hipAdaptorLaunchDeviceFunc, // flagcxResult_t
+                                  // (*launchDeviceFunc)(flagcxStream_t stream,
+                                  // void *args);
+      // Others
+      hipAdaptorGetDeviceProperties, // flagcxResult_t
+                                     // (*getDeviceProperties)(struct
+                                     // flagcxDevProps *props, int dev);
+      hipAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
+                                     // *pciBusId, int len, int dev);
+      hipAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                     // (*getDeviceByPciBusId)(int
+                                     // *dev, const char *pciBusId);
+      hipAdaptorLaunchHostFunc,
+      // DMA buffer
+      hipAdaptorDmaSupport, // flagcxResult_t (*dmaSupport)(bool
+                            // *dmaBufferSupport);
+      hipAdaptorMemGetHandleForAddressRange, // flagcxResult_t
+                                             // (*memGetHandleForAddressRange)(void
+                                             // *handleOut, void *buffer,
+                                             // size_t size, unsigned long long
+                                             // flags);
+      NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
+            // start, flagcxEvent_t end);
+      hipAdaptorStreamWaitValue64,
 };
 
 #endif // USE_AMD_ADAPTOR

--- a/flagcx/adaptor/device/ixcuda_adaptor.cc
+++ b/flagcx/adaptor/device/ixcuda_adaptor.cc
@@ -322,64 +322,84 @@ flagcxResult_t ixcudaAdaptorGetDeviceByPciBusId(int *dev,
   return flagcxSuccess;
 }
 
-struct flagcxDeviceAdaptor ixcudaAdaptor {
-  "IXCUDA",
-      // Basic functions
-      ixcudaAdaptorDeviceSynchronize, ixcudaAdaptorDeviceMemcpy,
-      ixcudaAdaptorDeviceMemset, ixcudaAdaptorDeviceMalloc,
-      ixcudaAdaptorDeviceFree, ixcudaAdaptorSetDevice, ixcudaAdaptorGetDevice,
-      ixcudaAdaptorGetDeviceCount, ixcudaAdaptorGetVendor, NULL,
-      // GDR functions
-      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-      ixcudaAdaptorGdrMemAlloc, ixcudaAdaptorGdrMemFree,
-      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-            // *memHandle);
-      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-            // sz);
-      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-      // Stream functions
-      ixcudaAdaptorStreamCreate, ixcudaAdaptorStreamDestroy,
-      ixcudaAdaptorStreamCopy, ixcudaAdaptorStreamFree,
-      ixcudaAdaptorStreamSynchronize, ixcudaAdaptorStreamQuery,
-      ixcudaAdaptorStreamWaitEvent,
-      // Event functions
-      ixcudaAdaptorEventCreate, ixcudaAdaptorEventDestroy,
-      ixcudaAdaptorEventRecord, ixcudaAdaptorEventSynchronize,
-      ixcudaAdaptorEventQuery,
-      // IpcMemHandle functions
-      ixcudaAdaptorIpcMemHandleCreate, ixcudaAdaptorIpcMemHandleGet,
-      ixcudaAdaptorIpcMemHandleOpen, ixcudaAdaptorIpcMemHandleClose,
-      ixcudaAdaptorIpcMemHandleFree,
-      // Kernel launch
-      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-            // share_mem, void *stream, void *memHandle);
-      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-      NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream, void
-            // *args);
-      // Others
-      ixcudaAdaptorGetDeviceProperties, // flagcxResult_t
-                                        // (*getDeviceProperties)(struct
-                                        // flagcxDeviceProps *props, int dev);
-      ixcudaAdaptorGetDevicePciBusId,   // flagcxResult_t
-                                        // (*getDevicePciBusId)(char *pciBusId,
-                                        // int len, int dev);
-      ixcudaAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                        // (*getDeviceByPciBusId)(int *dev,
-                                        // const char *pciBusId);
-      ixcudaAdaptorLaunchHostFunc,
+static flagcxResult_t ixcudaAdaptorStreamWaitValue64(flagcxStream_t, void *,
+                                                     uint64_t, int) {
+  return flagcxNotSupported;
+}
 
-      // DMA buffer
-      NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-            // void *buffer, size_t size, unsigned long long flags);
-      NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
-            // start,
-            // flagcxEvent_t end);
+struct flagcxDeviceAdaptor ixcudaAdaptor{
+    "IXCUDA",
+    // Basic functions
+    ixcudaAdaptorDeviceSynchronize,
+    ixcudaAdaptorDeviceMemcpy,
+    ixcudaAdaptorDeviceMemset,
+    ixcudaAdaptorDeviceMalloc,
+    ixcudaAdaptorDeviceFree,
+    ixcudaAdaptorSetDevice,
+    ixcudaAdaptorGetDevice,
+    ixcudaAdaptorGetDeviceCount,
+    ixcudaAdaptorGetVendor,
+    NULL,
+    // GDR functions
+    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+    ixcudaAdaptorGdrMemAlloc,
+    ixcudaAdaptorGdrMemFree,
+    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+          // *memHandle);
+    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+          // sz);
+    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+    // Stream functions
+    ixcudaAdaptorStreamCreate,
+    ixcudaAdaptorStreamDestroy,
+    ixcudaAdaptorStreamCopy,
+    ixcudaAdaptorStreamFree,
+    ixcudaAdaptorStreamSynchronize,
+    ixcudaAdaptorStreamQuery,
+    ixcudaAdaptorStreamWaitEvent,
+    // Event functions
+    ixcudaAdaptorEventCreate,
+    ixcudaAdaptorEventDestroy,
+    ixcudaAdaptorEventRecord,
+    ixcudaAdaptorEventSynchronize,
+    ixcudaAdaptorEventQuery,
+    // IpcMemHandle functions
+    ixcudaAdaptorIpcMemHandleCreate,
+    ixcudaAdaptorIpcMemHandleGet,
+    ixcudaAdaptorIpcMemHandleOpen,
+    ixcudaAdaptorIpcMemHandleClose,
+    ixcudaAdaptorIpcMemHandleFree,
+    // Kernel launch
+    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+          // share_mem, void *stream, void *memHandle);
+    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+    NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream, void
+          // *args);
+    // Others
+    ixcudaAdaptorGetDeviceProperties, // flagcxResult_t
+                                      // (*getDeviceProperties)(struct
+                                      // flagcxDeviceProps *props, int dev);
+    ixcudaAdaptorGetDevicePciBusId,   // flagcxResult_t
+                                      // (*getDevicePciBusId)(char *pciBusId,
+                                      // int len, int dev);
+    ixcudaAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                      // (*getDeviceByPciBusId)(int *dev,
+                                      // const char *pciBusId);
+    ixcudaAdaptorLaunchHostFunc,
+
+    // DMA buffer
+    NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
+    NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
+          // void *buffer, size_t size, unsigned long long flags);
+    NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
+          // start,
+          // flagcxEvent_t end);
+    ixcudaAdaptorStreamWaitValue64,
 };
 
 #endif // USE_ILUVATAR_COREX_ADAPTOR

--- a/flagcx/adaptor/device/ixcuda_adaptor.cc
+++ b/flagcx/adaptor/device/ixcuda_adaptor.cc
@@ -327,79 +327,65 @@ static flagcxResult_t ixcudaAdaptorStreamWaitValue64(flagcxStream_t, void *,
   return flagcxNotSupported;
 }
 
-struct flagcxDeviceAdaptor ixcudaAdaptor{
-    "IXCUDA",
-    // Basic functions
-    ixcudaAdaptorDeviceSynchronize,
-    ixcudaAdaptorDeviceMemcpy,
-    ixcudaAdaptorDeviceMemset,
-    ixcudaAdaptorDeviceMalloc,
-    ixcudaAdaptorDeviceFree,
-    ixcudaAdaptorSetDevice,
-    ixcudaAdaptorGetDevice,
-    ixcudaAdaptorGetDeviceCount,
-    ixcudaAdaptorGetVendor,
-    NULL,
-    // GDR functions
-    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-    ixcudaAdaptorGdrMemAlloc,
-    ixcudaAdaptorGdrMemFree,
-    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-          // *memHandle);
-    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-          // sz);
-    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-    // Stream functions
-    ixcudaAdaptorStreamCreate,
-    ixcudaAdaptorStreamDestroy,
-    ixcudaAdaptorStreamCopy,
-    ixcudaAdaptorStreamFree,
-    ixcudaAdaptorStreamSynchronize,
-    ixcudaAdaptorStreamQuery,
-    ixcudaAdaptorStreamWaitEvent,
-    // Event functions
-    ixcudaAdaptorEventCreate,
-    ixcudaAdaptorEventDestroy,
-    ixcudaAdaptorEventRecord,
-    ixcudaAdaptorEventSynchronize,
-    ixcudaAdaptorEventQuery,
-    // IpcMemHandle functions
-    ixcudaAdaptorIpcMemHandleCreate,
-    ixcudaAdaptorIpcMemHandleGet,
-    ixcudaAdaptorIpcMemHandleOpen,
-    ixcudaAdaptorIpcMemHandleClose,
-    ixcudaAdaptorIpcMemHandleFree,
-    // Kernel launch
-    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-          // share_mem, void *stream, void *memHandle);
-    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-    NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream, void
-          // *args);
-    // Others
-    ixcudaAdaptorGetDeviceProperties, // flagcxResult_t
-                                      // (*getDeviceProperties)(struct
-                                      // flagcxDeviceProps *props, int dev);
-    ixcudaAdaptorGetDevicePciBusId,   // flagcxResult_t
-                                      // (*getDevicePciBusId)(char *pciBusId,
-                                      // int len, int dev);
-    ixcudaAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                      // (*getDeviceByPciBusId)(int *dev,
-                                      // const char *pciBusId);
-    ixcudaAdaptorLaunchHostFunc,
+struct flagcxDeviceAdaptor ixcudaAdaptor {
+  "IXCUDA",
+      // Basic functions
+      ixcudaAdaptorDeviceSynchronize, ixcudaAdaptorDeviceMemcpy,
+      ixcudaAdaptorDeviceMemset, ixcudaAdaptorDeviceMalloc,
+      ixcudaAdaptorDeviceFree, ixcudaAdaptorSetDevice, ixcudaAdaptorGetDevice,
+      ixcudaAdaptorGetDeviceCount, ixcudaAdaptorGetVendor, NULL,
+      // GDR functions
+      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+      ixcudaAdaptorGdrMemAlloc, ixcudaAdaptorGdrMemFree,
+      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+            // *memHandle);
+      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+            // sz);
+      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+      // Stream functions
+      ixcudaAdaptorStreamCreate, ixcudaAdaptorStreamDestroy,
+      ixcudaAdaptorStreamCopy, ixcudaAdaptorStreamFree,
+      ixcudaAdaptorStreamSynchronize, ixcudaAdaptorStreamQuery,
+      ixcudaAdaptorStreamWaitEvent,
+      // Event functions
+      ixcudaAdaptorEventCreate, ixcudaAdaptorEventDestroy,
+      ixcudaAdaptorEventRecord, ixcudaAdaptorEventSynchronize,
+      ixcudaAdaptorEventQuery,
+      // IpcMemHandle functions
+      ixcudaAdaptorIpcMemHandleCreate, ixcudaAdaptorIpcMemHandleGet,
+      ixcudaAdaptorIpcMemHandleOpen, ixcudaAdaptorIpcMemHandleClose,
+      ixcudaAdaptorIpcMemHandleFree,
+      // Kernel launch
+      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+            // share_mem, void *stream, void *memHandle);
+      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+      NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream, void
+            // *args);
+      // Others
+      ixcudaAdaptorGetDeviceProperties, // flagcxResult_t
+                                        // (*getDeviceProperties)(struct
+                                        // flagcxDeviceProps *props, int dev);
+      ixcudaAdaptorGetDevicePciBusId,   // flagcxResult_t
+                                        // (*getDevicePciBusId)(char *pciBusId,
+                                        // int len, int dev);
+      ixcudaAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                        // (*getDeviceByPciBusId)(int *dev,
+                                        // const char *pciBusId);
+      ixcudaAdaptorLaunchHostFunc,
 
-    // DMA buffer
-    NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-    NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-          // void *buffer, size_t size, unsigned long long flags);
-    NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
-          // start,
-          // flagcxEvent_t end);
-    ixcudaAdaptorStreamWaitValue64,
+      // DMA buffer
+      NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
+      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
+            // void *buffer, size_t size, unsigned long long flags);
+      NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
+            // start,
+            // flagcxEvent_t end);
+      ixcudaAdaptorStreamWaitValue64,
 };
 
 #endif // USE_ILUVATAR_COREX_ADAPTOR

--- a/flagcx/adaptor/device/kunlunxin_adaptor.cc
+++ b/flagcx/adaptor/device/kunlunxin_adaptor.cc
@@ -360,63 +360,82 @@ flagcxResult_t kunlunAdaptorGetDeviceByPciBusId(int *dev,
   return flagcxSuccess;
 }
 
-struct flagcxDeviceAdaptor kunlunAdaptor {
-  "KUNLUN",
-      // Basic functions
-      kunlunAdaptorDeviceSynchronize, kunlunAdaptorDeviceMemcpy,
-      kunlunAdaptorDeviceMemset, kunlunAdaptorDeviceMalloc,
-      kunlunAdaptorDeviceFree, kunlunAdaptorSetDevice, kunlunAdaptorGetDevice,
-      kunlunAdaptorGetDeviceCount, kunlunAdaptorGetVendor,
-      kunlunAdaptorHostGetDevicePointer,
-      // GDR functions
-      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-      kunlunAdaptorGdrMemAlloc, kunlunAdaptorGdrMemFree,
-      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-            // *memHandle);
-      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-      kunlunAdaptorGdrPtrMmap,   // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr,
-                                 // void *devptr, size_t sz);
-      kunlunAdaptorGdrPtrMunmap, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr,
-                                 // size_t sz);
-      // Stream functions
-      kunlunAdaptorStreamCreate, kunlunAdaptorStreamDestroy,
-      kunlunAdaptorStreamCopy, kunlunAdaptorStreamFree,
-      kunlunAdaptorStreamSynchronize, kunlunAdaptorStreamQuery,
-      kunlunAdaptorStreamWaitEvent,
-      // Event functions
-      kunlunAdaptorEventCreate, kunlunAdaptorEventDestroy,
-      kunlunAdaptorEventRecord, kunlunAdaptorEventSynchronize,
-      kunlunAdaptorEventQuery,
-      // IpcMemHandle functions
-      kunlunAdaptorIpcMemHandleCreate, kunlunAdaptorIpcMemHandleGet,
-      kunlunAdaptorIpcMemHandleOpen, kunlunAdaptorIpcMemHandleClose,
-      kunlunAdaptorIpcMemHandleFree,
-      // Kernel launch
-      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-            // share_mem, void *stream, void *memHandle);
-      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-      kunlunAdaptorLaunchDeviceFunc,
-      // Others
-      kunlunAdaptorGetDeviceProperties, // flagcxResult_t
-                                        // (*getDeviceProperties)(struct
-                                        // flagcxDevProps *props, int dev);
-      kunlunAdaptorGetDevicePciBusId,   // flagcxResult_t
-                                        // (*getDevicePciBusId)(char *pciBusId,
-                                        // int len, int dev);
-      kunlunAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                        // (*getDeviceByPciBusId)(int
-                                        // *dev, const char *pciBusId);
-      kunlunAdaptorLaunchHostFunc,
-      // DMA buffer
-      NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-            // void *buffer, size_t size, unsigned long long flags);
-      NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
-            // start, flagcxEvent_t end);
+static flagcxResult_t kunlunAdaptorStreamWaitValue64(flagcxStream_t, void *,
+                                                     uint64_t, int) {
+  return flagcxNotSupported;
+}
+
+struct flagcxDeviceAdaptor kunlunAdaptor{
+    "KUNLUN",
+    // Basic functions
+    kunlunAdaptorDeviceSynchronize,
+    kunlunAdaptorDeviceMemcpy,
+    kunlunAdaptorDeviceMemset,
+    kunlunAdaptorDeviceMalloc,
+    kunlunAdaptorDeviceFree,
+    kunlunAdaptorSetDevice,
+    kunlunAdaptorGetDevice,
+    kunlunAdaptorGetDeviceCount,
+    kunlunAdaptorGetVendor,
+    kunlunAdaptorHostGetDevicePointer,
+    // GDR functions
+    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+    kunlunAdaptorGdrMemAlloc,
+    kunlunAdaptorGdrMemFree,
+    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+          // *memHandle);
+    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+    kunlunAdaptorGdrPtrMmap,   // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr,
+                               // void *devptr, size_t sz);
+    kunlunAdaptorGdrPtrMunmap, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr,
+                               // size_t sz);
+    // Stream functions
+    kunlunAdaptorStreamCreate,
+    kunlunAdaptorStreamDestroy,
+    kunlunAdaptorStreamCopy,
+    kunlunAdaptorStreamFree,
+    kunlunAdaptorStreamSynchronize,
+    kunlunAdaptorStreamQuery,
+    kunlunAdaptorStreamWaitEvent,
+    // Event functions
+    kunlunAdaptorEventCreate,
+    kunlunAdaptorEventDestroy,
+    kunlunAdaptorEventRecord,
+    kunlunAdaptorEventSynchronize,
+    kunlunAdaptorEventQuery,
+    // IpcMemHandle functions
+    kunlunAdaptorIpcMemHandleCreate,
+    kunlunAdaptorIpcMemHandleGet,
+    kunlunAdaptorIpcMemHandleOpen,
+    kunlunAdaptorIpcMemHandleClose,
+    kunlunAdaptorIpcMemHandleFree,
+    // Kernel launch
+    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+          // share_mem, void *stream, void *memHandle);
+    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+    kunlunAdaptorLaunchDeviceFunc,
+    // Others
+    kunlunAdaptorGetDeviceProperties, // flagcxResult_t
+                                      // (*getDeviceProperties)(struct
+                                      // flagcxDevProps *props, int dev);
+    kunlunAdaptorGetDevicePciBusId,   // flagcxResult_t
+                                      // (*getDevicePciBusId)(char *pciBusId,
+                                      // int len, int dev);
+    kunlunAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                      // (*getDeviceByPciBusId)(int
+                                      // *dev, const char *pciBusId);
+    kunlunAdaptorLaunchHostFunc,
+    // DMA buffer
+    NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
+    NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
+          // void *buffer, size_t size, unsigned long long flags);
+    NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
+          // start, flagcxEvent_t end);
+    kunlunAdaptorStreamWaitValue64,
 };
 
 #endif // USE_KUNLUNXIN_ADAPTOR

--- a/flagcx/adaptor/device/kunlunxin_adaptor.cc
+++ b/flagcx/adaptor/device/kunlunxin_adaptor.cc
@@ -365,77 +365,64 @@ static flagcxResult_t kunlunAdaptorStreamWaitValue64(flagcxStream_t, void *,
   return flagcxNotSupported;
 }
 
-struct flagcxDeviceAdaptor kunlunAdaptor{
-    "KUNLUN",
-    // Basic functions
-    kunlunAdaptorDeviceSynchronize,
-    kunlunAdaptorDeviceMemcpy,
-    kunlunAdaptorDeviceMemset,
-    kunlunAdaptorDeviceMalloc,
-    kunlunAdaptorDeviceFree,
-    kunlunAdaptorSetDevice,
-    kunlunAdaptorGetDevice,
-    kunlunAdaptorGetDeviceCount,
-    kunlunAdaptorGetVendor,
-    kunlunAdaptorHostGetDevicePointer,
-    // GDR functions
-    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-    kunlunAdaptorGdrMemAlloc,
-    kunlunAdaptorGdrMemFree,
-    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-          // *memHandle);
-    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-    kunlunAdaptorGdrPtrMmap,   // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr,
-                               // void *devptr, size_t sz);
-    kunlunAdaptorGdrPtrMunmap, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr,
-                               // size_t sz);
-    // Stream functions
-    kunlunAdaptorStreamCreate,
-    kunlunAdaptorStreamDestroy,
-    kunlunAdaptorStreamCopy,
-    kunlunAdaptorStreamFree,
-    kunlunAdaptorStreamSynchronize,
-    kunlunAdaptorStreamQuery,
-    kunlunAdaptorStreamWaitEvent,
-    // Event functions
-    kunlunAdaptorEventCreate,
-    kunlunAdaptorEventDestroy,
-    kunlunAdaptorEventRecord,
-    kunlunAdaptorEventSynchronize,
-    kunlunAdaptorEventQuery,
-    // IpcMemHandle functions
-    kunlunAdaptorIpcMemHandleCreate,
-    kunlunAdaptorIpcMemHandleGet,
-    kunlunAdaptorIpcMemHandleOpen,
-    kunlunAdaptorIpcMemHandleClose,
-    kunlunAdaptorIpcMemHandleFree,
-    // Kernel launch
-    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-          // share_mem, void *stream, void *memHandle);
-    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-    kunlunAdaptorLaunchDeviceFunc,
-    // Others
-    kunlunAdaptorGetDeviceProperties, // flagcxResult_t
-                                      // (*getDeviceProperties)(struct
-                                      // flagcxDevProps *props, int dev);
-    kunlunAdaptorGetDevicePciBusId,   // flagcxResult_t
-                                      // (*getDevicePciBusId)(char *pciBusId,
-                                      // int len, int dev);
-    kunlunAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                      // (*getDeviceByPciBusId)(int
-                                      // *dev, const char *pciBusId);
-    kunlunAdaptorLaunchHostFunc,
-    // DMA buffer
-    NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-    NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-          // void *buffer, size_t size, unsigned long long flags);
-    NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
-          // start, flagcxEvent_t end);
-    kunlunAdaptorStreamWaitValue64,
+struct flagcxDeviceAdaptor kunlunAdaptor {
+  "KUNLUN",
+      // Basic functions
+      kunlunAdaptorDeviceSynchronize, kunlunAdaptorDeviceMemcpy,
+      kunlunAdaptorDeviceMemset, kunlunAdaptorDeviceMalloc,
+      kunlunAdaptorDeviceFree, kunlunAdaptorSetDevice, kunlunAdaptorGetDevice,
+      kunlunAdaptorGetDeviceCount, kunlunAdaptorGetVendor,
+      kunlunAdaptorHostGetDevicePointer,
+      // GDR functions
+      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+      kunlunAdaptorGdrMemAlloc, kunlunAdaptorGdrMemFree,
+      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+            // *memHandle);
+      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+      kunlunAdaptorGdrPtrMmap,   // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr,
+                                 // void *devptr, size_t sz);
+      kunlunAdaptorGdrPtrMunmap, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr,
+                                 // size_t sz);
+      // Stream functions
+      kunlunAdaptorStreamCreate, kunlunAdaptorStreamDestroy,
+      kunlunAdaptorStreamCopy, kunlunAdaptorStreamFree,
+      kunlunAdaptorStreamSynchronize, kunlunAdaptorStreamQuery,
+      kunlunAdaptorStreamWaitEvent,
+      // Event functions
+      kunlunAdaptorEventCreate, kunlunAdaptorEventDestroy,
+      kunlunAdaptorEventRecord, kunlunAdaptorEventSynchronize,
+      kunlunAdaptorEventQuery,
+      // IpcMemHandle functions
+      kunlunAdaptorIpcMemHandleCreate, kunlunAdaptorIpcMemHandleGet,
+      kunlunAdaptorIpcMemHandleOpen, kunlunAdaptorIpcMemHandleClose,
+      kunlunAdaptorIpcMemHandleFree,
+      // Kernel launch
+      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+            // share_mem, void *stream, void *memHandle);
+      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+      kunlunAdaptorLaunchDeviceFunc,
+      // Others
+      kunlunAdaptorGetDeviceProperties, // flagcxResult_t
+                                        // (*getDeviceProperties)(struct
+                                        // flagcxDevProps *props, int dev);
+      kunlunAdaptorGetDevicePciBusId,   // flagcxResult_t
+                                        // (*getDevicePciBusId)(char *pciBusId,
+                                        // int len, int dev);
+      kunlunAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                        // (*getDeviceByPciBusId)(int
+                                        // *dev, const char *pciBusId);
+      kunlunAdaptorLaunchHostFunc,
+      // DMA buffer
+      NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
+      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
+            // void *buffer, size_t size, unsigned long long flags);
+      NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
+            // start, flagcxEvent_t end);
+      kunlunAdaptorStreamWaitValue64,
 };
 
 #endif // USE_KUNLUNXIN_ADAPTOR

--- a/flagcx/adaptor/device/maca_adaptor.cc
+++ b/flagcx/adaptor/device/maca_adaptor.cc
@@ -344,75 +344,58 @@ static flagcxResult_t macaAdaptorStreamWaitValue64(flagcxStream_t, void *,
   return flagcxNotSupported;
 }
 
-struct flagcxDeviceAdaptor macaAdaptor{
-    "MACA",
-    // Basic functions
-    macaAdaptorDeviceSynchronize,
-    macaAdaptorDeviceMemcpy,
-    macaAdaptorDeviceMemset,
-    macaAdaptorDeviceMalloc,
-    macaAdaptorDeviceFree,
-    macaAdaptorSetDevice,
-    macaAdaptorGetDevice,
-    macaAdaptorGetDeviceCount,
-    macaAdaptorGetVendor,
-    NULL,
-    // GDR functions
-    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-    macaAdaptorGdrMemAlloc,
-    macaAdaptorGdrMemFree,
-    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-          // *memHandle);
-    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-          // sz);
-    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-    // Stream functions
-    macaAdaptorStreamCreate,
-    macaAdaptorStreamDestroy,
-    macaAdaptorStreamCopy,
-    macaAdaptorStreamFree,
-    macaAdaptorStreamSynchronize,
-    macaAdaptorStreamQuery,
-    macaAdaptorStreamWaitEvent,
-    // Event functions
-    macaAdaptorEventCreate,
-    macaAdaptorEventDestroy,
-    macaAdaptorEventRecord,
-    macaAdaptorEventSynchronize,
-    macaAdaptorEventQuery,
-    // IpcMemHandle functions
-    macaAdaptorIpcMemHandleCreate,
-    macaAdaptorIpcMemHandleGet,
-    macaAdaptorIpcMemHandleOpen,
-    macaAdaptorIpcMemHandleClose,
-    macaAdaptorIpcMemHandleFree,
-    // Kernel launch
-    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-          // share_mem, void *stream, void *memHandle);
-    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-    NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream,
-          // void *args);
-    // Others
-    macaAdaptorGetDeviceProperties, // flagcxResult_t
-                                    // (*getDeviceProperties)(struct
-                                    // flagcxDevProps *props, int dev);
-    macaAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
+struct flagcxDeviceAdaptor macaAdaptor {
+  "MACA",
+      // Basic functions
+      macaAdaptorDeviceSynchronize, macaAdaptorDeviceMemcpy,
+      macaAdaptorDeviceMemset, macaAdaptorDeviceMalloc, macaAdaptorDeviceFree,
+      macaAdaptorSetDevice, macaAdaptorGetDevice, macaAdaptorGetDeviceCount,
+      macaAdaptorGetVendor, NULL,
+      // GDR functions
+      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+      macaAdaptorGdrMemAlloc, macaAdaptorGdrMemFree,
+      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+            // *memHandle);
+      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+            // sz);
+      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+      // Stream functions
+      macaAdaptorStreamCreate, macaAdaptorStreamDestroy, macaAdaptorStreamCopy,
+      macaAdaptorStreamFree, macaAdaptorStreamSynchronize,
+      macaAdaptorStreamQuery, macaAdaptorStreamWaitEvent,
+      // Event functions
+      macaAdaptorEventCreate, macaAdaptorEventDestroy, macaAdaptorEventRecord,
+      macaAdaptorEventSynchronize, macaAdaptorEventQuery,
+      // IpcMemHandle functions
+      macaAdaptorIpcMemHandleCreate, macaAdaptorIpcMemHandleGet,
+      macaAdaptorIpcMemHandleOpen, macaAdaptorIpcMemHandleClose,
+      macaAdaptorIpcMemHandleFree,
+      // Kernel launch
+      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+            // share_mem, void *stream, void *memHandle);
+      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+      NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream,
+            // void *args);
+      // Others
+      macaAdaptorGetDeviceProperties, // flagcxResult_t
+                                      // (*getDeviceProperties)(struct
+                                      // flagcxDevProps *props, int dev);
+      macaAdaptorGetDevicePciBusId, // flagcxResult_t (*getDevicePciBusId)(char
                                     // *pciBusId, int len, int dev);
-    macaAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                    // (*getDeviceByPciBusId)(int
-                                    // *dev, const char *pciBusId);
-    macaAdaptorLaunchHostFunc,
-    // DMA buffer
-    NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-    NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-          // void *buffer, size_t size, unsigned long long flags);
-    macaAdaptorEventElapsedTime,
-    macaAdaptorStreamWaitValue64,
+      macaAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                      // (*getDeviceByPciBusId)(int
+                                      // *dev, const char *pciBusId);
+      macaAdaptorLaunchHostFunc,
+      // DMA buffer
+      NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
+      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
+            // void *buffer, size_t size, unsigned long long flags);
+      macaAdaptorEventElapsedTime, macaAdaptorStreamWaitValue64,
 };
 
 #endif // USE_METAX_ADAPTOR

--- a/flagcx/adaptor/device/maca_adaptor.cc
+++ b/flagcx/adaptor/device/maca_adaptor.cc
@@ -339,58 +339,80 @@ flagcxResult_t macaAdaptorEventElapsedTime(float *ms, flagcxEvent_t start,
   }
 }
 
-struct flagcxDeviceAdaptor macaAdaptor {
-  "MACA",
-      // Basic functions
-      macaAdaptorDeviceSynchronize, macaAdaptorDeviceMemcpy,
-      macaAdaptorDeviceMemset, macaAdaptorDeviceMalloc, macaAdaptorDeviceFree,
-      macaAdaptorSetDevice, macaAdaptorGetDevice, macaAdaptorGetDeviceCount,
-      macaAdaptorGetVendor, NULL,
-      // GDR functions
-      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-      macaAdaptorGdrMemAlloc, macaAdaptorGdrMemFree,
-      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-            // *memHandle);
-      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-            // sz);
-      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-      // Stream functions
-      macaAdaptorStreamCreate, macaAdaptorStreamDestroy, macaAdaptorStreamCopy,
-      macaAdaptorStreamFree, macaAdaptorStreamSynchronize,
-      macaAdaptorStreamQuery, macaAdaptorStreamWaitEvent,
-      // Event functions
-      macaAdaptorEventCreate, macaAdaptorEventDestroy, macaAdaptorEventRecord,
-      macaAdaptorEventSynchronize, macaAdaptorEventQuery,
-      // IpcMemHandle functions
-      macaAdaptorIpcMemHandleCreate, macaAdaptorIpcMemHandleGet,
-      macaAdaptorIpcMemHandleOpen, macaAdaptorIpcMemHandleClose,
-      macaAdaptorIpcMemHandleFree,
-      // Kernel launch
-      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-            // share_mem, void *stream, void *memHandle);
-      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-      NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream,
-            // void *args);
-      // Others
-      macaAdaptorGetDeviceProperties, // flagcxResult_t
-                                      // (*getDeviceProperties)(struct
-                                      // flagcxDevProps *props, int dev);
-      macaAdaptorGetDevicePciBusId, // flagcxResult_t (*getDevicePciBusId)(char
+static flagcxResult_t macaAdaptorStreamWaitValue64(flagcxStream_t, void *,
+                                                   uint64_t, int) {
+  return flagcxNotSupported;
+}
+
+struct flagcxDeviceAdaptor macaAdaptor{
+    "MACA",
+    // Basic functions
+    macaAdaptorDeviceSynchronize,
+    macaAdaptorDeviceMemcpy,
+    macaAdaptorDeviceMemset,
+    macaAdaptorDeviceMalloc,
+    macaAdaptorDeviceFree,
+    macaAdaptorSetDevice,
+    macaAdaptorGetDevice,
+    macaAdaptorGetDeviceCount,
+    macaAdaptorGetVendor,
+    NULL,
+    // GDR functions
+    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+    macaAdaptorGdrMemAlloc,
+    macaAdaptorGdrMemFree,
+    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+          // *memHandle);
+    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+          // sz);
+    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+    // Stream functions
+    macaAdaptorStreamCreate,
+    macaAdaptorStreamDestroy,
+    macaAdaptorStreamCopy,
+    macaAdaptorStreamFree,
+    macaAdaptorStreamSynchronize,
+    macaAdaptorStreamQuery,
+    macaAdaptorStreamWaitEvent,
+    // Event functions
+    macaAdaptorEventCreate,
+    macaAdaptorEventDestroy,
+    macaAdaptorEventRecord,
+    macaAdaptorEventSynchronize,
+    macaAdaptorEventQuery,
+    // IpcMemHandle functions
+    macaAdaptorIpcMemHandleCreate,
+    macaAdaptorIpcMemHandleGet,
+    macaAdaptorIpcMemHandleOpen,
+    macaAdaptorIpcMemHandleClose,
+    macaAdaptorIpcMemHandleFree,
+    // Kernel launch
+    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+          // share_mem, void *stream, void *memHandle);
+    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+    NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream,
+          // void *args);
+    // Others
+    macaAdaptorGetDeviceProperties, // flagcxResult_t
+                                    // (*getDeviceProperties)(struct
+                                    // flagcxDevProps *props, int dev);
+    macaAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
                                     // *pciBusId, int len, int dev);
-      macaAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                      // (*getDeviceByPciBusId)(int
-                                      // *dev, const char *pciBusId);
-      macaAdaptorLaunchHostFunc,
-      // DMA buffer
-      NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-            // void *buffer, size_t size, unsigned long long flags);
-      macaAdaptorEventElapsedTime,
+    macaAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                    // (*getDeviceByPciBusId)(int
+                                    // *dev, const char *pciBusId);
+    macaAdaptorLaunchHostFunc,
+    // DMA buffer
+    NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
+    NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
+          // void *buffer, size_t size, unsigned long long flags);
+    macaAdaptorEventElapsedTime,
+    macaAdaptorStreamWaitValue64,
 };
 
 #endif // USE_METAX_ADAPTOR

--- a/flagcx/adaptor/device/mlu_adaptor.cc
+++ b/flagcx/adaptor/device/mlu_adaptor.cc
@@ -289,76 +289,60 @@ static flagcxResult_t mluAdaptorStreamWaitValue64(flagcxStream_t, void *,
   return flagcxNotSupported;
 }
 
-struct flagcxDeviceAdaptor mluAdaptor{
-    "MLU",
-    // Basic functions
-    mluAdaptorDeviceSynchronize,
-    mluAdaptorDeviceMemcpy,
-    mluAdaptorDeviceMemset,
-    mluAdaptorDeviceMalloc,
-    mluAdaptorDeviceFree,
-    mluAdaptorSetDevice,
-    mluAdaptorGetDevice,
-    mluAdaptorGetDeviceCount,
-    mluAdaptorGetVendor,
-    NULL,
-    // GDR functions
-    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-    mluAdaptorGdrMemAlloc,
-    mluAdaptorGdrMemFree,
-    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-          // *memHandle);
-    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-          // sz);
-    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-    // Stream functions
-    mluAdaptorStreamCreate,
-    mluAdaptorStreamDestroy,
-    mluAdaptorStreamCopy,
-    mluAdaptorStreamFree,
-    mluAdaptorStreamSynchronize,
-    mluAdaptorStreamQuery,
-    mluAdaptorStreamWaitEvent,
-    // Event functions
-    mluAdaptorEventCreate,
-    mluAdaptorEventDestroy,
-    mluAdaptorEventRecord,
-    mluAdaptorEventSynchronize,
-    mluAdaptorEventQuery,
-    // IpcMemHandle functions
-    mluAdaptorIpcMemHandleCreate,
-    mluAdaptorIpcMemHandleGet,
-    mluAdaptorIpcMemHandleOpen,
-    mluAdaptorIpcMemHandleClose,
-    mluAdaptorIpcMemHandleFree,
-    // Kernel launch
-    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-          // share_mem, void *stream, void *memHandle);
-    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-    NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream,
-          // void *args);
-    // Others
-    mluAdaptorGetDeviceProperties, // flagcxResult_t
-                                   // (*getDeviceProperties)(struct
-                                   // flagcxDevProps *props, int dev);
-    mluAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
-                                   // *pciBusId, int len, int dev);
-    mluAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                   // (*getDeviceByPciBusId)(int
-                                   // *dev, const char *pciBusId);
-    mluAdaptorLaunchHostFunc,
-    // DMA buffer
-    NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-    NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-          // void *buffer, size_t size, unsigned long long flags);
-    NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
-          // start, flagcxEvent_t end);
-    mluAdaptorStreamWaitValue64,
+struct flagcxDeviceAdaptor mluAdaptor {
+  "MLU",
+      // Basic functions
+      mluAdaptorDeviceSynchronize, mluAdaptorDeviceMemcpy,
+      mluAdaptorDeviceMemset, mluAdaptorDeviceMalloc, mluAdaptorDeviceFree,
+      mluAdaptorSetDevice, mluAdaptorGetDevice, mluAdaptorGetDeviceCount,
+      mluAdaptorGetVendor, NULL,
+      // GDR functions
+      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+      mluAdaptorGdrMemAlloc, mluAdaptorGdrMemFree,
+      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+            // *memHandle);
+      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+            // sz);
+      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+      // Stream functions
+      mluAdaptorStreamCreate, mluAdaptorStreamDestroy, mluAdaptorStreamCopy,
+      mluAdaptorStreamFree, mluAdaptorStreamSynchronize, mluAdaptorStreamQuery,
+      mluAdaptorStreamWaitEvent,
+      // Event functions
+      mluAdaptorEventCreate, mluAdaptorEventDestroy, mluAdaptorEventRecord,
+      mluAdaptorEventSynchronize, mluAdaptorEventQuery,
+      // IpcMemHandle functions
+      mluAdaptorIpcMemHandleCreate, mluAdaptorIpcMemHandleGet,
+      mluAdaptorIpcMemHandleOpen, mluAdaptorIpcMemHandleClose,
+      mluAdaptorIpcMemHandleFree,
+      // Kernel launch
+      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+            // share_mem, void *stream, void *memHandle);
+      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+      NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream,
+            // void *args);
+      // Others
+      mluAdaptorGetDeviceProperties, // flagcxResult_t
+                                     // (*getDeviceProperties)(struct
+                                     // flagcxDevProps *props, int dev);
+      mluAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
+                                     // *pciBusId, int len, int dev);
+      mluAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                     // (*getDeviceByPciBusId)(int
+                                     // *dev, const char *pciBusId);
+      mluAdaptorLaunchHostFunc,
+      // DMA buffer
+      NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
+      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
+            // void *buffer, size_t size, unsigned long long flags);
+      NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
+            // start, flagcxEvent_t end);
+      mluAdaptorStreamWaitValue64,
 };
 
 #endif // USE_CAMBRICON_ADAPTOR

--- a/flagcx/adaptor/device/mlu_adaptor.cc
+++ b/flagcx/adaptor/device/mlu_adaptor.cc
@@ -284,59 +284,81 @@ flagcxResult_t mluAdaptorIpcMemHandleFree(flagcxIpcMemHandle_t handle) {
   return flagcxNotSupported;
 }
 
-struct flagcxDeviceAdaptor mluAdaptor {
-  "MLU",
-      // Basic functions
-      mluAdaptorDeviceSynchronize, mluAdaptorDeviceMemcpy,
-      mluAdaptorDeviceMemset, mluAdaptorDeviceMalloc, mluAdaptorDeviceFree,
-      mluAdaptorSetDevice, mluAdaptorGetDevice, mluAdaptorGetDeviceCount,
-      mluAdaptorGetVendor, NULL,
-      // GDR functions
-      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-      mluAdaptorGdrMemAlloc, mluAdaptorGdrMemFree,
-      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-            // *memHandle);
-      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-            // sz);
-      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-      // Stream functions
-      mluAdaptorStreamCreate, mluAdaptorStreamDestroy, mluAdaptorStreamCopy,
-      mluAdaptorStreamFree, mluAdaptorStreamSynchronize, mluAdaptorStreamQuery,
-      mluAdaptorStreamWaitEvent,
-      // Event functions
-      mluAdaptorEventCreate, mluAdaptorEventDestroy, mluAdaptorEventRecord,
-      mluAdaptorEventSynchronize, mluAdaptorEventQuery,
-      // IpcMemHandle functions
-      mluAdaptorIpcMemHandleCreate, mluAdaptorIpcMemHandleGet,
-      mluAdaptorIpcMemHandleOpen, mluAdaptorIpcMemHandleClose,
-      mluAdaptorIpcMemHandleFree,
-      // Kernel launch
-      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-            // share_mem, void *stream, void *memHandle);
-      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-      NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream,
-            // void *args);
-      // Others
-      mluAdaptorGetDeviceProperties, // flagcxResult_t
-                                     // (*getDeviceProperties)(struct
-                                     // flagcxDevProps *props, int dev);
-      mluAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
-                                     // *pciBusId, int len, int dev);
-      mluAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                     // (*getDeviceByPciBusId)(int
-                                     // *dev, const char *pciBusId);
-      mluAdaptorLaunchHostFunc,
-      // DMA buffer
-      NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-            // void *buffer, size_t size, unsigned long long flags);
-      NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
-            // start, flagcxEvent_t end);
+static flagcxResult_t mluAdaptorStreamWaitValue64(flagcxStream_t, void *,
+                                                  uint64_t, int) {
+  return flagcxNotSupported;
+}
+
+struct flagcxDeviceAdaptor mluAdaptor{
+    "MLU",
+    // Basic functions
+    mluAdaptorDeviceSynchronize,
+    mluAdaptorDeviceMemcpy,
+    mluAdaptorDeviceMemset,
+    mluAdaptorDeviceMalloc,
+    mluAdaptorDeviceFree,
+    mluAdaptorSetDevice,
+    mluAdaptorGetDevice,
+    mluAdaptorGetDeviceCount,
+    mluAdaptorGetVendor,
+    NULL,
+    // GDR functions
+    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+    mluAdaptorGdrMemAlloc,
+    mluAdaptorGdrMemFree,
+    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+          // *memHandle);
+    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+          // sz);
+    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+    // Stream functions
+    mluAdaptorStreamCreate,
+    mluAdaptorStreamDestroy,
+    mluAdaptorStreamCopy,
+    mluAdaptorStreamFree,
+    mluAdaptorStreamSynchronize,
+    mluAdaptorStreamQuery,
+    mluAdaptorStreamWaitEvent,
+    // Event functions
+    mluAdaptorEventCreate,
+    mluAdaptorEventDestroy,
+    mluAdaptorEventRecord,
+    mluAdaptorEventSynchronize,
+    mluAdaptorEventQuery,
+    // IpcMemHandle functions
+    mluAdaptorIpcMemHandleCreate,
+    mluAdaptorIpcMemHandleGet,
+    mluAdaptorIpcMemHandleOpen,
+    mluAdaptorIpcMemHandleClose,
+    mluAdaptorIpcMemHandleFree,
+    // Kernel launch
+    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+          // share_mem, void *stream, void *memHandle);
+    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+    NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream,
+          // void *args);
+    // Others
+    mluAdaptorGetDeviceProperties, // flagcxResult_t
+                                   // (*getDeviceProperties)(struct
+                                   // flagcxDevProps *props, int dev);
+    mluAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
+                                   // *pciBusId, int len, int dev);
+    mluAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                   // (*getDeviceByPciBusId)(int
+                                   // *dev, const char *pciBusId);
+    mluAdaptorLaunchHostFunc,
+    // DMA buffer
+    NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
+    NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
+          // void *buffer, size_t size, unsigned long long flags);
+    NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
+          // start, flagcxEvent_t end);
+    mluAdaptorStreamWaitValue64,
 };
 
 #endif // USE_CAMBRICON_ADAPTOR

--- a/flagcx/adaptor/device/musa_adaptor.cc
+++ b/flagcx/adaptor/device/musa_adaptor.cc
@@ -315,76 +315,60 @@ static flagcxResult_t musaAdaptorStreamWaitValue64(flagcxStream_t, void *,
   return flagcxNotSupported;
 }
 
-struct flagcxDeviceAdaptor musaAdaptor{
-    "MUSA",
-    // Basic functions
-    musaAdaptorDeviceSynchronize,
-    musaAdaptorDeviceMemcpy,
-    musaAdaptorDeviceMemset,
-    musaAdaptorDeviceMalloc,
-    musaAdaptorDeviceFree,
-    musaAdaptorSetDevice,
-    musaAdaptorGetDevice,
-    musaAdaptorGetDeviceCount,
-    musaAdaptorGetVendor,
-    NULL,
-    // GDR functions
-    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-    musaAdaptorGdrMemAlloc,
-    musaAdaptorGdrMemFree,
-    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-          // *memHandle);
-    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-          // sz);
-    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-    // Stream functions
-    musaAdaptorStreamCreate,
-    musaAdaptorStreamDestroy,
-    musaAdaptorStreamCopy,
-    musaAdaptorStreamFree,
-    musaAdaptorStreamSynchronize,
-    musaAdaptorStreamQuery,
-    musaAdaptorStreamWaitEvent,
-    // Event functions
-    musaAdaptorEventCreate,
-    musaAdaptorEventDestroy,
-    musaAdaptorEventRecord,
-    musaAdaptorEventSynchronize,
-    musaAdaptorEventQuery,
-    // IpcMemHandle functions
-    musaAdaptorIpcMemHandleCreate,
-    musaAdaptorIpcMemHandleGet,
-    musaAdaptorIpcMemHandleOpen,
-    musaAdaptorIpcMemHandleClose,
-    musaAdaptorIpcMemHandleFree,
-    // Kernel launch
-    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-          // share_mem, void *stream, void *memHandle);
-    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-    NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream, void
-          // *args);
-    // Others
-    musaAdaptorGetDeviceProperties, // flagcxResult_t
-                                    // (*getDeviceProperties)(struct
-                                    // flagcxDevProps *props, int dev);
-    musaAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
+struct flagcxDeviceAdaptor musaAdaptor {
+  "MUSA",
+      // Basic functions
+      musaAdaptorDeviceSynchronize, musaAdaptorDeviceMemcpy,
+      musaAdaptorDeviceMemset, musaAdaptorDeviceMalloc, musaAdaptorDeviceFree,
+      musaAdaptorSetDevice, musaAdaptorGetDevice, musaAdaptorGetDeviceCount,
+      musaAdaptorGetVendor, NULL,
+      // GDR functions
+      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+      musaAdaptorGdrMemAlloc, musaAdaptorGdrMemFree,
+      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+            // *memHandle);
+      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+            // sz);
+      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+      // Stream functions
+      musaAdaptorStreamCreate, musaAdaptorStreamDestroy, musaAdaptorStreamCopy,
+      musaAdaptorStreamFree, musaAdaptorStreamSynchronize,
+      musaAdaptorStreamQuery, musaAdaptorStreamWaitEvent,
+      // Event functions
+      musaAdaptorEventCreate, musaAdaptorEventDestroy, musaAdaptorEventRecord,
+      musaAdaptorEventSynchronize, musaAdaptorEventQuery,
+      // IpcMemHandle functions
+      musaAdaptorIpcMemHandleCreate, musaAdaptorIpcMemHandleGet,
+      musaAdaptorIpcMemHandleOpen, musaAdaptorIpcMemHandleClose,
+      musaAdaptorIpcMemHandleFree,
+      // Kernel launch
+      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+            // share_mem, void *stream, void *memHandle);
+      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+      NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream, void
+            // *args);
+      // Others
+      musaAdaptorGetDeviceProperties, // flagcxResult_t
+                                      // (*getDeviceProperties)(struct
+                                      // flagcxDevProps *props, int dev);
+      musaAdaptorGetDevicePciBusId, // flagcxResult_t (*getDevicePciBusId)(char
                                     // *pciBusId, int len, int dev);
-    musaAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                    // (*getDeviceByPciBusId)(int
-                                    // *dev, const char *pciBusId);
-    musaAdaptorLaunchHostFunc,
-    // DMA buffer
-    NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-    NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-          // void *buffer, size_t size, unsigned long long flags);
-    NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
-          // start, flagcxEvent_t end);
-    musaAdaptorStreamWaitValue64,
+      musaAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                      // (*getDeviceByPciBusId)(int
+                                      // *dev, const char *pciBusId);
+      musaAdaptorLaunchHostFunc,
+      // DMA buffer
+      NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
+      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
+            // void *buffer, size_t size, unsigned long long flags);
+      NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
+            // start, flagcxEvent_t end);
+      musaAdaptorStreamWaitValue64,
 };
 
 #endif // USE_MUSA_ADAPTOR

--- a/flagcx/adaptor/device/musa_adaptor.cc
+++ b/flagcx/adaptor/device/musa_adaptor.cc
@@ -310,59 +310,81 @@ flagcxResult_t musaAdaptorGetDeviceByPciBusId(int *dev, const char *pciBusId) {
   return flagcxSuccess;
 }
 
-struct flagcxDeviceAdaptor musaAdaptor {
-  "MUSA",
-      // Basic functions
-      musaAdaptorDeviceSynchronize, musaAdaptorDeviceMemcpy,
-      musaAdaptorDeviceMemset, musaAdaptorDeviceMalloc, musaAdaptorDeviceFree,
-      musaAdaptorSetDevice, musaAdaptorGetDevice, musaAdaptorGetDeviceCount,
-      musaAdaptorGetVendor, NULL,
-      // GDR functions
-      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-      musaAdaptorGdrMemAlloc, musaAdaptorGdrMemFree,
-      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-            // *memHandle);
-      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-            // sz);
-      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-      // Stream functions
-      musaAdaptorStreamCreate, musaAdaptorStreamDestroy, musaAdaptorStreamCopy,
-      musaAdaptorStreamFree, musaAdaptorStreamSynchronize,
-      musaAdaptorStreamQuery, musaAdaptorStreamWaitEvent,
-      // Event functions
-      musaAdaptorEventCreate, musaAdaptorEventDestroy, musaAdaptorEventRecord,
-      musaAdaptorEventSynchronize, musaAdaptorEventQuery,
-      // IpcMemHandle functions
-      musaAdaptorIpcMemHandleCreate, musaAdaptorIpcMemHandleGet,
-      musaAdaptorIpcMemHandleOpen, musaAdaptorIpcMemHandleClose,
-      musaAdaptorIpcMemHandleFree,
-      // Kernel launch
-      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-            // share_mem, void *stream, void *memHandle);
-      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-      NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream, void
-            // *args);
-      // Others
-      musaAdaptorGetDeviceProperties, // flagcxResult_t
-                                      // (*getDeviceProperties)(struct
-                                      // flagcxDevProps *props, int dev);
-      musaAdaptorGetDevicePciBusId, // flagcxResult_t (*getDevicePciBusId)(char
+static flagcxResult_t musaAdaptorStreamWaitValue64(flagcxStream_t, void *,
+                                                   uint64_t, int) {
+  return flagcxNotSupported;
+}
+
+struct flagcxDeviceAdaptor musaAdaptor{
+    "MUSA",
+    // Basic functions
+    musaAdaptorDeviceSynchronize,
+    musaAdaptorDeviceMemcpy,
+    musaAdaptorDeviceMemset,
+    musaAdaptorDeviceMalloc,
+    musaAdaptorDeviceFree,
+    musaAdaptorSetDevice,
+    musaAdaptorGetDevice,
+    musaAdaptorGetDeviceCount,
+    musaAdaptorGetVendor,
+    NULL,
+    // GDR functions
+    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+    musaAdaptorGdrMemAlloc,
+    musaAdaptorGdrMemFree,
+    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+          // *memHandle);
+    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+          // sz);
+    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+    // Stream functions
+    musaAdaptorStreamCreate,
+    musaAdaptorStreamDestroy,
+    musaAdaptorStreamCopy,
+    musaAdaptorStreamFree,
+    musaAdaptorStreamSynchronize,
+    musaAdaptorStreamQuery,
+    musaAdaptorStreamWaitEvent,
+    // Event functions
+    musaAdaptorEventCreate,
+    musaAdaptorEventDestroy,
+    musaAdaptorEventRecord,
+    musaAdaptorEventSynchronize,
+    musaAdaptorEventQuery,
+    // IpcMemHandle functions
+    musaAdaptorIpcMemHandleCreate,
+    musaAdaptorIpcMemHandleGet,
+    musaAdaptorIpcMemHandleOpen,
+    musaAdaptorIpcMemHandleClose,
+    musaAdaptorIpcMemHandleFree,
+    // Kernel launch
+    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+          // share_mem, void *stream, void *memHandle);
+    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+    NULL, // flagcxResult_t (*launchDeviceFunc)(flagcxStream_t stream, void
+          // *args);
+    // Others
+    musaAdaptorGetDeviceProperties, // flagcxResult_t
+                                    // (*getDeviceProperties)(struct
+                                    // flagcxDevProps *props, int dev);
+    musaAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
                                     // *pciBusId, int len, int dev);
-      musaAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                      // (*getDeviceByPciBusId)(int
-                                      // *dev, const char *pciBusId);
-      musaAdaptorLaunchHostFunc,
-      // DMA buffer
-      NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-      NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-            // void *buffer, size_t size, unsigned long long flags);
-      NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
-            // start, flagcxEvent_t end);
+    musaAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                    // (*getDeviceByPciBusId)(int
+                                    // *dev, const char *pciBusId);
+    musaAdaptorLaunchHostFunc,
+    // DMA buffer
+    NULL, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
+    NULL, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
+          // void *buffer, size_t size, unsigned long long flags);
+    NULL, // flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t
+          // start, flagcxEvent_t end);
+    musaAdaptorStreamWaitValue64,
 };
 
 #endif // USE_MUSA_ADAPTOR

--- a/flagcx/adaptor/device/tops_adaptor.cc
+++ b/flagcx/adaptor/device/tops_adaptor.cc
@@ -378,80 +378,64 @@ static flagcxResult_t topsAdaptorStreamWaitValue64(flagcxStream_t, void *,
   return flagcxNotSupported;
 }
 
-struct flagcxDeviceAdaptor topsAdaptor{
-    "TOPS",
-    // Basic functions
-    topsAdaptorDeviceSynchronize,
-    topsAdaptorDeviceMemcpy,
-    topsAdaptorDeviceMemset,
-    topsAdaptorDeviceMalloc,
-    topsAdaptorDeviceFree,
-    topsAdaptorSetDevice,
-    topsAdaptorGetDevice,
-    topsAdaptorGetDeviceCount,
-    topsAdaptorGetVendor,
-    topsAdaptorHostGetDevicePointer,
-    // GDR functions
-    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-    topsAdaptorGdrMemAlloc,
-    topsAdaptorGdrMemFree,
-    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-          // *memHandle);
-    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-          // sz);
-    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-    // Stream functions
-    topsAdaptorStreamCreate,
-    topsAdaptorStreamDestroy,
-    topsAdaptorStreamCopy,
-    topsAdaptorStreamFree,
-    topsAdaptorStreamSynchronize,
-    topsAdaptorStreamQuery,
-    topsAdaptorStreamWaitEvent,
-    // Event functions
-    topsAdaptorEventCreate,
-    topsAdaptorEventDestroy,
-    topsAdaptorEventRecord,
-    topsAdaptorEventSynchronize,
-    topsAdaptorEventQuery,
-    // IpcMemHandle functions
-    topsAdaptorIpcMemHandleCreate,
-    topsAdaptorIpcMemHandleGet,
-    topsAdaptorIpcMemHandleOpen,
-    topsAdaptorIpcMemHandleClose,
-    topsAdaptorIpcMemHandleFree,
-    // Kernel launch
-    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-          // share_mem, void *stream, void *memHandle);
-    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-    topsAdaptorLaunchDeviceFunc, // flagcxResult_t
-                                 // (*launchDeviceFunc)(flagcxStream_t stream,
-                                 // void *args);
-    // Others
-    topsAdaptorGetDeviceProperties, // flagcxResult_t
-                                    // (*getDeviceProperties)(struct
-                                    // flagcxDevProps *props, int dev);
-    topsAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
+struct flagcxDeviceAdaptor topsAdaptor {
+  "TOPS",
+      // Basic functions
+      topsAdaptorDeviceSynchronize, topsAdaptorDeviceMemcpy,
+      topsAdaptorDeviceMemset, topsAdaptorDeviceMalloc, topsAdaptorDeviceFree,
+      topsAdaptorSetDevice, topsAdaptorGetDevice, topsAdaptorGetDeviceCount,
+      topsAdaptorGetVendor, topsAdaptorHostGetDevicePointer,
+      // GDR functions
+      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+      topsAdaptorGdrMemAlloc, topsAdaptorGdrMemFree,
+      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+            // *memHandle);
+      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+            // sz);
+      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+      // Stream functions
+      topsAdaptorStreamCreate, topsAdaptorStreamDestroy, topsAdaptorStreamCopy,
+      topsAdaptorStreamFree, topsAdaptorStreamSynchronize,
+      topsAdaptorStreamQuery, topsAdaptorStreamWaitEvent,
+      // Event functions
+      topsAdaptorEventCreate, topsAdaptorEventDestroy, topsAdaptorEventRecord,
+      topsAdaptorEventSynchronize, topsAdaptorEventQuery,
+      // IpcMemHandle functions
+      topsAdaptorIpcMemHandleCreate, topsAdaptorIpcMemHandleGet,
+      topsAdaptorIpcMemHandleOpen, topsAdaptorIpcMemHandleClose,
+      topsAdaptorIpcMemHandleFree,
+      // Kernel launch
+      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+            // share_mem, void *stream, void *memHandle);
+      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+      topsAdaptorLaunchDeviceFunc, // flagcxResult_t
+                                   // (*launchDeviceFunc)(flagcxStream_t stream,
+                                   // void *args);
+      // Others
+      topsAdaptorGetDeviceProperties, // flagcxResult_t
+                                      // (*getDeviceProperties)(struct
+                                      // flagcxDevProps *props, int dev);
+      topsAdaptorGetDevicePciBusId, // flagcxResult_t (*getDevicePciBusId)(char
                                     // *pciBusId, int len, int dev);
-    topsAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                    // (*getDeviceByPciBusId)(int
-                                    // *dev, const char *pciBusId);
-    topsAdaptorLaunchHostFunc,
-    // DMA buffer
-    topsAdaptorDmaSupport,                  // flagcxResult_t (*dmaSupport)(bool
-                                            // *dmaBufferSupport);
-    topsAdaptorMemGetHandleForAddressRange, // flagcxResult_t
-                                            // (*memGetHandleForAddressRange)(void
-                                            // *handleOut, void *buffer,
-                                            // size_t size, unsigned long long
-                                            // flags);
-    topsAdaptorEventElapsedTime, // flagcxResult_t
-    topsAdaptorStreamWaitValue64,
+      topsAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                      // (*getDeviceByPciBusId)(int
+                                      // *dev, const char *pciBusId);
+      topsAdaptorLaunchHostFunc,
+      // DMA buffer
+      topsAdaptorDmaSupport, // flagcxResult_t (*dmaSupport)(bool
+                             // *dmaBufferSupport);
+      topsAdaptorMemGetHandleForAddressRange, // flagcxResult_t
+                                              // (*memGetHandleForAddressRange)(void
+                                              // *handleOut, void *buffer,
+                                              // size_t size, unsigned long long
+                                              // flags);
+      topsAdaptorEventElapsedTime, // flagcxResult_t
+      topsAdaptorStreamWaitValue64,
 };
 
 #endif // USE_ENFLAME_ADAPTOR

--- a/flagcx/adaptor/device/tops_adaptor.cc
+++ b/flagcx/adaptor/device/tops_adaptor.cc
@@ -373,63 +373,85 @@ flagcxResult_t topsAdaptorEventElapsedTime(float *ms, flagcxEvent_t start,
   }
 }
 
-struct flagcxDeviceAdaptor topsAdaptor {
-  "TOPS",
-      // Basic functions
-      topsAdaptorDeviceSynchronize, topsAdaptorDeviceMemcpy,
-      topsAdaptorDeviceMemset, topsAdaptorDeviceMalloc, topsAdaptorDeviceFree,
-      topsAdaptorSetDevice, topsAdaptorGetDevice, topsAdaptorGetDeviceCount,
-      topsAdaptorGetVendor, topsAdaptorHostGetDevicePointer,
-      // GDR functions
-      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-      topsAdaptorGdrMemAlloc, topsAdaptorGdrMemFree,
-      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-            // *memHandle);
-      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-            // sz);
-      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-      // Stream functions
-      topsAdaptorStreamCreate, topsAdaptorStreamDestroy, topsAdaptorStreamCopy,
-      topsAdaptorStreamFree, topsAdaptorStreamSynchronize,
-      topsAdaptorStreamQuery, topsAdaptorStreamWaitEvent,
-      // Event functions
-      topsAdaptorEventCreate, topsAdaptorEventDestroy, topsAdaptorEventRecord,
-      topsAdaptorEventSynchronize, topsAdaptorEventQuery,
-      // IpcMemHandle functions
-      topsAdaptorIpcMemHandleCreate, topsAdaptorIpcMemHandleGet,
-      topsAdaptorIpcMemHandleOpen, topsAdaptorIpcMemHandleClose,
-      topsAdaptorIpcMemHandleFree,
-      // Kernel launch
-      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-            // share_mem, void *stream, void *memHandle);
-      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-      topsAdaptorLaunchDeviceFunc, // flagcxResult_t
-                                   // (*launchDeviceFunc)(flagcxStream_t stream,
-                                   // void *args);
-      // Others
-      topsAdaptorGetDeviceProperties, // flagcxResult_t
-                                      // (*getDeviceProperties)(struct
-                                      // flagcxDevProps *props, int dev);
-      topsAdaptorGetDevicePciBusId, // flagcxResult_t (*getDevicePciBusId)(char
+static flagcxResult_t topsAdaptorStreamWaitValue64(flagcxStream_t, void *,
+                                                   uint64_t, int) {
+  return flagcxNotSupported;
+}
+
+struct flagcxDeviceAdaptor topsAdaptor{
+    "TOPS",
+    // Basic functions
+    topsAdaptorDeviceSynchronize,
+    topsAdaptorDeviceMemcpy,
+    topsAdaptorDeviceMemset,
+    topsAdaptorDeviceMalloc,
+    topsAdaptorDeviceFree,
+    topsAdaptorSetDevice,
+    topsAdaptorGetDevice,
+    topsAdaptorGetDeviceCount,
+    topsAdaptorGetVendor,
+    topsAdaptorHostGetDevicePointer,
+    // GDR functions
+    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+    topsAdaptorGdrMemAlloc,
+    topsAdaptorGdrMemFree,
+    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+          // *memHandle);
+    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+          // sz);
+    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+    // Stream functions
+    topsAdaptorStreamCreate,
+    topsAdaptorStreamDestroy,
+    topsAdaptorStreamCopy,
+    topsAdaptorStreamFree,
+    topsAdaptorStreamSynchronize,
+    topsAdaptorStreamQuery,
+    topsAdaptorStreamWaitEvent,
+    // Event functions
+    topsAdaptorEventCreate,
+    topsAdaptorEventDestroy,
+    topsAdaptorEventRecord,
+    topsAdaptorEventSynchronize,
+    topsAdaptorEventQuery,
+    // IpcMemHandle functions
+    topsAdaptorIpcMemHandleCreate,
+    topsAdaptorIpcMemHandleGet,
+    topsAdaptorIpcMemHandleOpen,
+    topsAdaptorIpcMemHandleClose,
+    topsAdaptorIpcMemHandleFree,
+    // Kernel launch
+    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+          // share_mem, void *stream, void *memHandle);
+    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+    topsAdaptorLaunchDeviceFunc, // flagcxResult_t
+                                 // (*launchDeviceFunc)(flagcxStream_t stream,
+                                 // void *args);
+    // Others
+    topsAdaptorGetDeviceProperties, // flagcxResult_t
+                                    // (*getDeviceProperties)(struct
+                                    // flagcxDevProps *props, int dev);
+    topsAdaptorGetDevicePciBusId,   // flagcxResult_t (*getDevicePciBusId)(char
                                     // *pciBusId, int len, int dev);
-      topsAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                      // (*getDeviceByPciBusId)(int
-                                      // *dev, const char *pciBusId);
-      topsAdaptorLaunchHostFunc,
-      // DMA buffer
-      topsAdaptorDmaSupport, // flagcxResult_t (*dmaSupport)(bool
-                             // *dmaBufferSupport);
-      topsAdaptorMemGetHandleForAddressRange, // flagcxResult_t
-                                              // (*memGetHandleForAddressRange)(void
-                                              // *handleOut, void *buffer,
-                                              // size_t size, unsigned long long
-                                              // flags);
-      topsAdaptorEventElapsedTime, // flagcxResult_t
+    topsAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                    // (*getDeviceByPciBusId)(int
+                                    // *dev, const char *pciBusId);
+    topsAdaptorLaunchHostFunc,
+    // DMA buffer
+    topsAdaptorDmaSupport,                  // flagcxResult_t (*dmaSupport)(bool
+                                            // *dmaBufferSupport);
+    topsAdaptorMemGetHandleForAddressRange, // flagcxResult_t
+                                            // (*memGetHandleForAddressRange)(void
+                                            // *handleOut, void *buffer,
+                                            // size_t size, unsigned long long
+                                            // flags);
+    topsAdaptorEventElapsedTime, // flagcxResult_t
+    topsAdaptorStreamWaitValue64,
 };
 
 #endif // USE_ENFLAME_ADAPTOR

--- a/flagcx/adaptor/device/tsmicro_adaptor.cc
+++ b/flagcx/adaptor/device/tsmicro_adaptor.cc
@@ -349,67 +349,86 @@ flagcxResult_t tsmicroAdaptorEventElapsedTime(float *ms, flagcxEvent_t start,
     return flagcxUnhandledDeviceError;
   }
 }
-struct flagcxDeviceAdaptor tsmicroAdaptor {
-  "TSM",
-      // Basic functions
-      tsmicroAdaptorDeviceSynchronize, tsmicroAdaptorDeviceMemcpy,
-      tsmicroAdaptorDeviceMemset, tsmicroAdaptorDeviceMalloc,
-      tsmicroAdaptorDeviceFree, tsmicroAdaptorSetDevice,
-      tsmicroAdaptorGetDevice, tsmicroAdaptorGetDeviceCount,
-      tsmicroAdaptorGetVendor, tsmicroAdaptorHostGetDevicePointer,
-      // GDR functions
-      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-      tsmicroAdaptorGdrMemAlloc, tsmicroAdaptorGdrMemFree,
-      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-            // *memHandle);
-      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-            // sz);
-      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-      // Stream functions
-      tsmicroAdaptorStreamCreate, tsmicroAdaptorStreamDestroy,
-      tsmicroAdaptorStreamCopy, tsmicroAdaptorStreamFree,
-      tsmicroAdaptorStreamSynchronize, tsmicroAdaptorStreamQuery,
-      tsmicroAdaptorStreamWaitEvent,
-      // Event functions
-      tsmicroAdaptorEventCreate, tsmicroAdaptorEventDestroy,
-      tsmicroAdaptorEventRecord, tsmicroAdaptorEventSynchronize,
-      tsmicroAdaptorEventQuery,
-      // IpcMemHandle functions
-      tsmicroAdaptorIpcMemHandleCreate, tsmicroAdaptorIpcMemHandleGet,
-      tsmicroAdaptorIpcMemHandleOpen, tsmicroAdaptorIpcMemHandleClose,
-      tsmicroAdaptorIpcMemHandleFree,
-      // Kernel launch
-      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-            // share_mem, void *stream, void *memHandle);
-      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-      tsmicroAdaptorLaunchDeviceFunc, // flagcxResult_t
-                                      // (*launchDeviceFunc)(flagcxStream_t
-                                      // stream, void *args);
-      // Others
-      tsmicroAdaptorGetDeviceProperties, // flagcxResult_t
-                                         // (*getDeviceProperties)(struct
-                                         // flagcxDevProps *props, int dev);
-      tsmicroAdaptorGetDevicePciBusId,   // flagcxResult_t
-                                         // (*getDevicePciBusId)(char *pciBusId,
-                                         // int len, int dev);
-      tsmicroAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                         // (*getDeviceByPciBusId)(int
-                                         // *dev, const char *pciBusId);
-      tsmicroAdaptorLaunchHostFunc,
-      // DMA buffer
-      tsmicroAdaptorDmaSupport, // flagcxResult_t (*dmaSupport)(bool
-                                // *dmaBufferSupport);
-      tsmicroAdaptorMemGetHandleForAddressRange, // flagcxResult_t
-                                                 // (*memGetHandleForAddressRange)(void
-                                                 // *handleOut, void *buffer,
-                                                 // size_t size, unsigned long
-                                                 // long flags);
-      tsmicroAdaptorEventElapsedTime, // flagcxResult_t
+static flagcxResult_t tsmicroAdaptorStreamWaitValue64(flagcxStream_t, void *,
+                                                      uint64_t, int) {
+  return flagcxNotSupported;
+}
+
+struct flagcxDeviceAdaptor tsmicroAdaptor{
+    "TSM",
+    // Basic functions
+    tsmicroAdaptorDeviceSynchronize,
+    tsmicroAdaptorDeviceMemcpy,
+    tsmicroAdaptorDeviceMemset,
+    tsmicroAdaptorDeviceMalloc,
+    tsmicroAdaptorDeviceFree,
+    tsmicroAdaptorSetDevice,
+    tsmicroAdaptorGetDevice,
+    tsmicroAdaptorGetDeviceCount,
+    tsmicroAdaptorGetVendor,
+    tsmicroAdaptorHostGetDevicePointer,
+    // GDR functions
+    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+    tsmicroAdaptorGdrMemAlloc,
+    tsmicroAdaptorGdrMemFree,
+    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+          // *memHandle);
+    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+          // sz);
+    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+    // Stream functions
+    tsmicroAdaptorStreamCreate,
+    tsmicroAdaptorStreamDestroy,
+    tsmicroAdaptorStreamCopy,
+    tsmicroAdaptorStreamFree,
+    tsmicroAdaptorStreamSynchronize,
+    tsmicroAdaptorStreamQuery,
+    tsmicroAdaptorStreamWaitEvent,
+    // Event functions
+    tsmicroAdaptorEventCreate,
+    tsmicroAdaptorEventDestroy,
+    tsmicroAdaptorEventRecord,
+    tsmicroAdaptorEventSynchronize,
+    tsmicroAdaptorEventQuery,
+    // IpcMemHandle functions
+    tsmicroAdaptorIpcMemHandleCreate,
+    tsmicroAdaptorIpcMemHandleGet,
+    tsmicroAdaptorIpcMemHandleOpen,
+    tsmicroAdaptorIpcMemHandleClose,
+    tsmicroAdaptorIpcMemHandleFree,
+    // Kernel launch
+    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+          // share_mem, void *stream, void *memHandle);
+    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+    tsmicroAdaptorLaunchDeviceFunc, // flagcxResult_t
+                                    // (*launchDeviceFunc)(flagcxStream_t
+                                    // stream, void *args);
+    // Others
+    tsmicroAdaptorGetDeviceProperties, // flagcxResult_t
+                                       // (*getDeviceProperties)(struct
+                                       // flagcxDevProps *props, int dev);
+    tsmicroAdaptorGetDevicePciBusId,   // flagcxResult_t
+                                       // (*getDevicePciBusId)(char *pciBusId,
+                                       // int len, int dev);
+    tsmicroAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                       // (*getDeviceByPciBusId)(int
+                                       // *dev, const char *pciBusId);
+    tsmicroAdaptorLaunchHostFunc,
+    // DMA buffer
+    tsmicroAdaptorDmaSupport, // flagcxResult_t (*dmaSupport)(bool
+                              // *dmaBufferSupport);
+    tsmicroAdaptorMemGetHandleForAddressRange, // flagcxResult_t
+                                               // (*memGetHandleForAddressRange)(void
+                                               // *handleOut, void *buffer,
+                                               // size_t size, unsigned long
+                                               // long flags);
+    tsmicroAdaptorEventElapsedTime, // flagcxResult_t
+    tsmicroAdaptorStreamWaitValue64,
 };
 
 #endif // USE_TSM_ADAPTOR

--- a/flagcx/adaptor/device/tsmicro_adaptor.cc
+++ b/flagcx/adaptor/device/tsmicro_adaptor.cc
@@ -354,81 +354,68 @@ static flagcxResult_t tsmicroAdaptorStreamWaitValue64(flagcxStream_t, void *,
   return flagcxNotSupported;
 }
 
-struct flagcxDeviceAdaptor tsmicroAdaptor{
-    "TSM",
-    // Basic functions
-    tsmicroAdaptorDeviceSynchronize,
-    tsmicroAdaptorDeviceMemcpy,
-    tsmicroAdaptorDeviceMemset,
-    tsmicroAdaptorDeviceMalloc,
-    tsmicroAdaptorDeviceFree,
-    tsmicroAdaptorSetDevice,
-    tsmicroAdaptorGetDevice,
-    tsmicroAdaptorGetDeviceCount,
-    tsmicroAdaptorGetVendor,
-    tsmicroAdaptorHostGetDevicePointer,
-    // GDR functions
-    NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-    NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
-    tsmicroAdaptorGdrMemAlloc,
-    tsmicroAdaptorGdrMemFree,
-    NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
-          // *memHandle);
-    NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
-    NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
-          // sz);
-    NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
-    // Stream functions
-    tsmicroAdaptorStreamCreate,
-    tsmicroAdaptorStreamDestroy,
-    tsmicroAdaptorStreamCopy,
-    tsmicroAdaptorStreamFree,
-    tsmicroAdaptorStreamSynchronize,
-    tsmicroAdaptorStreamQuery,
-    tsmicroAdaptorStreamWaitEvent,
-    // Event functions
-    tsmicroAdaptorEventCreate,
-    tsmicroAdaptorEventDestroy,
-    tsmicroAdaptorEventRecord,
-    tsmicroAdaptorEventSynchronize,
-    tsmicroAdaptorEventQuery,
-    // IpcMemHandle functions
-    tsmicroAdaptorIpcMemHandleCreate,
-    tsmicroAdaptorIpcMemHandleGet,
-    tsmicroAdaptorIpcMemHandleOpen,
-    tsmicroAdaptorIpcMemHandleClose,
-    tsmicroAdaptorIpcMemHandleFree,
-    // Kernel launch
-    NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
-          // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
-          // unsigned int grid_y, unsigned int grid_z, void **args, size_t
-          // share_mem, void *stream, void *memHandle);
-    NULL, // flagcxResult_t (*copyArgsInit)(void **args);
-    NULL, // flagcxResult_t (*copyArgsFree)(void *args);
-    tsmicroAdaptorLaunchDeviceFunc, // flagcxResult_t
-                                    // (*launchDeviceFunc)(flagcxStream_t
-                                    // stream, void *args);
-    // Others
-    tsmicroAdaptorGetDeviceProperties, // flagcxResult_t
-                                       // (*getDeviceProperties)(struct
-                                       // flagcxDevProps *props, int dev);
-    tsmicroAdaptorGetDevicePciBusId,   // flagcxResult_t
-                                       // (*getDevicePciBusId)(char *pciBusId,
-                                       // int len, int dev);
-    tsmicroAdaptorGetDeviceByPciBusId, // flagcxResult_t
-                                       // (*getDeviceByPciBusId)(int
-                                       // *dev, const char *pciBusId);
-    tsmicroAdaptorLaunchHostFunc,
-    // DMA buffer
-    tsmicroAdaptorDmaSupport, // flagcxResult_t (*dmaSupport)(bool
-                              // *dmaBufferSupport);
-    tsmicroAdaptorMemGetHandleForAddressRange, // flagcxResult_t
-                                               // (*memGetHandleForAddressRange)(void
-                                               // *handleOut, void *buffer,
-                                               // size_t size, unsigned long
-                                               // long flags);
-    tsmicroAdaptorEventElapsedTime, // flagcxResult_t
-    tsmicroAdaptorStreamWaitValue64,
+struct flagcxDeviceAdaptor tsmicroAdaptor {
+  "TSM",
+      // Basic functions
+      tsmicroAdaptorDeviceSynchronize, tsmicroAdaptorDeviceMemcpy,
+      tsmicroAdaptorDeviceMemset, tsmicroAdaptorDeviceMalloc,
+      tsmicroAdaptorDeviceFree, tsmicroAdaptorSetDevice,
+      tsmicroAdaptorGetDevice, tsmicroAdaptorGetDeviceCount,
+      tsmicroAdaptorGetVendor, tsmicroAdaptorHostGetDevicePointer,
+      // GDR functions
+      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+      tsmicroAdaptorGdrMemAlloc, tsmicroAdaptorGdrMemFree,
+      NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
+            // *memHandle);
+      NULL, // flagcxResult_t (*hostShareMemFree)(void *ptr, void *memHandle);
+      NULL, // flagcxResult_t (*gdrPtrMmap)(void **pcpuptr, void *devptr, size_t
+            // sz);
+      NULL, // flagcxResult_t (*gdrPtrMunmap)(void *cpuptr, size_t sz);
+      // Stream functions
+      tsmicroAdaptorStreamCreate, tsmicroAdaptorStreamDestroy,
+      tsmicroAdaptorStreamCopy, tsmicroAdaptorStreamFree,
+      tsmicroAdaptorStreamSynchronize, tsmicroAdaptorStreamQuery,
+      tsmicroAdaptorStreamWaitEvent,
+      // Event functions
+      tsmicroAdaptorEventCreate, tsmicroAdaptorEventDestroy,
+      tsmicroAdaptorEventRecord, tsmicroAdaptorEventSynchronize,
+      tsmicroAdaptorEventQuery,
+      // IpcMemHandle functions
+      tsmicroAdaptorIpcMemHandleCreate, tsmicroAdaptorIpcMemHandleGet,
+      tsmicroAdaptorIpcMemHandleOpen, tsmicroAdaptorIpcMemHandleClose,
+      tsmicroAdaptorIpcMemHandleFree,
+      // Kernel launch
+      NULL, // flagcxResult_t (*launchKernel)(void *func, unsigned int block_x,
+            // unsigned int block_y, unsigned int block_z, unsigned int grid_x,
+            // unsigned int grid_y, unsigned int grid_z, void **args, size_t
+            // share_mem, void *stream, void *memHandle);
+      NULL, // flagcxResult_t (*copyArgsInit)(void **args);
+      NULL, // flagcxResult_t (*copyArgsFree)(void *args);
+      tsmicroAdaptorLaunchDeviceFunc, // flagcxResult_t
+                                      // (*launchDeviceFunc)(flagcxStream_t
+                                      // stream, void *args);
+      // Others
+      tsmicroAdaptorGetDeviceProperties, // flagcxResult_t
+                                         // (*getDeviceProperties)(struct
+                                         // flagcxDevProps *props, int dev);
+      tsmicroAdaptorGetDevicePciBusId,   // flagcxResult_t
+                                         // (*getDevicePciBusId)(char *pciBusId,
+                                         // int len, int dev);
+      tsmicroAdaptorGetDeviceByPciBusId, // flagcxResult_t
+                                         // (*getDeviceByPciBusId)(int
+                                         // *dev, const char *pciBusId);
+      tsmicroAdaptorLaunchHostFunc,
+      // DMA buffer
+      tsmicroAdaptorDmaSupport, // flagcxResult_t (*dmaSupport)(bool
+                                // *dmaBufferSupport);
+      tsmicroAdaptorMemGetHandleForAddressRange, // flagcxResult_t
+                                                 // (*memGetHandleForAddressRange)(void
+                                                 // *handleOut, void *buffer,
+                                                 // size_t size, unsigned long
+                                                 // long flags);
+      tsmicroAdaptorEventElapsedTime, // flagcxResult_t
+      tsmicroAdaptorStreamWaitValue64,
 };
 
 #endif // USE_TSM_ADAPTOR

--- a/flagcx/adaptor/flagcx_device.cc
+++ b/flagcx/adaptor/flagcx_device.cc
@@ -379,14 +379,14 @@ static flagcxResult_t setupInterNodeSignalRelay(flagcxComm_t comm,
         hetero->netAdaptor->regMr(
             handle->signalSendComms[p],
             &handle->signalSendBufs[p * sizeof(flagcxSignalMessage)],
-            sizeof(flagcxSignalMessage), FLAGCX_PTR_HOST,
+            sizeof(flagcxSignalMessage), FLAGCX_PTR_HOST, 0,
             &handle->signalSendMrs[p]),
         res, fail);
     FLAGCXCHECKGOTO(
         hetero->netAdaptor->regMr(
             handle->signalRecvComms[p],
             &handle->signalRecvBufs[p * sizeof(flagcxSignalMessage)],
-            sizeof(flagcxSignalMessage), FLAGCX_PTR_HOST,
+            sizeof(flagcxSignalMessage), FLAGCX_PTR_HOST, 0,
             &handle->signalRecvMrs[p]),
         res, fail);
   }
@@ -566,7 +566,7 @@ static flagcxResult_t setupIpcBarriers(flagcxComm_t comm,
 // ==========================================================================
 // Unified DevComm: Additive capability layers
 //   Baseline: rank info + fifoBuffer (always)
-//   IPC layer: barrier pointers (if reqs->fields[0] > 0)
+//   IPC layer: barrier pointers (if intraBarrierCount > 0)
 //   NCCL layer: ncclDevComm (if NCCL > 2.28)
 // ==========================================================================
 
@@ -594,7 +594,7 @@ flagcxResult_t flagcxDevCommCreate(flagcxComm_t comm,
       (comm->heteroComm != nullptr) ? comm->heteroComm->fifoBuffer : nullptr;
 
   // ---- IPC barrier layer: if barriers requested ----
-  if (reqs->fields[0] > 0) {
+  if (reqs->intraBarrierCount > 0) {
     flagcxResult_t res = setupIpcBarriers(comm, handle);
     if (res != flagcxSuccess) {
       WARN("flagcxDevCommCreate: IPC barrier setup failed (%d), "
@@ -624,10 +624,16 @@ flagcxResult_t flagcxDevCommCreate(flagcxComm_t comm,
     flagcxInnerComm_t innerComm = comm->homoComm;
     if (innerComm != nullptr) {
       ncclDevCommRequirements ncclReqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
-      ncclReqs.lsaBarrierCount = reqs->fields[0];
-      ncclReqs.lsaMultimem = reqs->fields[1];
-      ncclReqs.railGinBarrierCount = reqs->fields[2];
-      ncclReqs.ginSignalCount = reqs->fields[3];
+      ncclReqs.lsaBarrierCount = reqs->intraBarrierCount;
+      ncclReqs.lsaMultimem = reqs->intraMulticast;
+      ncclReqs.railGinBarrierCount = reqs->interBarrierCount;
+      ncclReqs.ginSignalCount = reqs->interSignalCount;
+      ncclReqs.barrierCount = reqs->barrierCount;
+      ncclReqs.ginForceEnable = reqs->interForceEnable;
+      ncclReqs.ginContextCount = reqs->interContextCount;
+      ncclReqs.ginCounterCount = reqs->interCounterCount;
+      ncclReqs.lsaLLA2ABlockCount = reqs->intraLLA2ABlockCount;
+      ncclReqs.lsaLLA2ASlotCount = reqs->intraLLA2ASlotCount;
 
       flagcxResult_t ret = ncclAdaptorDevCommCreate(innerComm->base, &ncclReqs,
                                                     &handle->ncclDev);
@@ -772,4 +778,61 @@ flagcxResult_t flagcxDevMemDestroy(flagcxComm_t comm, flagcxDevMem_t devMem) {
 
   free(devMem);
   return flagcxSuccess;
+}
+
+// ==========================================================================
+// Communicator property query
+// ==========================================================================
+
+flagcxResult_t flagcxCommQueryProperties(flagcxComm_t comm,
+                                         flagcxCommProperties_t *props) {
+  if (comm == nullptr || props == nullptr) {
+    return flagcxInvalidArgument;
+  }
+  memset(props, 0, sizeof(*props));
+
+  // Baseline fields (always available)
+  props->rank = comm->rank;
+  props->nRanks = comm->nranks;
+  props->deviceId = comm->heteroComm ? comm->heteroComm->cudaDev : -1;
+
+  // NCCL-specific fields: fill from NCCL if available
+#ifdef FLAGCX_DEVICE_API_NCCL
+  flagcxInnerComm_t innerComm = comm->homoComm;
+  if (innerComm != nullptr && innerComm->base != nullptr) {
+    props->deviceApiSupport = true; // NCCL > 2.28 available
+    // ncclCommQueryProperties not yet wired through adaptor — set defaults.
+    // Full delegation will be added when the adaptor wrapper is available.
+    props->multicastSupport = false;
+    props->netType = flagcxNetTypeNone;
+  }
+#endif
+
+  return flagcxSuccess;
+}
+
+// ==========================================================================
+// Barrier requirement stubs (resource-handle model not yet implemented)
+// ==========================================================================
+
+flagcxResult_t
+flagcxIntraBarrierCreateRequirement(flagcxTeam_t team, int nBarriers,
+                                    flagcxIntraBarrierHandle_t *outHandle,
+                                    flagcxDevCommRequirements *outReq) {
+  (void)team;
+  (void)nBarriers;
+  (void)outHandle;
+  (void)outReq;
+  return flagcxNotSupported;
+}
+
+flagcxResult_t flagcxInterBarrierCreateRequirement(
+    flagcxComm_t comm, flagcxTeam_t team, int nBarriers,
+    flagcxInterBarrierHandle_t *outHandle, flagcxDevCommRequirements *outReq) {
+  (void)comm;
+  (void)team;
+  (void)nBarriers;
+  (void)outHandle;
+  (void)outReq;
+  return flagcxNotSupported;
 }

--- a/flagcx/adaptor/include/atomic_device.h
+++ b/flagcx/adaptor/include/atomic_device.h
@@ -15,7 +15,8 @@ typedef enum {
 typedef enum {
   flagcxDeviceScopeSystem = 0,
   flagcxDeviceScopeDevice = 1,
-  flagcxDeviceScopeBlock = 2
+  flagcxDeviceScopeBlock = 2,
+  flagcxDeviceScopeThread = 3
 } flagcxDeviceScope_t;
 
 #if defined(USE_NVIDIA_ADAPTOR)
@@ -27,6 +28,11 @@ static FLAGCX_DEVICE_CONSTANT_DECORATOR cuda::memory_order
         cuda::memory_order_relaxed, cuda::memory_order_acquire,
         cuda::memory_order_release, cuda::memory_order_acq_rel,
         cuda::memory_order_seq_cst};
+
+static FLAGCX_DEVICE_CONSTANT_DECORATOR cuda::thread_scope
+    flagcxDeviceScopeMap[] = {
+        cuda::thread_scope_system, cuda::thread_scope_device,
+        cuda::thread_scope_block, cuda::thread_scope_thread};
 
 // Helper to dispatch based on scope at compile time
 template <typename T, flagcxDeviceScope_t Scope>
@@ -45,6 +51,11 @@ struct flagcxAtomicHelper<T, flagcxDeviceScopeDevice> {
 template <typename T>
 struct flagcxAtomicHelper<T, flagcxDeviceScopeBlock> {
   using atomic_ref_t = cuda::atomic_ref<T, cuda::thread_scope_block>;
+};
+
+template <typename T>
+struct flagcxAtomicHelper<T, flagcxDeviceScopeThread> {
+  using atomic_ref_t = cuda::atomic_ref<T, cuda::thread_scope_thread>;
 };
 
 template <typename T, flagcxDeviceScope_t Scope = flagcxDeviceScopeSystem>

--- a/flagcx/adaptor/include/device_api/flagcx_device.h
+++ b/flagcx/adaptor/include/device_api/flagcx_device.h
@@ -267,6 +267,56 @@ struct flagcxTeam {
 };
 typedef struct flagcxTeam flagcxTeam_t;
 
+// ============================================================
+// Section 4c: flagcxMulticastHandle — Multicast Memory Handle
+//
+// Wraps ncclMultimemHandle on Tier 1. Empty shell on Tier 2.
+// Naming: NCCL "Multimem" → FlagCX "Multicast".
+// ============================================================
+struct flagcxMulticastHandle {
+  void *mcBasePtr;
+
+#ifdef FLAGCX_DEVICE_API_NCCL
+  ncclMultimemHandle_t _base;
+
+  FLAGCX_HOST_DEVICE_INLINE flagcxMulticastHandle()
+      : mcBasePtr(nullptr), _base() {}
+  FLAGCX_HOST_DEVICE_INLINE flagcxMulticastHandle(ncclMultimemHandle_t base)
+      : mcBasePtr(base.mcBasePtr), _base(base) {}
+  FLAGCX_HOST_DEVICE_INLINE operator ncclMultimemHandle_t() const {
+    return _base;
+  }
+#else
+  FLAGCX_HOST_DEVICE_INLINE flagcxMulticastHandle() : mcBasePtr(nullptr) {}
+#endif
+};
+typedef struct flagcxMulticastHandle flagcxMulticastHandle_t;
+
+// ============================================================
+// Section 4d: Barrier Handle Types
+//
+// flagcxIntraBarrierHandle → ncclLsaBarrierHandle (Tier 1)
+// flagcxInterBarrierHandle → ncclGinBarrierHandle (Tier 1)
+// Tier 2: placeholder structs (no resource-handle model yet).
+// ============================================================
+struct flagcxIntraBarrierHandle {
+#ifdef FLAGCX_DEVICE_API_NCCL
+  ncclLsaBarrierHandle _impl;
+#else
+  int nBarriers;
+#endif
+};
+typedef struct flagcxIntraBarrierHandle flagcxIntraBarrierHandle_t;
+
+struct flagcxInterBarrierHandle {
+#ifdef FLAGCX_DEVICE_API_NCCL
+  ncclGinBarrierHandle _impl;
+#else
+  int placeholder;
+#endif
+};
+typedef struct flagcxInterBarrierHandle flagcxInterBarrierHandle_t;
+
 // Team tag types for barrier session constructors
 struct flagcxTeamTagWorld {};
 struct flagcxTeamTagIntra {};
@@ -324,11 +374,106 @@ flagcxTeam_t flagcxTeamInter(const flagcxDevComm &devComm) {
   return team;
 }
 
+// ---- Team Algebra (pure arithmetic on {nRanks, rank, stride}) ----
+// These 5 functions are identical on all tiers — no NCCL delegation needed.
+
+// Is team b's bPeer also a member of team a?
+FLAGCX_HOST_DEVICE_INLINE bool
+flagcxTeamRankIsMember(flagcxTeam_t a, flagcxTeam_t b, int bPeer) {
+  int wrank = (bPeer - b.rank) * b.stride;
+  uint32_t adelta = wrank / a.stride;
+  uint32_t amod = wrank % a.stride;
+  int arank = a.rank + adelta;
+  return 0 <= arank && arank < a.nRanks && amod == 0;
+}
+
+// Convert team b's bPeer to team a's rank.
+FLAGCX_HOST_DEVICE_INLINE int flagcxTeamRankToTeam(flagcxTeam_t a,
+                                                   flagcxTeam_t b, int bPeer) {
+  int wrank = (bPeer - b.rank) * b.stride;
+  uint32_t adelta = wrank / a.stride;
+  int arank = a.rank + adelta;
+  return arank;
+}
+
+// Extract inner sub-team (first innerSize ranks per stride group).
+FLAGCX_HOST_DEVICE_INLINE flagcxTeam_t
+flagcxTeamInnerFactor(flagcxTeam_t parent, int innerSize) {
+  flagcxTeam_t ans;
+  ans.nRanks = innerSize;
+  ans.rank = parent.rank % innerSize;
+  ans.stride = parent.stride;
+  return ans;
+}
+
+// Extract outer sub-team (stride groups).
+FLAGCX_HOST_DEVICE_INLINE flagcxTeam_t
+flagcxTeamOuterFactor(flagcxTeam_t parent, int innerSize) {
+  flagcxTeam_t ans;
+  ans.nRanks = parent.nRanks / innerSize;
+  ans.rank = parent.rank / innerSize;
+  ans.stride = parent.stride * innerSize;
+  return ans;
+}
+
+// Return the index'th element of parent minus subset (set difference).
+FLAGCX_HOST_DEVICE_INLINE int flagcxTeamRankInDifference(flagcxTeam_t parent,
+                                                         flagcxTeam_t subset,
+                                                         int index) {
+  int stride = subset.stride / parent.stride;
+  int below = parent.rank - subset.rank * stride;
+  if (stride < 0) {
+    stride = -stride;
+    below -= (subset.nRanks - 1) * stride;
+  }
+  if (index < below) {
+    return index;
+  } else if (index - below < (subset.nRanks - 1) * (stride - 1)) {
+    return below + 1 + ((index - below) / (stride - 1)) * stride +
+           (index - below) % (stride - 1);
+  } else {
+    return below + 1 + (subset.nRanks - 1) * stride +
+           (index - below - (subset.nRanks - 1) * (stride - 1));
+  }
+}
+
+// ---- DevComm-dependent team conversions ----
+
+// Convert team rank to world rank.
+FLAGCX_DEVICE_INLINE_DECORATOR int
+flagcxTeamRankToWorld(const flagcxDevComm &devComm, flagcxTeam_t team,
+                      int rank) {
+#ifdef FLAGCX_DEVICE_API_NCCL
+  if (devComm._hasBase)
+    return ncclTeamRankToWorld(devComm._base, team._base, rank);
+#endif
+  return devComm.getRank() + (rank - team.rank) * team.stride;
+}
+
+// Convert team rank to intra-node rank (NCCL "Lsa" → FlagCX "Intra").
+FLAGCX_DEVICE_INLINE_DECORATOR int
+flagcxTeamRankToIntra(const flagcxDevComm &devComm, flagcxTeam_t team,
+                      int rank) {
+#ifdef FLAGCX_DEVICE_API_NCCL
+  if (devComm._hasBase)
+    return ncclTeamRankToLsa(devComm._base, team._base, rank);
+#endif
+  return devComm.getIntraRank() + (rank - team.rank) * team.stride;
+}
+
 // ============================================================
-// Section 6: flagcxCoopBlock — Block-Level Cooperative Group
+// Section 6: Cooperative Group Types
 //
-// On NVIDIA: wraps ncclCoopCta.
+// Platform-neutral cooperative groups for device-side synchronization.
+// Naming: "Tile" = N PEs cooperating (avoids vendor-specific
+//         Warp/Wave/Subgroup terms).
+//
+// 3-way guard: FLAGCX_DEVICE_API_NCCL → wrap NCCL types (Tier 1)
+//              FLAGCX_SIMT_WIDTH       → SIMT intrinsics (Tier 2)
+//              else                    → non-SIMT stubs
 // ============================================================
+
+// ---- 6a. flagcxCoopBlock — CTA-level cooperative group ----
 struct flagcxCoopBlock {
 #ifdef FLAGCX_DEVICE_API_NCCL
   ncclCoopCta _impl;
@@ -336,35 +481,322 @@ struct flagcxCoopBlock {
   FLAGCX_HOST_DEVICE_INLINE flagcxCoopBlock() : _impl() {}
 
   FLAGCX_DEVICE_INLINE_DECORATOR int threadRank() const {
-    return _impl.threadRank();
+    return _impl.thread_rank();
   }
   FLAGCX_DEVICE_INLINE_DECORATOR int size() const { return _impl.size(); }
   FLAGCX_DEVICE_INLINE_DECORATOR void sync() { _impl.sync(); }
 
   // Implicit conversion for passthrough to NCCL APIs
   FLAGCX_HOST_DEVICE_INLINE operator ncclCoopCta() const { return _impl; }
-#else
+#elif defined(FLAGCX_SIMT_WIDTH)
   FLAGCX_DEVICE_INLINE_DECORATOR int threadRank() const {
-    return 0; // placeholder for fallback
+    return FLAGCX_THREAD_IDX_X;
   }
-  FLAGCX_DEVICE_INLINE_DECORATOR int size() const {
-    return 0; // placeholder for fallback
-  }
+  FLAGCX_DEVICE_INLINE_DECORATOR int size() const { return FLAGCX_BLOCK_DIM_X; }
   FLAGCX_DEVICE_INLINE_DECORATOR void sync() { FLAGCX_DEVICE_SYNC_THREADS(); }
+#else
+  int threadRank() const { return FLAGCX_THREAD_IDX_X; }
+  int size() const { return FLAGCX_BLOCK_DIM_X; }
+  void sync() {}
 #endif
 };
 
-// ============================================================
-// Section 6b: flagcxCoopThread — Single-Thread Cooperative Group
-//
-// On NVIDIA: wraps ncclCoopThread.
-// Used for thread-0-only control-plane ops (put, waitSignal, flush).
-// ============================================================
-struct flagcxCoopThread {
-  FLAGCX_DEVICE_INLINE_DECORATOR int threadRank() const { return 0; }
-  FLAGCX_DEVICE_INLINE_DECORATOR int size() const { return 1; }
-  FLAGCX_DEVICE_INLINE_DECORATOR void sync() {}
+// ---- 6b. flagcxCoopTile<N> — Tile of N threads within a warp ----
+template <int N>
+struct flagcxCoopTile {
+#ifdef FLAGCX_DEVICE_API_NCCL
+  ncclCoopTile<N> _impl;
+
+  FLAGCX_DEVICE_INLINE_DECORATOR int threadRank() const {
+    return _impl.thread_rank();
+  }
+  FLAGCX_DEVICE_INLINE_DECORATOR constexpr int size() const { return N; }
+  FLAGCX_DEVICE_INLINE_DECORATOR uint32_t laneMask() const {
+    return _impl.laneMask();
+  }
+  FLAGCX_DEVICE_INLINE_DECORATOR void sync() { _impl.sync(); }
+#elif defined(FLAGCX_SIMT_WIDTH)
+  static_assert(N > 0 && (N & (N - 1)) == 0 && N <= FLAGCX_SIMT_WIDTH,
+                "N must be a power of 2 and <= FLAGCX_SIMT_WIDTH");
+
+  FLAGCX_DEVICE_INLINE_DECORATOR int threadRank() const {
+    return flagcxLane() % N;
+  }
+  FLAGCX_DEVICE_INLINE_DECORATOR constexpr int size() const { return N; }
+  FLAGCX_DEVICE_INLINE_DECORATOR uint32_t laneMask() const {
+    return (0xffffffffu >> (32 - N)) << (flagcxLane() & -N);
+  }
+  FLAGCX_DEVICE_INLINE_DECORATOR void sync() {
+    if (N > 1)
+      flagcxSyncwarp(laneMask());
+  }
+#else
+  int threadRank() const { return 0; }
+  constexpr int size() const { return N; }
+  void sync() {}
+#endif
 };
+
+// ---- 6c. flagcxCoopThread — single-thread alias ----
+typedef flagcxCoopTile<1> flagcxCoopThread;
+
+// ---- 6d. flagcxCoopWarp — full-warp alias (SIMT only) ----
+#ifdef FLAGCX_SIMT_WIDTH
+typedef flagcxCoopTile<FLAGCX_SIMT_WIDTH> flagcxCoopWarp;
+#endif
+
+// ---- 6e. flagcxCoopTileSpan — consecutive tiles with named barrier ----
+#ifdef FLAGCX_SIMT_WIDTH
+struct flagcxCoopTileSpan {
+#ifdef FLAGCX_DEVICE_API_NCCL
+  ncclCoopWarpSpan _impl;
+
+  FLAGCX_DEVICE_INLINE_DECORATOR constexpr flagcxCoopTileSpan(int t0,
+                                                              int nTiles,
+                                                              int id)
+      : _impl(t0, nTiles, id) {}
+
+  FLAGCX_DEVICE_INLINE_DECORATOR int threadRank() const {
+    return _impl.thread_rank();
+  }
+  FLAGCX_DEVICE_INLINE_DECORATOR int size() const { return _impl.size(); }
+  FLAGCX_DEVICE_INLINE_DECORATOR void sync() { _impl.sync(); }
+#else
+  uint32_t t0 : 8, nTiles : 8, id : 8;
+
+  FLAGCX_DEVICE_INLINE_DECORATOR constexpr flagcxCoopTileSpan(int t0,
+                                                              int nTiles,
+                                                              int id)
+      : t0(t0), nTiles(nTiles), id(id) {}
+
+  FLAGCX_DEVICE_INLINE_DECORATOR int threadRank() const {
+    return FLAGCX_THREAD_IDX_X - FLAGCX_SIMT_WIDTH * t0;
+  }
+  FLAGCX_DEVICE_INLINE_DECORATOR int size() const {
+    return FLAGCX_SIMT_WIDTH * nTiles;
+  }
+  FLAGCX_DEVICE_INLINE_DECORATOR void sync() {
+    flagcxNamedBarrierSync(1 + id, FLAGCX_SIMT_WIDTH * nTiles);
+  }
+#endif
+};
+#endif // FLAGCX_SIMT_WIDTH
+
+// ---- 6f. flagcxCoopLanes — arbitrary lane bitmask ----
+#ifdef FLAGCX_SIMT_WIDTH
+struct flagcxCoopLanes {
+#ifdef FLAGCX_DEVICE_API_NCCL
+  ncclCoopLanes _impl;
+
+  FLAGCX_DEVICE_INLINE_DECORATOR constexpr flagcxCoopLanes(
+      uint32_t lmask = 0xffffffffu)
+      : _impl{lmask} {}
+
+  FLAGCX_DEVICE_INLINE_DECORATOR int threadRank() const {
+    return _impl.thread_rank();
+  }
+  FLAGCX_DEVICE_INLINE_DECORATOR int size() const { return _impl.size(); }
+  FLAGCX_DEVICE_INLINE_DECORATOR void sync() { _impl.sync(); }
+  FLAGCX_DEVICE_INLINE_DECORATOR uint32_t getLmask() const {
+    return _impl.lmask;
+  }
+#else
+  uint32_t lmask;
+
+  FLAGCX_DEVICE_INLINE_DECORATOR constexpr flagcxCoopLanes(
+      uint32_t lmask = 0xffffffffu)
+      : lmask(lmask) {}
+
+  FLAGCX_DEVICE_INLINE_DECORATOR int threadRank() const {
+    return flagcxPopc(lmask & flagcxLanemaskLt());
+  }
+  FLAGCX_DEVICE_INLINE_DECORATOR int size() const { return flagcxPopc(lmask); }
+  FLAGCX_DEVICE_INLINE_DECORATOR void sync() { flagcxSyncwarp(lmask); }
+  FLAGCX_DEVICE_INLINE_DECORATOR uint32_t getLmask() const { return lmask; }
+#endif
+};
+#endif // FLAGCX_SIMT_WIDTH
+
+// ---- 6g. flagcxCoopAny — type-erased cooperative group ----
+struct flagcxCoopAny {
+#ifdef FLAGCX_DEVICE_API_NCCL
+  ncclCoopAny _impl;
+
+  flagcxCoopAny() = default;
+  flagcxCoopAny(flagcxCoopAny const &) = default;
+
+  FLAGCX_DEVICE_INLINE_DECORATOR flagcxCoopAny(flagcxCoopBlock b)
+      : _impl(b._impl) {}
+  template <int N>
+  FLAGCX_DEVICE_INLINE_DECORATOR flagcxCoopAny(flagcxCoopTile<N> t)
+      : _impl(t._impl) {}
+#ifdef FLAGCX_SIMT_WIDTH
+  FLAGCX_DEVICE_INLINE_DECORATOR flagcxCoopAny(flagcxCoopTileSpan s)
+      : _impl(s._impl) {}
+  FLAGCX_DEVICE_INLINE_DECORATOR flagcxCoopAny(flagcxCoopLanes l)
+      : _impl(l._impl) {}
+#endif
+
+  FLAGCX_DEVICE_INLINE_DECORATOR int threadRank() const {
+    return _impl.thread_rank();
+  }
+  FLAGCX_DEVICE_INLINE_DECORATOR int size() const { return _impl.size(); }
+  FLAGCX_DEVICE_INLINE_DECORATOR void sync() { _impl.sync(); }
+
+#elif defined(FLAGCX_SIMT_WIDTH)
+  // Tier 2: own vtable-based type erasure
+  struct Storage {
+    alignas(alignof(void *)) char space[16];
+  };
+  struct VTable {
+    int (*threadRank)(void const *);
+    int (*size)(void const *);
+    void (*sync)(void *);
+  };
+
+  template <typename Impl>
+  FLAGCX_DEVICE_INLINE_DECORATOR static int threadRank_fn(void const *o) {
+    return static_cast<Impl const *>(o)->threadRank();
+  }
+  template <typename Impl>
+  FLAGCX_DEVICE_INLINE_DECORATOR static int size_fn(void const *o) {
+    return static_cast<Impl const *>(o)->size();
+  }
+  template <typename Impl>
+  FLAGCX_DEVICE_INLINE_DECORATOR static void sync_fn(void *o) {
+    static_cast<Impl *>(o)->sync();
+  }
+
+  template <typename Impl>
+  FLAGCX_DEVICE_INLINE_DECORATOR static VTable const *get_vtable() {
+    static_assert(sizeof(Impl) <= sizeof(Storage), "Coop type too large");
+    static_assert(alignof(Impl) <= alignof(Storage),
+                  "Coop type alignment too large");
+    static constexpr VTable v = {&threadRank_fn<Impl>, &size_fn<Impl>,
+                                 &sync_fn<Impl>};
+    return &v;
+  }
+
+  Storage storage;
+  VTable const *vtable;
+
+  flagcxCoopAny() = default;
+  flagcxCoopAny(flagcxCoopAny const &) = default;
+
+  template <typename Impl>
+  FLAGCX_DEVICE_INLINE_DECORATOR flagcxCoopAny(Impl impl) {
+    ::new (&this->storage) Impl(impl);
+    this->vtable = get_vtable<Impl>();
+  }
+
+  FLAGCX_DEVICE_INLINE_DECORATOR int threadRank() const {
+    return vtable->threadRank(&storage);
+  }
+  FLAGCX_DEVICE_INLINE_DECORATOR int size() const {
+    return vtable->size(&storage);
+  }
+  FLAGCX_DEVICE_INLINE_DECORATOR void sync() { vtable->sync(&storage); }
+
+#else
+  // Non-SIMT fallback: simple capture
+  int _threadRank;
+  int _size;
+
+  flagcxCoopAny() : _threadRank(0), _size(1) {}
+  flagcxCoopAny(flagcxCoopBlock b)
+      : _threadRank(b.threadRank()), _size(b.size()) {}
+  template <int N>
+  flagcxCoopAny(flagcxCoopTile<N>) : _threadRank(0), _size(N) {}
+
+  int threadRank() const { return _threadRank; }
+  int size() const { return _size; }
+  void sync() {}
+#endif
+};
+
+// ---- 6h. Free functions ----
+
+// flagcxCoopGetLaneMask: get the active lane bitmask for a cooperative group
+#ifdef FLAGCX_SIMT_WIDTH
+template <int N>
+FLAGCX_DEVICE_INLINE_DECORATOR
+    uint32_t flagcxCoopGetLaneMask(flagcxCoopTile<N> coop) {
+  return coop.laneMask();
+}
+FLAGCX_DEVICE_INLINE_DECORATOR uint32_t flagcxCoopGetLaneMask(flagcxCoopBlock) {
+  return 0xffffffffu;
+}
+FLAGCX_DEVICE_INLINE_DECORATOR uint32_t
+flagcxCoopGetLaneMask(flagcxCoopLanes coop) {
+  return coop.getLmask();
+}
+FLAGCX_DEVICE_INLINE_DECORATOR uint32_t
+flagcxCoopGetLaneMask(flagcxCoopTileSpan) {
+  return 0xffffffffu;
+}
+#endif // FLAGCX_SIMT_WIDTH
+
+// flagcxCoopIsThread: compile-time check if group is a single thread
+template <int N>
+FLAGCX_DEVICE_INLINE_DECORATOR constexpr bool
+flagcxCoopIsThread(flagcxCoopTile<N>) {
+  return N == 1;
+}
+FLAGCX_DEVICE_INLINE_DECORATOR constexpr bool
+flagcxCoopIsThread(flagcxCoopBlock) {
+  return false;
+}
+#ifdef FLAGCX_SIMT_WIDTH
+FLAGCX_DEVICE_INLINE_DECORATOR constexpr bool
+flagcxCoopIsThread(flagcxCoopLanes) {
+  return false;
+}
+FLAGCX_DEVICE_INLINE_DECORATOR constexpr bool
+flagcxCoopIsThread(flagcxCoopTileSpan) {
+  return false;
+}
+#endif // FLAGCX_SIMT_WIDTH
+
+// flagcxCoopWithinTile: compile-time check if group fits within a single tile
+template <int N>
+FLAGCX_DEVICE_INLINE_DECORATOR constexpr bool
+flagcxCoopWithinTile(flagcxCoopTile<N>) {
+  return true;
+}
+FLAGCX_DEVICE_INLINE_DECORATOR constexpr bool
+flagcxCoopWithinTile(flagcxCoopBlock) {
+  return false;
+}
+#ifdef FLAGCX_SIMT_WIDTH
+FLAGCX_DEVICE_INLINE_DECORATOR constexpr bool
+flagcxCoopWithinTile(flagcxCoopLanes) {
+  return true;
+}
+FLAGCX_DEVICE_INLINE_DECORATOR constexpr bool
+flagcxCoopWithinTile(flagcxCoopTileSpan) {
+  return false;
+}
+#endif // FLAGCX_SIMT_WIDTH
+
+// flagcxCoopCoalesced: get a cooperative group of active/safe threads
+#ifdef FLAGCX_SIMT_WIDTH
+FLAGCX_DEVICE_INLINE_DECORATOR flagcxCoopLanes flagcxCoopCoalesced() {
+  return flagcxCoopLanes{flagcxActivemask()};
+}
+template <typename Coop>
+FLAGCX_DEVICE_INLINE_DECORATOR flagcxCoopWarp flagcxCoopCoalesced(Coop) {
+  return flagcxCoopWarp();
+}
+FLAGCX_DEVICE_INLINE_DECORATOR flagcxCoopLanes
+flagcxCoopCoalesced(flagcxCoopLanes coop) {
+  return coop;
+}
+template <int N>
+FLAGCX_DEVICE_INLINE_DECORATOR flagcxCoopTile<N>
+flagcxCoopCoalesced(flagcxCoopTile<N> coop) {
+  return coop;
+}
+#endif // FLAGCX_SIMT_WIDTH
 
 // ============================================================
 // Section 7: flagcxIntraBarrierSession — Intra-Node Barrier
@@ -379,9 +811,11 @@ struct flagcxIntraBarrierSession {
 
   FLAGCX_DEVICE_INLINE_DECORATOR
   flagcxIntraBarrierSession(Coop coop, const flagcxDevComm &devComm,
-                            flagcxTeam_t team, uint32_t index)
+                            flagcxTeam_t team, uint32_t index,
+                            bool multimem = false,
+                            flagcxMulticastHandle mcHandle = {})
       : _impl(ncclCoopCta(), devComm._base, ncclTeamLsa(devComm._base),
-              devComm._base.lsaBarrier, index, false) {}
+              devComm._base.lsaBarrier, index, multimem, mcHandle) {}
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   arrive(Coop coop,
@@ -410,7 +844,9 @@ struct flagcxIntraBarrierSession {
 
   FLAGCX_DEVICE_INLINE_DECORATOR
   flagcxIntraBarrierSession(Coop coop, const flagcxDevComm &devComm,
-                            flagcxTeam_t team, uint32_t index)
+                            flagcxTeam_t team, uint32_t index,
+                            bool multimem = false,
+                            flagcxMulticastHandle mcHandle = {})
       : _peerSignals(devComm._barrierPeers), _nRanks(team.nRanks),
         _myRank(team.rank), _ctaIndex(index), _epoch(devComm._barrierEpoch) {}
 
@@ -476,10 +912,15 @@ struct flagcxIntraBarrierSession {
 // ============================================================
 // Section 8: Pointer Access Functions (Inline Wrappers)
 //
-// 3 functions total (see plan Decision 7.8 / 7.9 / 7.19):
-//   flagcxGetPeerPointer(mem, off, team, peer)  — canonical unicast
-//   flagcxGetLocalPointer(mem, off)              — convenience (own buffer)
-//   flagcxGetMulticastPointer(mem, off, devComm) — intra-node multicast
+// 7 functions total (see plan Decision 7.8 / 7.9 / 7.19):
+//   flagcxGetPeerPointer(mem, off, team, peer)      — canonical unicast
+//   flagcxGetLocalPointer(mem, off)                  — convenience (own buffer)
+//   flagcxGetMulticastPointer(mem, off, devComm)     — intra-node multicast
+//   (LSA convenience) flagcxGetPeerPointer(mem, off, peer)             —
+//   world-rank unicast (no team) flagcxGetIntraPointer(mem, off, peer) —
+//   intra-node rank pointer flagcxGetMulticastPointer(mem, off, mmHandle)    —
+//   explicit multicast handle flagcxFindMem(coop, devComm, ptr) — reverse
+//   lookup
 //
 // Priority dispatch: Window > IPC > Raw.
 // Capabilities detected by _hasWindow flag and peerPtrs null-check.
@@ -519,6 +960,70 @@ flagcxGetMulticastPointer(const flagcxDevMem &mem, size_t offset,
   return nullptr; // IPC/raw mode: multicast not available
 }
 
+// ---- Additional pointer functions (Step 2c) ----
+
+// World-rank peer pointer (no team parameter).
+// Tier 1: window-based. Tier 2: IPC peerPtrs with world→local index mapping.
+FLAGCX_DEVICE_INLINE_DECORATOR void *
+flagcxGetPeerPointer(const flagcxDevMem &mem, size_t offset, int peer) {
+#ifdef FLAGCX_DEVICE_API_NCCL
+  if (mem._hasWindow)
+    return ncclGetPeerPointer(mem._base, offset, peer);
+#endif
+  if (mem.peerPtrs != nullptr) {
+    // Map world rank to local peer index: localIdx = intraRank + (peer -
+    // worldRank) Note: caller must ensure peer is on the same node. Without
+    // devComm, we use the mem's intraRank as the base index offset.
+    return (char *)mem.peerPtrs[mem.intraRank + peer] + offset;
+  }
+  return nullptr;
+}
+
+// Intra-node rank pointer (NCCL "Lsa" → FlagCX "Intra").
+// peer is a local (intra-node) rank index.
+FLAGCX_DEVICE_INLINE_DECORATOR void *
+flagcxGetIntraPointer(const flagcxDevMem &mem, size_t offset, int peer) {
+#ifdef FLAGCX_DEVICE_API_NCCL
+  if (mem._hasWindow)
+    return ncclGetLsaPointer(mem._base, offset, peer);
+#endif
+  if (mem.peerPtrs != nullptr)
+    return (char *)mem.peerPtrs[peer] + offset;
+  return nullptr;
+}
+
+// Multicast pointer with explicit MulticastHandle.
+FLAGCX_DEVICE_INLINE_DECORATOR void *
+flagcxGetMulticastPointer(const flagcxDevMem &mem, size_t offset,
+                          flagcxMulticastHandle_t mmHandle) {
+#ifdef FLAGCX_DEVICE_API_NCCL
+  if (mem._hasWindow)
+    return ncclGetMultimemPointer(mem._base, offset, mmHandle._base);
+#endif
+  return nullptr; // Multicast not available without NCCL window
+}
+
+// Reverse lookup: raw pointer → flagcxDevMem.
+// Tier 1: cooperative search through NCCL window table.
+// Tier 2: not supported (returns empty flagcxDevMem).
+template <typename Coop>
+FLAGCX_DEVICE_INLINE_DECORATOR flagcxDevMem
+flagcxFindMem(Coop coop, const flagcxDevComm &devComm, void const *ptr) {
+  flagcxDevMem result;
+#ifdef FLAGCX_DEVICE_API_NCCL
+  if (devComm._hasBase) {
+    ncclWindow_t w = ncclFindWindow(toNccl(coop), devComm._base, ptr);
+    result._base = w;
+    result._hasWindow = true;
+    return result;
+  }
+#endif
+  (void)coop;
+  (void)devComm;
+  (void)ptr;
+  return result;
+}
+
 // ============================================================
 // Section 8b: flagcxSymPtr<T> — Typed Symmetric Pointer
 //
@@ -535,34 +1040,110 @@ struct flagcxSymPtr {
   FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr(flagcxDevMem m, size_t off)
       : mem(m), offset(off) {}
 
-  // Typed pointer methods (delegate to existing free functions)
+  // Type conversion (e.g. flagcxSymPtr<float> → flagcxSymPtr<char>)
+  template <typename U>
+  FLAGCX_HOST_DEVICE_INLINE operator flagcxSymPtr<U>() const {
+    return {mem, offset};
+  }
+
+  // Typed pointer methods (delegate to free functions)
   FLAGCX_DEVICE_INLINE_DECORATOR T *localPtr() const {
     return (T *)flagcxGetLocalPointer(mem, offset);
   }
   FLAGCX_DEVICE_INLINE_DECORATOR T *peerPtr(flagcxTeam_t team, int peer) const {
     return (T *)flagcxGetPeerPointer(mem, offset, team, peer);
   }
+  FLAGCX_DEVICE_INLINE_DECORATOR T *peerPtr(int peer) const {
+    return (T *)flagcxGetPeerPointer(mem, offset, peer);
+  }
+  FLAGCX_DEVICE_INLINE_DECORATOR T *intraPtr(int peer) const {
+    return (T *)flagcxGetIntraPointer(mem, offset, peer);
+  }
   FLAGCX_DEVICE_INLINE_DECORATOR T *
   multicastPtr(const flagcxDevComm &devComm) const {
     return (T *)flagcxGetMulticastPointer(mem, offset, devComm);
   }
+  FLAGCX_DEVICE_INLINE_DECORATOR T *
+  multicastPtr(flagcxMulticastHandle_t mmHandle) const {
+    return (T *)flagcxGetMulticastPointer(mem, offset, mmHandle);
+  }
 
-  // Type-aware pointer arithmetic
+  // Type-aware pointer arithmetic (reinterpret_cast pattern matches NCCL)
   FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator+=(int d) {
-    offset += d * sizeof(T);
+    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) + d);
     return *this;
   }
+  FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator+=(unsigned int d) {
+    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) + d);
+    return *this;
+  }
+  FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator+=(long d) {
+    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) + d);
+    return *this;
+  }
+  FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator+=(unsigned long d) {
+    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) + d);
+    return *this;
+  }
+  FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator+=(long long d) {
+    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) + d);
+    return *this;
+  }
+  FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator+=(unsigned long long d) {
+    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) + d);
+    return *this;
+  }
+
   FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator-=(int d) {
-    offset -= d * sizeof(T);
+    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) - d);
     return *this;
   }
-  FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> operator+(int d) const {
-    return {mem, offset + d * sizeof(T)};
+  FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator-=(unsigned int d) {
+    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) - d);
+    return *this;
   }
-  FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> operator-(int d) const {
-    return {mem, offset - d * sizeof(T)};
+  FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator-=(long d) {
+    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) - d);
+    return *this;
+  }
+  FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator-=(unsigned long d) {
+    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) - d);
+    return *this;
+  }
+  FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator-=(long long d) {
+    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) - d);
+    return *this;
+  }
+  FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator-=(unsigned long long d) {
+    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) - d);
+    return *this;
   }
 };
+
+// Free operators for flagcxSymPtr<T>
+template <typename T, typename Int>
+FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> operator+(flagcxSymPtr<T> p, Int d) {
+  return p += d;
+}
+template <typename T, typename Int>
+FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> operator-(flagcxSymPtr<T> p, Int d) {
+  return p -= d;
+}
+template <typename T>
+FLAGCX_HOST_DEVICE_INLINE ptrdiff_t operator-(flagcxSymPtr<T> a,
+                                              flagcxSymPtr<T> b) {
+  return reinterpret_cast<T *>(a.offset) - reinterpret_cast<T *>(b.offset);
+}
+template <typename T>
+FLAGCX_HOST_DEVICE_INLINE bool operator==(flagcxSymPtr<T> a,
+                                          flagcxSymPtr<T> b) {
+  return a.mem.rawPtr == b.mem.rawPtr && a.offset == b.offset;
+}
+template <typename T>
+FLAGCX_HOST_DEVICE_INLINE bool operator!=(flagcxSymPtr<T> a,
+                                          flagcxSymPtr<T> b) {
+  return a.mem.rawPtr != b.mem.rawPtr || a.offset != b.offset;
+}
 
 #endif // FLAGCX_DEVICE_COMPILE
 
@@ -672,6 +1253,18 @@ struct flagcxDevNet_CounterInc {
   flagcxDevNetCounter_t counter;
 };
 
+// Shared memory descriptor for NIC descriptor optimization (Tier 1 / GIN only).
+// On Tier 2, the struct is empty; GIN methods accepting this type are stubs.
+struct flagcxDescriptorSmem {
+#ifdef FLAGCX_DEVICE_API_NCCL
+  ncclGinDescriptorSmem *_impl;
+#endif
+};
+
+struct flagcxDevNet_DescriptorSmem {
+  flagcxDescriptorSmem smem;
+};
+
 #ifdef FLAGCX_DEVICE_API_NCCL
 // Action type mapping helpers (flagcx -> nccl)
 FLAGCX_DEVICE_INLINE_DECORATOR ncclGin_None toNccl(flagcxDevNet_None) {
@@ -689,11 +1282,25 @@ FLAGCX_DEVICE_INLINE_DECORATOR ncclGin_CounterInc
 toNccl(flagcxDevNet_CounterInc a) {
   return {a.counter};
 }
-FLAGCX_DEVICE_INLINE_DECORATOR ncclCoopCta toNccl(flagcxCoopBlock) {
-  return {};
+FLAGCX_DEVICE_INLINE_DECORATOR ncclGin_DescriptorSmem
+toNccl(flagcxDevNet_DescriptorSmem a) {
+  return {a.smem._impl};
 }
-FLAGCX_DEVICE_INLINE_DECORATOR ncclCoopThread toNccl(flagcxCoopThread) {
-  return {};
+FLAGCX_DEVICE_INLINE_DECORATOR ncclCoopCta toNccl(flagcxCoopBlock b) {
+  return b._impl;
+}
+template <int N>
+FLAGCX_DEVICE_INLINE_DECORATOR ncclCoopTile<N> toNccl(flagcxCoopTile<N> t) {
+  return t._impl;
+}
+FLAGCX_DEVICE_INLINE_DECORATOR ncclCoopWarpSpan toNccl(flagcxCoopTileSpan s) {
+  return s._impl;
+}
+FLAGCX_DEVICE_INLINE_DECORATOR ncclCoopLanes toNccl(flagcxCoopLanes l) {
+  return l._impl;
+}
+FLAGCX_DEVICE_INLINE_DECORATOR ncclCoopAny toNccl(flagcxCoopAny a) {
+  return a._impl;
 }
 #endif // FLAGCX_DEVICE_API_NCCL
 
@@ -771,47 +1378,84 @@ struct flagcxDevNet {
 
   template <typename RemoteAction = flagcxDevNet_None,
             typename LocalAction = flagcxDevNet_None,
-            typename Coop = flagcxCoopBlock>
+            typename Coop = flagcxCoopBlock,
+            typename DescriptorSmem = flagcxDevNet_None>
   FLAGCX_DEVICE_INLINE_DECORATOR void
   put(flagcxTeam_t team, int peer, const flagcxDevMem &dstMem, size_t dstOffset,
       const flagcxDevMem &srcMem, size_t srcOffset, size_t bytes,
       RemoteAction remoteAction = flagcxDevNet_None{},
       LocalAction localAction = flagcxDevNet_None{},
-      Coop coop = flagcxCoopBlock{}) const {
+      Coop coop = flagcxCoopBlock{},
+      DescriptorSmem descriptor = flagcxDevNet_None{},
+      flagcxDeviceScope_t alreadyReleased = flagcxDeviceScopeThread,
+      flagcxDeviceScope_t expected_scope = flagcxDeviceScopeDevice) const {
     _gin.put(team._base, peer, dstMem._base, dstOffset, srcMem._base, srcOffset,
-             bytes, toNccl(remoteAction), toNccl(localAction), toNccl(coop));
+             bytes, toNccl(remoteAction), toNccl(localAction), toNccl(coop),
+             toNccl(descriptor), flagcxDeviceScopeMap[alreadyReleased],
+             flagcxDeviceScopeMap[expected_scope]);
   }
 
-  // SymPtr-based put overload — convenience wrapper, delegates to window-based
-  // put with nElts * sizeof(T) bytes.
+  // SymPtr-based put overload — convenience wrapper.
   template <typename T, typename RemoteAction = flagcxDevNet_None,
             typename LocalAction = flagcxDevNet_None,
-            typename Coop = flagcxCoopBlock>
+            typename Coop = flagcxCoopBlock,
+            typename DescriptorSmem = flagcxDevNet_None>
   FLAGCX_DEVICE_INLINE_DECORATOR void
   put(flagcxTeam_t team, int peer, flagcxSymPtr<T> dst, flagcxSymPtr<T> src,
       size_t nElts, RemoteAction remoteAction = flagcxDevNet_None{},
       LocalAction localAction = flagcxDevNet_None{},
-      Coop coop = flagcxCoopBlock{}) const {
+      Coop coop = flagcxCoopBlock{},
+      DescriptorSmem descriptor = flagcxDevNet_None{},
+      flagcxDeviceScope_t alreadyReleased = flagcxDeviceScopeThread,
+      flagcxDeviceScope_t expected_scope = flagcxDeviceScopeDevice) const {
     this->put(team, peer, dst.mem, dst.offset, src.mem, src.offset,
-              nElts * sizeof(T), remoteAction, localAction, coop);
+              nElts * sizeof(T), remoteAction, localAction, coop, descriptor,
+              alreadyReleased, expected_scope);
   }
 
   template <typename T, typename RemoteAction = flagcxDevNet_None,
-            typename Coop = flagcxCoopBlock>
+            typename Coop = flagcxCoopBlock,
+            typename DescriptorSmem = flagcxDevNet_None>
   FLAGCX_DEVICE_INLINE_DECORATOR void
   putValue(flagcxTeam_t team, int peer, const flagcxDevMem &dstMem,
            size_t dstOffset, T value,
            RemoteAction remoteAction = flagcxDevNet_None{},
-           Coop coop = flagcxCoopBlock{}) const {
+           Coop coop = flagcxCoopBlock{},
+           DescriptorSmem descriptor = flagcxDevNet_None{},
+           flagcxDeviceScope_t alreadyReleased = flagcxDeviceScopeThread,
+           flagcxDeviceScope_t expected_scope = flagcxDeviceScopeDevice) const {
     _gin.putValue(team._base, peer, dstMem._base, dstOffset, value,
-                  toNccl(remoteAction), toNccl(coop));
+                  toNccl(remoteAction), toNccl(coop), toNccl(descriptor),
+                  flagcxDeviceScopeMap[alreadyReleased],
+                  flagcxDeviceScopeMap[expected_scope]);
   }
 
-  template <typename RemoteAction, typename Coop = flagcxCoopBlock>
+  // SymPtr-based putValue overload.
+  template <typename T, typename RemoteAction = flagcxDevNet_None,
+            typename Coop = flagcxCoopBlock,
+            typename DescriptorSmem = flagcxDevNet_None>
+  FLAGCX_DEVICE_INLINE_DECORATOR void
+  putValue(flagcxTeam_t team, int peer, flagcxSymPtr<T> dst, T value,
+           RemoteAction remoteAction = flagcxDevNet_None{},
+           Coop coop = flagcxCoopBlock{},
+           DescriptorSmem descriptor = flagcxDevNet_None{},
+           flagcxDeviceScope_t alreadyReleased = flagcxDeviceScopeThread,
+           flagcxDeviceScope_t expected_scope = flagcxDeviceScopeDevice) const {
+    this->putValue(team, peer, dst.mem, dst.offset, value, remoteAction, coop,
+                   descriptor, alreadyReleased, expected_scope);
+  }
+
+  template <typename RemoteAction, typename Coop = flagcxCoopBlock,
+            typename DescriptorSmem = flagcxDevNet_None>
   FLAGCX_DEVICE_INLINE_DECORATOR void
   signal(flagcxTeam_t team, int peer, RemoteAction remoteAction,
-         Coop coop = flagcxCoopBlock{}) const {
-    _gin.signal(team._base, peer, toNccl(remoteAction), toNccl(coop));
+         Coop coop = flagcxCoopBlock{},
+         DescriptorSmem descriptor = flagcxDevNet_None{},
+         flagcxDeviceScope_t alreadyReleased = flagcxDeviceScopeThread,
+         flagcxDeviceScope_t expected_scope = flagcxDeviceScopeDevice) const {
+    _gin.signal(team._base, peer, toNccl(remoteAction), toNccl(coop),
+                toNccl(descriptor), flagcxDeviceScopeMap[alreadyReleased],
+                flagcxDeviceScopeMap[expected_scope]);
   }
 
   template <typename Coop>
@@ -899,30 +1543,54 @@ struct flagcxDevNet {
 
   template <typename RemoteAction = flagcxDevNet_None,
             typename LocalAction = flagcxDevNet_None,
-            typename Coop = flagcxCoopBlock>
+            typename Coop = flagcxCoopBlock,
+            typename DescriptorSmem = flagcxDevNet_None>
   FLAGCX_DEVICE_INLINE_DECORATOR void
   put(flagcxTeam_t, int, const flagcxDevMem &, size_t, const flagcxDevMem &,
       size_t, size_t, RemoteAction = flagcxDevNet_None{},
-      LocalAction = flagcxDevNet_None{}, Coop = flagcxCoopBlock{}) const {}
+      LocalAction = flagcxDevNet_None{}, Coop = flagcxCoopBlock{},
+      DescriptorSmem = flagcxDevNet_None{},
+      flagcxDeviceScope_t = flagcxDeviceScopeThread,
+      flagcxDeviceScope_t = flagcxDeviceScopeDevice) const {}
 
   template <typename T, typename RemoteAction = flagcxDevNet_None,
             typename LocalAction = flagcxDevNet_None,
-            typename Coop = flagcxCoopBlock>
+            typename Coop = flagcxCoopBlock,
+            typename DescriptorSmem = flagcxDevNet_None>
   FLAGCX_DEVICE_INLINE_DECORATOR void
   put(flagcxTeam_t, int, flagcxSymPtr<T>, flagcxSymPtr<T>, size_t,
       RemoteAction = flagcxDevNet_None{}, LocalAction = flagcxDevNet_None{},
-      Coop = flagcxCoopBlock{}) const {}
+      Coop = flagcxCoopBlock{}, DescriptorSmem = flagcxDevNet_None{},
+      flagcxDeviceScope_t = flagcxDeviceScopeThread,
+      flagcxDeviceScope_t = flagcxDeviceScopeDevice) const {}
 
   template <typename T, typename RemoteAction = flagcxDevNet_None,
-            typename Coop = flagcxCoopBlock>
+            typename Coop = flagcxCoopBlock,
+            typename DescriptorSmem = flagcxDevNet_None>
   FLAGCX_DEVICE_INLINE_DECORATOR void
   putValue(flagcxTeam_t, int, const flagcxDevMem &, size_t, T,
-           RemoteAction = flagcxDevNet_None{}, Coop = flagcxCoopBlock{}) const {
-  }
+           RemoteAction = flagcxDevNet_None{}, Coop = flagcxCoopBlock{},
+           DescriptorSmem = flagcxDevNet_None{},
+           flagcxDeviceScope_t = flagcxDeviceScopeThread,
+           flagcxDeviceScope_t = flagcxDeviceScopeDevice) const {}
 
-  template <typename RemoteAction, typename Coop = flagcxCoopBlock>
-  FLAGCX_DEVICE_INLINE_DECORATOR void signal(flagcxTeam_t, int, RemoteAction,
-                                             Coop = flagcxCoopBlock{}) const {}
+  template <typename T, typename RemoteAction = flagcxDevNet_None,
+            typename Coop = flagcxCoopBlock,
+            typename DescriptorSmem = flagcxDevNet_None>
+  FLAGCX_DEVICE_INLINE_DECORATOR void
+  putValue(flagcxTeam_t, int, flagcxSymPtr<T>, T,
+           RemoteAction = flagcxDevNet_None{}, Coop = flagcxCoopBlock{},
+           DescriptorSmem = flagcxDevNet_None{},
+           flagcxDeviceScope_t = flagcxDeviceScopeThread,
+           flagcxDeviceScope_t = flagcxDeviceScopeDevice) const {}
+
+  template <typename RemoteAction, typename Coop = flagcxCoopBlock,
+            typename DescriptorSmem = flagcxDevNet_None>
+  FLAGCX_DEVICE_INLINE_DECORATOR void
+  signal(flagcxTeam_t, int, RemoteAction, Coop = flagcxCoopBlock{},
+         DescriptorSmem = flagcxDevNet_None{},
+         flagcxDeviceScope_t = flagcxDeviceScopeThread,
+         flagcxDeviceScope_t = flagcxDeviceScopeDevice) const {}
 
   template <typename Coop>
   FLAGCX_DEVICE_INLINE_DECORATOR void
@@ -1074,14 +1742,16 @@ struct flagcxBarrierSession {
   // World barrier (intra + inter)
   FLAGCX_DEVICE_INLINE_DECORATOR
   flagcxBarrierSession(Coop coop, flagcxTeamTagWorld, const flagcxDevNet &net,
-                       uint32_t index)
-      : _impl(ncclCoopCta(), ncclTeamTagWorld(), net._gin, index) {}
+                       uint32_t index, bool multimem = false)
+      : _impl(ncclCoopCta(), ncclTeamTagWorld(), net._gin, index, multimem) {}
 
   // Intra-only barrier
   FLAGCX_DEVICE_INLINE_DECORATOR
   flagcxBarrierSession(Coop coop, flagcxTeamTagIntra,
-                       const flagcxDevComm &devComm, uint32_t index)
-      : _impl(ncclCoopCta(), ncclTeamTagLsa(), devComm._base, index) {}
+                       const flagcxDevComm &devComm, uint32_t index,
+                       bool multimem = false)
+      : _impl(ncclCoopCta(), ncclTeamTagLsa(), devComm._base, index, multimem) {
+  }
 
   // Inter-only barrier
   FLAGCX_DEVICE_INLINE_DECORATOR
@@ -1113,7 +1783,7 @@ struct flagcxBarrierSession {
   // World barrier: intra (IPC) + inter (FIFO Signal → isend)
   FLAGCX_DEVICE_INLINE_DECORATOR
   flagcxBarrierSession(Coop coop, flagcxTeamTagWorld, const flagcxDevNet &net,
-                       uint32_t index)
+                       uint32_t index, bool multimem = false)
       : _intra(coop, net._devComm, flagcxTeamIntra(net._devComm), index),
         _inter(coop, net._devComm, index),
         _nInterPeers(net._devComm._nInterPeers) {}
@@ -1121,9 +1791,17 @@ struct flagcxBarrierSession {
   // Intra-only barrier: inter is default constructed (no-op)
   FLAGCX_DEVICE_INLINE_DECORATOR
   flagcxBarrierSession(Coop coop, flagcxTeamTagIntra,
-                       const flagcxDevComm &devComm, uint32_t index)
+                       const flagcxDevComm &devComm, uint32_t index,
+                       bool multimem = false)
       : _intra(coop, devComm, flagcxTeamIntra(devComm), index), _inter(),
         _nInterPeers(0) {}
+
+  // Accessors for sub-barrier sessions (Tier 2 only)
+  FLAGCX_DEVICE_INLINE_DECORATOR
+  flagcxIntraBarrierSession<Coop> &intraBarrier() { return _intra; }
+
+  FLAGCX_DEVICE_INLINE_DECORATOR
+  flagcxInterBarrierSession<Coop> &interBarrier() { return _inter; }
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   sync(Coop coop,

--- a/flagcx/adaptor/include/device_api/flagcx_device.h
+++ b/flagcx/adaptor/include/device_api/flagcx_device.h
@@ -16,6 +16,8 @@
 #ifndef FLAGCX_DEVICE_API_H_
 #define FLAGCX_DEVICE_API_H_
 
+#include <cstddef> // ptrdiff_t, size_t
+
 #include "atomic_device.h"
 #include "device_utils.h"
 #include "flagcx.h"
@@ -381,8 +383,8 @@ flagcxTeam_t flagcxTeamInter(const flagcxDevComm &devComm) {
 FLAGCX_HOST_DEVICE_INLINE bool
 flagcxTeamRankIsMember(flagcxTeam_t a, flagcxTeam_t b, int bPeer) {
   int wrank = (bPeer - b.rank) * b.stride;
-  uint32_t adelta = wrank / a.stride;
-  uint32_t amod = wrank % a.stride;
+  int adelta = wrank / a.stride;
+  int amod = wrank % a.stride;
   int arank = a.rank + adelta;
   return 0 <= arank && arank < a.nRanks && amod == 0;
 }
@@ -391,7 +393,7 @@ flagcxTeamRankIsMember(flagcxTeam_t a, flagcxTeam_t b, int bPeer) {
 FLAGCX_HOST_DEVICE_INLINE int flagcxTeamRankToTeam(flagcxTeam_t a,
                                                    flagcxTeam_t b, int bPeer) {
   int wrank = (bPeer - b.rank) * b.stride;
-  uint32_t adelta = wrank / a.stride;
+  int adelta = wrank / a.stride;
   int arank = a.rank + adelta;
   return arank;
 }
@@ -680,12 +682,15 @@ struct flagcxCoopAny {
   Storage storage;
   VTable const *vtable;
 
-  flagcxCoopAny() = default;
+  FLAGCX_DEVICE_INLINE_DECORATOR flagcxCoopAny()
+      : storage{}, vtable(get_vtable<flagcxCoopThread>()) {}
   flagcxCoopAny(flagcxCoopAny const &) = default;
 
   template <typename Impl>
   FLAGCX_DEVICE_INLINE_DECORATOR flagcxCoopAny(Impl impl) {
-    ::new (&this->storage) Impl(impl);
+    char const *src = reinterpret_cast<char const *>(&impl);
+    for (unsigned i = 0; i < sizeof(Impl); ++i)
+      this->storage.space[i] = src[i];
     this->vtable = get_vtable<Impl>();
   }
 
@@ -962,20 +967,18 @@ flagcxGetMulticastPointer(const flagcxDevMem &mem, size_t offset,
 
 // ---- Additional pointer functions (Step 2c) ----
 
-// World-rank peer pointer (no team parameter).
-// Tier 1: window-based. Tier 2: IPC peerPtrs with world→local index mapping.
+// Peer pointer without team parameter.
+// Tier 1: delegates to NCCL (peer interpreted by NCCL runtime).
+// Tier 2: peer is an intra-node rank index into peerPtrs[] (same as
+// flagcxGetIntraPointer). Without a team, world→local mapping is not possible.
 FLAGCX_DEVICE_INLINE_DECORATOR void *
 flagcxGetPeerPointer(const flagcxDevMem &mem, size_t offset, int peer) {
 #ifdef FLAGCX_DEVICE_API_NCCL
   if (mem._hasWindow)
     return ncclGetPeerPointer(mem._base, offset, peer);
 #endif
-  if (mem.peerPtrs != nullptr) {
-    // Map world rank to local peer index: localIdx = intraRank + (peer -
-    // worldRank) Note: caller must ensure peer is on the same node. Without
-    // devComm, we use the mem's intraRank as the base index offset.
-    return (char *)mem.peerPtrs[mem.intraRank + peer] + offset;
-  }
+  if (mem.peerPtrs != nullptr)
+    return (char *)mem.peerPtrs[peer] + offset;
   return nullptr;
 }
 
@@ -1068,54 +1071,54 @@ struct flagcxSymPtr {
     return (T *)flagcxGetMulticastPointer(mem, offset, mmHandle);
   }
 
-  // Type-aware pointer arithmetic (reinterpret_cast pattern matches NCCL)
+  // Type-aware pointer arithmetic (integer math, no UB)
   FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator+=(int d) {
-    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) + d);
+    offset += d * sizeof(T);
     return *this;
   }
   FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator+=(unsigned int d) {
-    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) + d);
+    offset += d * sizeof(T);
     return *this;
   }
   FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator+=(long d) {
-    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) + d);
+    offset += d * sizeof(T);
     return *this;
   }
   FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator+=(unsigned long d) {
-    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) + d);
+    offset += d * sizeof(T);
     return *this;
   }
   FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator+=(long long d) {
-    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) + d);
+    offset += d * sizeof(T);
     return *this;
   }
   FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator+=(unsigned long long d) {
-    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) + d);
+    offset += d * sizeof(T);
     return *this;
   }
 
   FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator-=(int d) {
-    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) - d);
+    offset -= d * sizeof(T);
     return *this;
   }
   FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator-=(unsigned int d) {
-    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) - d);
+    offset -= d * sizeof(T);
     return *this;
   }
   FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator-=(long d) {
-    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) - d);
+    offset -= d * sizeof(T);
     return *this;
   }
   FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator-=(unsigned long d) {
-    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) - d);
+    offset -= d * sizeof(T);
     return *this;
   }
   FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator-=(long long d) {
-    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) - d);
+    offset -= d * sizeof(T);
     return *this;
   }
   FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> &operator-=(unsigned long long d) {
-    offset = reinterpret_cast<size_t>(reinterpret_cast<T *>(offset) - d);
+    offset -= d * sizeof(T);
     return *this;
   }
 };
@@ -1132,7 +1135,7 @@ FLAGCX_HOST_DEVICE_INLINE flagcxSymPtr<T> operator-(flagcxSymPtr<T> p, Int d) {
 template <typename T>
 FLAGCX_HOST_DEVICE_INLINE ptrdiff_t operator-(flagcxSymPtr<T> a,
                                               flagcxSymPtr<T> b) {
-  return reinterpret_cast<T *>(a.offset) - reinterpret_cast<T *>(b.offset);
+  return ((ptrdiff_t)a.offset - (ptrdiff_t)b.offset) / (ptrdiff_t)sizeof(T);
 }
 template <typename T>
 FLAGCX_HOST_DEVICE_INLINE bool operator==(flagcxSymPtr<T> a,

--- a/flagcx/adaptor/include/device_api/flagcx_device.h
+++ b/flagcx/adaptor/include/device_api/flagcx_device.h
@@ -724,8 +724,8 @@ struct flagcxCoopAny {
 // flagcxCoopGetLaneMask: get the active lane bitmask for a cooperative group
 #ifdef FLAGCX_SIMT_WIDTH
 template <int N>
-FLAGCX_DEVICE_INLINE_DECORATOR
-    uint32_t flagcxCoopGetLaneMask(flagcxCoopTile<N> coop) {
+FLAGCX_DEVICE_INLINE_DECORATOR uint32_t
+flagcxCoopGetLaneMask(flagcxCoopTile<N> coop) {
   return coop.laneMask();
 }
 FLAGCX_DEVICE_INLINE_DECORATOR uint32_t flagcxCoopGetLaneMask(flagcxCoopBlock) {

--- a/flagcx/adaptor/include/device_utils.h
+++ b/flagcx/adaptor/include/device_utils.h
@@ -36,6 +36,33 @@ FLAGCX_DEVICE_INLINE_DECORATOR void spinBackoff(int iter) {
   }
 #endif
 }
+// SIMT lockstep width (32 lanes on NVIDIA/CUDA)
+#define FLAGCX_SIMT_WIDTH 32
+#define FLAGCX_SHARED __shared__
+
+// SIMT intrinsic wrappers
+FLAGCX_DEVICE_INLINE_DECORATOR int flagcxLane() {
+  int lane;
+  asm("mov.u32 %0, %%laneid;" : "=r"(lane));
+  return lane;
+}
+FLAGCX_DEVICE_INLINE_DECORATOR uint32_t flagcxLanemaskLt() {
+  uint32_t mask;
+  asm("mov.u32 %0, %%lanemask_lt;" : "=r"(mask));
+  return mask;
+}
+FLAGCX_DEVICE_INLINE_DECORATOR uint32_t flagcxActivemask() {
+  return __activemask();
+}
+FLAGCX_DEVICE_INLINE_DECORATOR void
+flagcxSyncwarp(uint32_t mask = 0xffffffffu) {
+  __syncwarp(mask);
+}
+FLAGCX_DEVICE_INLINE_DECORATOR int flagcxPopc(uint32_t x) { return __popc(x); }
+FLAGCX_DEVICE_INLINE_DECORATOR void flagcxNamedBarrierSync(int id,
+                                                           int nThreads) {
+  __barrier_sync_count(id, nThreads);
+}
 #else
 // Host compiler (g++/clang++) on NVIDIA platform — no CUDA qualifiers
 #define FLAGCX_HOST_DECORATOR
@@ -50,6 +77,18 @@ FLAGCX_DEVICE_INLINE_DECORATOR void spinBackoff(int iter) {
 #define FLAGCX_BLOCK_IDX_X 0
 #define FLAGCX_BLOCK_DIM_X 1
 #define FLAGCX_GRID_DIM_X 1
+
+// SIMT width (same as device, for template instantiation)
+#define FLAGCX_SIMT_WIDTH 32
+#define FLAGCX_SHARED static
+
+// Host stubs for SIMT intrinsics (allow template instantiation)
+inline int flagcxLane() { return 0; }
+inline uint32_t flagcxLanemaskLt() { return 0; }
+inline uint32_t flagcxActivemask() { return 1; }
+inline void flagcxSyncwarp(uint32_t mask = 0xffffffffu) {}
+inline int flagcxPopc(uint32_t x) { return 0; }
+inline void flagcxNamedBarrierSync(int id, int nThreads) {}
 #endif // __CUDACC__
 
 // CUDA runtime macros — available from both nvcc and host compiler

--- a/flagcx/adaptor/include/device_utils.h
+++ b/flagcx/adaptor/include/device_utils.h
@@ -65,6 +65,7 @@ FLAGCX_DEVICE_INLINE_DECORATOR void flagcxNamedBarrierSync(int id,
 }
 #else
 // Host compiler (g++/clang++) on NVIDIA platform — no CUDA qualifiers
+#include <cassert>
 #define FLAGCX_HOST_DECORATOR
 #define FLAGCX_DEVICE_DECORATOR
 #define FLAGCX_GLOBAL_DECORATOR
@@ -83,12 +84,28 @@ FLAGCX_DEVICE_INLINE_DECORATOR void flagcxNamedBarrierSync(int id,
 #define FLAGCX_SHARED static
 
 // Host stubs for SIMT intrinsics (allow template instantiation)
-inline int flagcxLane() { return 0; }
-inline uint32_t flagcxLanemaskLt() { return 0; }
-inline uint32_t flagcxActivemask() { return 1; }
-inline void flagcxSyncwarp(uint32_t mask = 0xffffffffu) {}
-inline int flagcxPopc(uint32_t x) { return 0; }
-inline void flagcxNamedBarrierSync(int id, int nThreads) {}
+inline int flagcxLane() {
+  assert(false && "flagcxLane called on host");
+  return 0;
+}
+inline uint32_t flagcxLanemaskLt() {
+  assert(false && "flagcxLanemaskLt called on host");
+  return 0;
+}
+inline uint32_t flagcxActivemask() {
+  assert(false && "flagcxActivemask called on host");
+  return 1;
+}
+inline void flagcxSyncwarp(uint32_t mask = 0xffffffffu) {
+  assert(false && "flagcxSyncwarp called on host");
+}
+inline int flagcxPopc(uint32_t x) {
+  assert(false && "flagcxPopc called on host");
+  return 0;
+}
+inline void flagcxNamedBarrierSync(int id, int nThreads) {
+  assert(false && "flagcxNamedBarrierSync called on host");
+}
 #endif // __CUDACC__
 
 // CUDA runtime macros — available from both nvcc and host compiler

--- a/flagcx/adaptor/include/flagcx_device_adaptor.h
+++ b/flagcx/adaptor/include/flagcx_device_adaptor.h
@@ -102,6 +102,10 @@ struct flagcxDeviceAdaptor {
   // Event elapsed time
   flagcxResult_t (*eventElapsedTime)(float *ms, flagcxEvent_t start,
                                      flagcxEvent_t end);
+
+  // Stream memory operations (one-sided signal polling)
+  flagcxResult_t (*streamWaitValue64)(flagcxStream_t stream, void *addr,
+                                      uint64_t value, int flags);
 };
 
 // Device adaptor plugin API version (independent of CCL/Net versions)

--- a/flagcx/adaptor/include/flagcx_net_adaptor.h
+++ b/flagcx/adaptor/include/flagcx_net_adaptor.h
@@ -11,6 +11,13 @@
 extern "C" {
 #endif
 
+// MR registration flags for one-sided strong ordering
+typedef enum {
+  FLAGCX_NET_MR_FLAG_NONE = 0,
+  FLAGCX_NET_MR_FLAG_FORCE_SO =
+      (1 << 0), // Force strong ordering (disable relaxed ordering)
+} flagcxNetMrFlag_t;
+
 struct flagcxNetAdaptor {
   // Basic functions
   const char *name;
@@ -32,9 +39,10 @@ struct flagcxNetAdaptor {
 
   // Memory region functions
   flagcxResult_t (*regMr)(void *comm, void *data, size_t size, int type,
-                          void **mhandle);
+                          int mrFlags, void **mhandle);
   flagcxResult_t (*regMrDmaBuf)(void *comm, void *data, size_t size, int type,
-                                uint64_t offset, int fd, void **mhandle);
+                                uint64_t offset, int fd, int mrFlags,
+                                void **mhandle);
   flagcxResult_t (*deregMr)(void *comm, void *mhandle);
 
   // Two-sided functions
@@ -48,13 +56,15 @@ struct flagcxNetAdaptor {
   flagcxResult_t (*test)(void *request, int *done, int *sizes);
 
   // One-sided
-  flagcxResult_t (*put)(void *sendComm, uint64_t srcOff, uint64_t dstOff,
-                        size_t size, int srcRank, int dstRank, void **gHandles,
-                        void **request);
-  flagcxResult_t (*putSignal)(void *sendComm, uint64_t dstOff, int dstRank,
-                              void **gHandles, void **request);
-  flagcxResult_t (*waitValue)(void **gHandles, int rank, uint64_t offset,
-                              uint64_t expected);
+  flagcxResult_t (*iput)(void *sendComm, uint64_t srcOff, uint64_t dstOff,
+                         size_t size, int srcRank, int dstRank, void **gHandles,
+                         void **request);
+  // Data + signal combined (NCCL GIN-aligned: enables chained WRITE + ATOMIC)
+  // When size == 0, only signal ATOMIC is posted (signal-only mode)
+  flagcxResult_t (*iputSignal)(void *sendComm, uint64_t srcOff, uint64_t dstOff,
+                               size_t size, int srcRank, int dstRank,
+                               void **dataHandles, uint64_t signalOff,
+                               void **signalHandles, void **request);
 
   // Device name lookup
   flagcxResult_t (*getDevFromName)(char *name, int *dev);

--- a/flagcx/adaptor/include/ib_common.h
+++ b/flagcx/adaptor/include/ib_common.h
@@ -126,10 +126,14 @@ struct flagcxIbGlobalHandleInfo {
   uintptr_t *baseVas;
   uint32_t *rkeys;
   uint32_t *lkeys;
+  void *localMrHandle; // local rank's MR handle for iflush
+  void *localRecvComm; // local recvComm for iflush (gpuFlush QP)
 };
 
-// Global variable for one-sided operation handles
+// Global variable for one-sided data handles
 extern struct flagcxIbGlobalHandleInfo *globalOneSideHandles;
+// Global variable for one-sided signal handles (separate MR, NCCL-style)
+extern struct flagcxIbGlobalHandleInfo *globalOneSideSignalHandles;
 
 #define FLAGCX_NET_IB_REQ_UNUSED 0
 #define FLAGCX_NET_IB_REQ_SEND 1
@@ -312,6 +316,7 @@ struct flagcxIbRemSizesFifo {
 struct flagcxIbSendCommDev {
   struct flagcxIbNetCommDevBase base;
   struct ibv_mr *fifoMr;
+  struct ibv_mr *putSignalScratchpadMr;
 
   struct flagcxIbCtrlQp ctrlQp;
   struct ibv_mr *ackMr;
@@ -343,6 +348,7 @@ struct flagcxIbSendComm {
   alignas(32) struct ibv_send_wr wrs[FLAGCX_NET_IB_MAX_RECVS + 1];
   struct flagcxIbRemSizesFifo remSizesFifo;
   uint64_t fifoHead;
+  uint64_t putSignalScratchpad;
   int ar;
 
   struct flagcxIbRetransState retrans;

--- a/flagcx/adaptor/include/ib_common.h
+++ b/flagcx/adaptor/include/ib_common.h
@@ -128,6 +128,7 @@ struct flagcxIbGlobalHandleInfo {
   uint32_t *lkeys;
   void *localMrHandle; // local rank's MR handle for iflush
   void *localRecvComm; // local recvComm for iflush (gpuFlush QP)
+  void *localSendComm; // local sendComm for cleanup
 };
 
 // Global variable for one-sided data handles

--- a/flagcx/adaptor/net/ibrc_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_adaptor.cc
@@ -1681,19 +1681,6 @@ flagcxResult_t flagcxIbRegMr(void *comm, void *data, size_t size, int type,
                              int mrFlags, void **mhandle) {
   return flagcxIbRegMrDmaBuf(comm, data, size, type, 0ULL, -1, mrFlags,
                              mhandle);
-
-  assert(size > 0);
-  struct flagcxIbNetCommBase *base = (struct flagcxIbNetCommBase *)comm;
-  struct flagcxIbMrHandle *mhandleWrapper =
-      (struct flagcxIbMrHandle *)malloc(sizeof(struct flagcxIbMrHandle));
-  for (int i = 0; i < base->ndevs; i++) {
-    struct flagcxIbNetCommDevBase *devComm = flagcxIbGetNetCommDevBase(base, i);
-    unsigned int flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
-                         IBV_ACCESS_REMOTE_READ;
-    flagcxWrapIbvRegMr(&mhandleWrapper->mrs[i], devComm->pd, data, size, flags);
-  }
-  *mhandle = mhandleWrapper;
-  return flagcxSuccess;
 }
 
 flagcxResult_t flagcxIbDeregMrInternal(flagcxIbNetCommDevBase *base,
@@ -2468,8 +2455,13 @@ flagcxResult_t flagcxIbIput(void *sendComm, uint64_t srcOff, uint64_t dstOff,
   wr.num_sge = 1;
 
   sge.addr = (uintptr_t)srcPtr; // Local buffer address
-  sge.length = size;            // Size of the transfer
-  sge.lkey = lkey;              // Local key
+  sge.length = (uint32_t)size;  // ibv_sge::length is 32-bit
+  if ((size_t)sge.length != size) {
+    WARN("flagcxIbIput: transfer size %zu exceeds ibv_sge 32-bit limit", size);
+    flagcxIbFreeRequest(req);
+    return flagcxInternalError;
+  }
+  sge.lkey = lkey; // Local key
 
   struct ibv_send_wr *bad_wr;
   FLAGCXCHECK(flagcxWrapIbvPostSend(qp->qp, &wr, &bad_wr));
@@ -2489,6 +2481,10 @@ flagcxResult_t flagcxIbIputSignal(void *sendComm, uint64_t srcOff,
       (struct flagcxIbGlobalHandleInfo *)dataHandles;
   struct flagcxIbGlobalHandleInfo *signalInfo =
       (struct flagcxIbGlobalHandleInfo *)signalHandles;
+  if (signalInfo == NULL || signalInfo->baseVas == NULL) {
+    WARN("flagcxIbIputSignal: signalHandles is NULL or uninitialized");
+    return flagcxInternalError;
+  }
 
   struct flagcxIbQp *qp = &comm->base.qps[0];
   int devIndex = qp->devIndex;
@@ -2522,7 +2518,13 @@ flagcxResult_t flagcxIbIputSignal(void *sendComm, uint64_t srcOff,
     wr[0].num_sge = 1;
 
     sge[0].addr = (uintptr_t)srcPtr;
-    sge[0].length = size;
+    sge[0].length = (uint32_t)size;
+    if ((size_t)sge[0].length != size) {
+      WARN("flagcxIbIputSignal: transfer size %zu exceeds ibv_sge 32-bit limit",
+           size);
+      flagcxIbFreeRequest(req);
+      return flagcxInternalError;
+    }
     sge[0].lkey = lkey;
   }
 
@@ -2546,8 +2548,9 @@ flagcxResult_t flagcxIbIputSignal(void *sendComm, uint64_t srcOff,
 
   // Post chained (data+signal) or signal-only
   struct ibv_send_wr *bad_wr;
+  bool chainData = (size > 0 && dataInfo != NULL);
   FLAGCXCHECK(
-      flagcxWrapIbvPostSend(qp->qp, size > 0 ? &wr[0] : &wr[1], &bad_wr));
+      flagcxWrapIbvPostSend(qp->qp, chainData ? &wr[0] : &wr[1], &bad_wr));
   flagcxIbAddEvent(req, qp->devIndex, &comm->devs[qp->devIndex].base);
 
   *request = req;

--- a/flagcx/adaptor/net/ibrc_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_adaptor.cc
@@ -868,6 +868,12 @@ ib_connect_check:
                                IBV_ACCESS_REMOTE_READ));
     devInfo->fifoRkey = commDev->fifoMr->rkey;
 
+    // Prepare putSignalScratchpad (for RDMA Atomic result)
+    FLAGCXCHECK(flagcxWrapIbvRegMr(&commDev->putSignalScratchpadMr,
+                                   commDev->base.pd, &comm->putSignalScratchpad,
+                                   sizeof(comm->putSignalScratchpad),
+                                   IBV_ACCESS_LOCAL_WRITE));
+
     // RoCE support
     devInfo->linkLayer = commDev->base.gidInfo.linkLayer =
         ibDev->portAttr.link_layer;
@@ -1554,7 +1560,7 @@ flagcxResult_t flagcxIbTest(void *request, int *done, int *size);
 
 flagcxResult_t flagcxIbRegMrDmaBufInternal(flagcxIbNetCommDevBase *base,
                                            void *data, size_t size, int type,
-                                           uint64_t offset, int fd,
+                                           uint64_t offset, int fd, int mrFlags,
                                            ibv_mr **mhandle) {
   static __thread uintptr_t pageSize = 0;
   if (pageSize == 0)
@@ -1577,7 +1583,8 @@ flagcxResult_t flagcxIbRegMrDmaBufInternal(flagcxIbNetCommDevBase *base,
       struct ibv_mr *mr;
       unsigned int flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
                            IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
-      if (flagcxIbRelaxedOrderingEnabled)
+      if (flagcxIbRelaxedOrderingEnabled &&
+          !(mrFlags & FLAGCX_NET_MR_FLAG_FORCE_SO))
         flags |= IBV_ACCESS_RELAXED_ORDERING;
       if (fd != -1) {
         /* DMA-BUF support */
@@ -1590,7 +1597,8 @@ flagcxResult_t flagcxIbRegMrDmaBufInternal(flagcxIbNetCommDevBase *base,
         if (deviceAdaptor->gdrPtrMmap && deviceAdaptor->gdrPtrMunmap) {
           deviceAdaptor->gdrPtrMmap(&cpuptr, (void *)addr, pages * pageSize);
         }
-        if (flagcxIbRelaxedOrderingEnabled) {
+        if (flagcxIbRelaxedOrderingEnabled &&
+            !(mrFlags & FLAGCX_NET_MR_FLAG_FORCE_SO)) {
           // Use IBVERBS_1.8 API - needed for IBV_ACCESS_RELAXED_ORDERING
           // support
           FLAGCXCHECKGOTO(
@@ -1652,7 +1660,7 @@ flagcxIbGetNetCommDevBase(flagcxIbNetCommBase *base, int devIndex) {
 /* DMA-BUF support */
 flagcxResult_t flagcxIbRegMrDmaBuf(void *comm, void *data, size_t size,
                                    int type, uint64_t offset, int fd,
-                                   void **mhandle) {
+                                   int mrFlags, void **mhandle) {
   assert(size > 0);
   struct flagcxIbNetCommBase *base = (struct flagcxIbNetCommBase *)comm;
   struct flagcxIbMrHandle *mhandleWrapper =
@@ -1662,15 +1670,17 @@ flagcxResult_t flagcxIbRegMrDmaBuf(void *comm, void *data, size_t size,
     // netComms
     struct flagcxIbNetCommDevBase *devComm = flagcxIbGetNetCommDevBase(base, i);
     FLAGCXCHECK(flagcxIbRegMrDmaBufInternal(devComm, data, size, type, offset,
-                                            fd, mhandleWrapper->mrs + i));
+                                            fd, mrFlags,
+                                            mhandleWrapper->mrs + i));
   }
   *mhandle = (void *)mhandleWrapper;
   return flagcxSuccess;
 }
 
 flagcxResult_t flagcxIbRegMr(void *comm, void *data, size_t size, int type,
-                             void **mhandle) {
-  return flagcxIbRegMrDmaBuf(comm, data, size, type, 0ULL, -1, mhandle);
+                             int mrFlags, void **mhandle) {
+  return flagcxIbRegMrDmaBuf(comm, data, size, type, 0ULL, -1, mrFlags,
+                             mhandle);
 
   assert(size > 0);
   struct flagcxIbNetCommBase *base = (struct flagcxIbNetCommBase *)comm;
@@ -2239,6 +2249,8 @@ flagcxResult_t flagcxIbCloseSend(void *sendComm) {
       struct flagcxIbSendCommDev *commDev = comm->devs + i;
       if (commDev->fifoMr != NULL)
         FLAGCXCHECK(flagcxWrapIbvDeregMr(commDev->fifoMr));
+      if (commDev->putSignalScratchpadMr != NULL)
+        FLAGCXCHECK(flagcxWrapIbvDeregMr(commDev->putSignalScratchpadMr));
       if (comm->remSizesFifo.mrs[i] != NULL)
         FLAGCXCHECK(flagcxWrapIbvDeregMr(comm->remSizesFifo.mrs[i]));
       FLAGCXCHECK(flagcxIbDestroyBase(&commDev->base));
@@ -2421,9 +2433,9 @@ flagcxResult_t flagcxIbGetProperties(int dev, void *props) {
   properties->netDeviceVersion = FLAGCX_NET_DEVICE_INVALID_VERSION;
   return flagcxSuccess;
 }
-flagcxResult_t flagcxIbPut(void *sendComm, uint64_t srcOff, uint64_t dstOff,
-                           size_t size, int srcRank, int dstRank,
-                           void **gHandles, void **request) {
+flagcxResult_t flagcxIbIput(void *sendComm, uint64_t srcOff, uint64_t dstOff,
+                            size_t size, int srcRank, int dstRank,
+                            void **gHandles, void **request) {
   struct flagcxIbSendComm *comm = (struct flagcxIbSendComm *)sendComm;
   struct flagcxIbGlobalHandleInfo *info =
       (struct flagcxIbGlobalHandleInfo *)gHandles;
@@ -2467,16 +2479,19 @@ flagcxResult_t flagcxIbPut(void *sendComm, uint64_t srcOff, uint64_t dstOff,
   return flagcxSuccess;
 }
 
-flagcxResult_t flagcxIbPutSignal(void *sendComm, uint64_t dstOff, int dstRank,
-                                 void **gHandles, void **request) {
+flagcxResult_t flagcxIbIputSignal(void *sendComm, uint64_t srcOff,
+                                  uint64_t dstOff, size_t size, int srcRank,
+                                  int dstRank, void **dataHandles,
+                                  uint64_t signalOff, void **signalHandles,
+                                  void **request) {
   struct flagcxIbSendComm *comm = (struct flagcxIbSendComm *)sendComm;
-  struct flagcxIbGlobalHandleInfo *info =
-      (struct flagcxIbGlobalHandleInfo *)gHandles;
+  struct flagcxIbGlobalHandleInfo *dataInfo =
+      (struct flagcxIbGlobalHandleInfo *)dataHandles;
+  struct flagcxIbGlobalHandleInfo *signalInfo =
+      (struct flagcxIbGlobalHandleInfo *)signalHandles;
 
   struct flagcxIbQp *qp = &comm->base.qps[0];
   int devIndex = qp->devIndex;
-  void *dstPtr = (void *)(info->baseVas[dstRank] + dstOff);
-  int rkey = info->rkeys[dstRank];
   struct flagcxIbRequest *req;
   FLAGCXCHECK(flagcxIbGetRequest(&comm->base, &req));
   req->type = FLAGCX_NET_IB_REQ_IPUT;
@@ -2485,44 +2500,60 @@ flagcxResult_t flagcxIbPutSignal(void *sendComm, uint64_t dstOff, int dstRank,
     req->devBases[i] = &comm->devs[i].base;
   }
 
-  struct ibv_send_wr wr;
+  struct ibv_send_wr wr[2];
   memset(&wr, 0, sizeof(wr));
-  struct ibv_sge sge;
+  struct ibv_sge sge[2];
   memset(&sge, 0, sizeof(sge));
-  wr.opcode = IBV_WR_ATOMIC_FETCH_AND_ADD;
-  wr.send_flags = IBV_SEND_SIGNALED;
-  wr.wr_id = req - comm->base.reqs;
-  wr.next = NULL;
-  wr.wr.atomic.remote_addr = (uint64_t)dstPtr;
-  wr.wr.atomic.compare_add = 1;
-  wr.wr.atomic.rkey = rkey;
 
-  wr.sg_list = &sge;
-  wr.num_sge = 1;
+  // wr[0]: RDMA WRITE (data) — no CQE, chained to signal
+  if (size > 0 && dataInfo != NULL) {
+    void *srcPtr = (void *)(dataInfo->baseVas[srcRank] + srcOff);
+    void *dstPtr = (void *)(dataInfo->baseVas[dstRank] + dstOff);
+    uint32_t lkey = dataInfo->lkeys[srcRank];
+    uint32_t rkey = dataInfo->rkeys[dstRank];
 
-  sge.addr = (uintptr_t)&comm->fifo;
-  sge.length = sizeof(comm->fifo);
-  sge.lkey = comm->devs[devIndex].fifoMr->lkey;
+    wr[0].opcode = IBV_WR_RDMA_WRITE;
+    wr[0].send_flags = 0; // No CQE — only signal gets CQE
+    wr[0].wr_id = req - comm->base.reqs;
+    wr[0].next = &wr[1]; // Chain to signal
+    wr[0].wr.rdma.remote_addr = (uint64_t)dstPtr;
+    wr[0].wr.rdma.rkey = rkey;
+    wr[0].sg_list = &sge[0];
+    wr[0].num_sge = 1;
+
+    sge[0].addr = (uintptr_t)srcPtr;
+    sge[0].length = size;
+    sge[0].lkey = lkey;
+  }
+
+  // wr[1]: ATOMIC FETCH_AND_ADD (signal) — IBV_SEND_SIGNALED
+  void *signalPtr = (void *)(signalInfo->baseVas[dstRank] + signalOff);
+  uint32_t signalRkey = signalInfo->rkeys[dstRank];
+
+  wr[1].opcode = IBV_WR_ATOMIC_FETCH_AND_ADD;
+  wr[1].send_flags = IBV_SEND_SIGNALED;
+  wr[1].wr_id = req - comm->base.reqs;
+  wr[1].next = NULL;
+  wr[1].wr.atomic.remote_addr = (uint64_t)signalPtr;
+  wr[1].wr.atomic.compare_add = 1;
+  wr[1].wr.atomic.rkey = signalRkey;
+  wr[1].sg_list = &sge[1];
+  wr[1].num_sge = 1;
+
+  sge[1].addr = (uintptr_t)&comm->putSignalScratchpad;
+  sge[1].length = sizeof(comm->putSignalScratchpad);
+  sge[1].lkey = comm->devs[devIndex].putSignalScratchpadMr->lkey;
+
+  // Post chained (data+signal) or signal-only
   struct ibv_send_wr *bad_wr;
-  FLAGCXCHECK(flagcxWrapIbvPostSend(qp->qp, &wr, &bad_wr));
+  FLAGCXCHECK(
+      flagcxWrapIbvPostSend(qp->qp, size > 0 ? &wr[0] : &wr[1], &bad_wr));
   flagcxIbAddEvent(req, qp->devIndex, &comm->devs[qp->devIndex].base);
 
   *request = req;
   return flagcxSuccess;
 }
 
-flagcxResult_t flagcxIbWaitValue(void **gHandles, int rank, uint64_t offset,
-                                 uint64_t expected) {
-  struct flagcxIbGlobalHandleInfo *info =
-      (struct flagcxIbGlobalHandleInfo *)gHandles;
-  volatile uint64_t *addr = (volatile uint64_t *)(info->baseVas[rank] + offset);
-
-  while (__atomic_load_n(addr, __ATOMIC_ACQUIRE) != expected) {
-    sched_yield();
-  }
-
-  return flagcxSuccess;
-}
 // Adapter wrapper functions
 
 struct flagcxNetAdaptor flagcxNetIb = {
@@ -2543,7 +2574,7 @@ struct flagcxNetAdaptor flagcxNetIb = {
     flagcxIbIsend, flagcxIbIrecv, flagcxIbIflush, flagcxIbTest,
 
     // One-sided functions
-    flagcxIbPut, flagcxIbPutSignal, flagcxIbWaitValue,
+    flagcxIbIput, flagcxIbIputSignal,
 
     // Device name lookup
     flagcxIbGetDevFromName};

--- a/flagcx/adaptor/net/ibuc_adaptor.cc
+++ b/flagcx/adaptor/net/ibuc_adaptor.cc
@@ -2247,16 +2247,6 @@ flagcxResult_t flagcxIbucGetProperties(int dev, void *props) {
 }
 
 // One-sided stubs (not supported by IBUC adaptor)
-static flagcxResult_t flagcxIbucIput(void *, uint64_t, uint64_t, size_t, int,
-                                     int, void **, void **) {
-  return flagcxNotSupported;
-}
-static flagcxResult_t flagcxIbucIputSignal(void *, uint64_t, uint64_t, size_t,
-                                           int, int, void **, uint64_t, void **,
-                                           void **) {
-  return flagcxNotSupported;
-}
-
 // Adapter wrapper functions
 
 struct flagcxNetAdaptor flagcxNetIbuc = {
@@ -2277,7 +2267,8 @@ struct flagcxNetAdaptor flagcxNetIbuc = {
     flagcxIbucIsend, flagcxIbucIrecv, flagcxIbucIflush, flagcxIbucTest,
 
     // One-sided functions
-    flagcxIbucIput, flagcxIbucIputSignal,
+    NULL, // iput - not supported on IBUC
+    NULL, // iputSignal - not supported on IBUC
 
     // Device name lookup
     flagcxIbucGetDevFromName};

--- a/flagcx/adaptor/net/ibuc_adaptor.cc
+++ b/flagcx/adaptor/net/ibuc_adaptor.cc
@@ -1491,7 +1491,7 @@ flagcxResult_t flagcxIbucGetRequest(struct flagcxIbNetCommBase *base,
 flagcxResult_t flagcxIbucRegMrDmaBufInternal(flagcxIbNetCommDevBase *base,
                                              void *data, size_t size, int type,
                                              uint64_t offset, int fd,
-                                             ibv_mr **mhandle) {
+                                             int mrFlags, ibv_mr **mhandle) {
   static __thread uintptr_t pageSize = 0;
   if (pageSize == 0)
     pageSize = sysconf(_SC_PAGESIZE);
@@ -1512,7 +1512,8 @@ flagcxResult_t flagcxIbucRegMrDmaBufInternal(flagcxIbNetCommDevBase *base,
       struct ibv_mr *mr;
       unsigned int flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
                            IBV_ACCESS_REMOTE_READ;
-      if (flagcxIbRelaxedOrderingEnabled)
+      if (flagcxIbRelaxedOrderingEnabled &&
+          !(mrFlags & FLAGCX_NET_MR_FLAG_FORCE_SO))
         flags |= IBV_ACCESS_RELAXED_ORDERING;
       if (fd != -1) {
         /* DMA-BUF support */
@@ -1525,7 +1526,8 @@ flagcxResult_t flagcxIbucRegMrDmaBufInternal(flagcxIbNetCommDevBase *base,
         if (deviceAdaptor->gdrPtrMmap && deviceAdaptor->gdrPtrMunmap) {
           deviceAdaptor->gdrPtrMmap(&cpuptr, (void *)addr, pages * pageSize);
         }
-        if (flagcxIbRelaxedOrderingEnabled) {
+        if (flagcxIbRelaxedOrderingEnabled &&
+            !(mrFlags & FLAGCX_NET_MR_FLAG_FORCE_SO)) {
           // Use IBVERBS_1.8 API - needed for IBV_ACCESS_RELAXED_ORDERING
           // support
           FLAGCXCHECKGOTO(
@@ -1587,7 +1589,7 @@ flagcxIbucGetNetCommDevBase(flagcxIbNetCommBase *base, int devIndex) {
 /* DMA-BUF support */
 flagcxResult_t flagcxIbucRegMrDmaBuf(void *comm, void *data, size_t size,
                                      int type, uint64_t offset, int fd,
-                                     void **mhandle) {
+                                     int mrFlags, void **mhandle) {
   assert(size > 0);
   struct flagcxIbNetCommBase *base = (struct flagcxIbNetCommBase *)comm;
   struct flagcxIbMrHandle *mhandleWrapper =
@@ -1596,15 +1598,17 @@ flagcxResult_t flagcxIbucRegMrDmaBuf(void *comm, void *data, size_t size,
     struct flagcxIbNetCommDevBase *devComm =
         flagcxIbucGetNetCommDevBase(base, i);
     FLAGCXCHECK(flagcxIbucRegMrDmaBufInternal(devComm, data, size, type, offset,
-                                              fd, mhandleWrapper->mrs + i));
+                                              fd, mrFlags,
+                                              mhandleWrapper->mrs + i));
   }
   *mhandle = (void *)mhandleWrapper;
   return flagcxSuccess;
 }
 
 flagcxResult_t flagcxIbucRegMr(void *comm, void *data, size_t size, int type,
-                               void **mhandle) {
-  return flagcxIbucRegMrDmaBuf(comm, data, size, type, 0ULL, -1, mhandle);
+                               int mrFlags, void **mhandle) {
+  return flagcxIbucRegMrDmaBuf(comm, data, size, type, 0ULL, -1, mrFlags,
+                               mhandle);
 }
 
 flagcxResult_t flagcxIbucDeregMrInternal(flagcxIbNetCommDevBase *base,
@@ -2242,6 +2246,17 @@ flagcxResult_t flagcxIbucGetProperties(int dev, void *props) {
   return flagcxSuccess;
 }
 
+// One-sided stubs (not supported by IBUC adaptor)
+static flagcxResult_t flagcxIbucIput(void *, uint64_t, uint64_t, size_t, int,
+                                     int, void **, void **) {
+  return flagcxNotSupported;
+}
+static flagcxResult_t flagcxIbucIputSignal(void *, uint64_t, uint64_t, size_t,
+                                           int, int, void **, uint64_t, void **,
+                                           void **) {
+  return flagcxNotSupported;
+}
+
 // Adapter wrapper functions
 
 struct flagcxNetAdaptor flagcxNetIbuc = {
@@ -2262,7 +2277,7 @@ struct flagcxNetAdaptor flagcxNetIbuc = {
     flagcxIbucIsend, flagcxIbucIrecv, flagcxIbucIflush, flagcxIbucTest,
 
     // One-sided functions
-    NULL, NULL, NULL, // put, putSignal, waitValue
+    flagcxIbucIput, flagcxIbucIputSignal,
 
     // Device name lookup
     flagcxIbucGetDevFromName};

--- a/flagcx/adaptor/net/socket_adaptor.cc
+++ b/flagcx/adaptor/net/socket_adaptor.cc
@@ -595,7 +595,7 @@ flagcxResult_t flagcxNetSocketTest(void *request, int *done, int *size) {
 }
 
 flagcxResult_t flagcxNetSocketRegMr(void *comm, void *data, size_t size,
-                                    int type, void **mhandle) {
+                                    int type, int mrFlags, void **mhandle) {
   return (type != FLAGCX_PTR_HOST) ? flagcxInternalError : flagcxSuccess;
 }
 
@@ -673,16 +673,30 @@ flagcxResult_t flagcxNetSocketClose(void *opaqueComm) {
   return flagcxSuccess;
 }
 
+static flagcxResult_t flagcxNetSocketIput(void *, uint64_t, uint64_t, size_t,
+                                          int, int, void **, void **) {
+  return flagcxNotSupported;
+}
+static flagcxResult_t flagcxNetSocketIputSignal(void *, uint64_t, uint64_t,
+                                                size_t, int, int, void **,
+                                                uint64_t, void **, void **) {
+  return flagcxNotSupported;
+}
+
 flagcxNetAdaptor flagcxNetSocket = {
     // Basic functions
-    "Socket", flagcxNetSocketInit, flagcxNetSocketDevices,
+    "Socket",
+    flagcxNetSocketInit,
+    flagcxNetSocketDevices,
     flagcxNetSocketGetProperties,
     NULL, // reduceSupport - not implemented
     NULL, // getDeviceMr - not implemented
     NULL, // irecvConsumed - not implemented
 
     // Setup functions
-    flagcxNetSocketListen, flagcxNetSocketConnect, flagcxNetSocketAccept,
+    flagcxNetSocketListen,
+    flagcxNetSocketConnect,
+    flagcxNetSocketAccept,
     flagcxNetSocketClose, // closeSend
     flagcxNetSocketClose, // closeRecv (same as closeSend for socket)
     flagcxNetSocketCloseListen,
@@ -693,11 +707,14 @@ flagcxNetAdaptor flagcxNetSocket = {
     flagcxNetSocketDeregMr,
 
     // Two-sided functions
-    flagcxNetSocketIsend, flagcxNetSocketIrecv, flagcxNetSocketIflush,
+    flagcxNetSocketIsend,
+    flagcxNetSocketIrecv,
+    flagcxNetSocketIflush,
     flagcxNetSocketTest,
 
     // One-sided functions
-    NULL, NULL, NULL, // put, putSignal, waitValue
+    flagcxNetSocketIput,
+    flagcxNetSocketIputSignal,
 
     // Device name lookup
     NULL, // getDevFromName

--- a/flagcx/adaptor/net/socket_adaptor.cc
+++ b/flagcx/adaptor/net/socket_adaptor.cc
@@ -596,6 +596,7 @@ flagcxResult_t flagcxNetSocketTest(void *request, int *done, int *size) {
 
 flagcxResult_t flagcxNetSocketRegMr(void *comm, void *data, size_t size,
                                     int type, int mrFlags, void **mhandle) {
+  (void)mrFlags;
   return (type != FLAGCX_PTR_HOST) ? flagcxInternalError : flagcxSuccess;
 }
 
@@ -673,16 +674,6 @@ flagcxResult_t flagcxNetSocketClose(void *opaqueComm) {
   return flagcxSuccess;
 }
 
-static flagcxResult_t flagcxNetSocketIput(void *, uint64_t, uint64_t, size_t,
-                                          int, int, void **, void **) {
-  return flagcxNotSupported;
-}
-static flagcxResult_t flagcxNetSocketIputSignal(void *, uint64_t, uint64_t,
-                                                size_t, int, int, void **,
-                                                uint64_t, void **, void **) {
-  return flagcxNotSupported;
-}
-
 flagcxNetAdaptor flagcxNetSocket = {
     // Basic functions
     "Socket",
@@ -713,8 +704,8 @@ flagcxNetAdaptor flagcxNetSocket = {
     flagcxNetSocketTest,
 
     // One-sided functions
-    flagcxNetSocketIput,
-    flagcxNetSocketIputSignal,
+    NULL, // iput - not supported on socket
+    NULL, // iputSignal - not supported on socket
 
     // Device name lookup
     NULL, // getDevFromName

--- a/flagcx/adaptor/net/socket_adaptor.cc
+++ b/flagcx/adaptor/net/socket_adaptor.cc
@@ -676,18 +676,14 @@ flagcxResult_t flagcxNetSocketClose(void *opaqueComm) {
 
 flagcxNetAdaptor flagcxNetSocket = {
     // Basic functions
-    "Socket",
-    flagcxNetSocketInit,
-    flagcxNetSocketDevices,
+    "Socket", flagcxNetSocketInit, flagcxNetSocketDevices,
     flagcxNetSocketGetProperties,
     NULL, // reduceSupport - not implemented
     NULL, // getDeviceMr - not implemented
     NULL, // irecvConsumed - not implemented
 
     // Setup functions
-    flagcxNetSocketListen,
-    flagcxNetSocketConnect,
-    flagcxNetSocketAccept,
+    flagcxNetSocketListen, flagcxNetSocketConnect, flagcxNetSocketAccept,
     flagcxNetSocketClose, // closeSend
     flagcxNetSocketClose, // closeRecv (same as closeSend for socket)
     flagcxNetSocketCloseListen,
@@ -698,9 +694,7 @@ flagcxNetAdaptor flagcxNetSocket = {
     flagcxNetSocketDeregMr,
 
     // Two-sided functions
-    flagcxNetSocketIsend,
-    flagcxNetSocketIrecv,
-    flagcxNetSocketIflush,
+    flagcxNetSocketIsend, flagcxNetSocketIrecv, flagcxNetSocketIflush,
     flagcxNetSocketTest,
 
     // One-sided functions

--- a/flagcx/adaptor/net/ucx_adaptor.cc
+++ b/flagcx/adaptor/net/ucx_adaptor.cc
@@ -1026,6 +1026,7 @@ flagcxUcxAcceptCheck:
 #define REG_ALIGN (4096)
 flagcxResult_t flagcxUcxRegMr(void *comm, void *data, size_t size, int type,
                               int mrFlags, void **mhandle) {
+  (void)mrFlags;
   flagcxUcxCtx_t *ctx = (flagcxUcxCtx_t *)comm;
   uint64_t addr = (uint64_t)data;
   ucp_mem_map_params_t mmap_params;
@@ -1483,16 +1484,6 @@ flagcxResult_t flagcxUcxGetDevFromName(char *name, int *dev) {
   }
   return flagcxSystemError;
 }
-// One-sided stubs (not supported by UCX adaptor)
-static flagcxResult_t flagcxUcxIput(void *, uint64_t, uint64_t, size_t, int,
-                                    int, void **, void **) {
-  return flagcxNotSupported;
-}
-static flagcxResult_t flagcxUcxIputSignal(void *, uint64_t, uint64_t, size_t,
-                                          int, int, void **, uint64_t, void **,
-                                          void **) {
-  return flagcxNotSupported;
-}
 
 // UCX network adaptor structure
 struct flagcxNetAdaptor flagcxNetUcx = {
@@ -1522,7 +1513,8 @@ struct flagcxNetAdaptor flagcxNetUcx = {
     flagcxUcxTest,   // test
 
     // One-sided functions
-    flagcxUcxIput, flagcxUcxIputSignal,
+    NULL, // iput - not supported on UCX
+    NULL, // iputSignal - not supported on UCX
 
     // Device name lookup
     flagcxUcxGetDevFromName // getDevFromName

--- a/flagcx/adaptor/net/ucx_adaptor.cc
+++ b/flagcx/adaptor/net/ucx_adaptor.cc
@@ -38,9 +38,7 @@
 // Additional global variables
 static pthread_mutex_t flagcx_p2p_lock = PTHREAD_MUTEX_INITIALIZER;
 static int flagcxIbGdrModuleLoaded = 0;
-static struct {
-  pthread_once_t once;
-} onces[MAX_IB_DEVS];
+static struct { pthread_once_t once; } onces[MAX_IB_DEVS];
 
 flagcxResult_t flagcxIbMakeVDeviceInternal(int *d,
                                            flagcxNetVDeviceProps_t *props,

--- a/flagcx/adaptor/net/ucx_adaptor.cc
+++ b/flagcx/adaptor/net/ucx_adaptor.cc
@@ -38,7 +38,9 @@
 // Additional global variables
 static pthread_mutex_t flagcx_p2p_lock = PTHREAD_MUTEX_INITIALIZER;
 static int flagcxIbGdrModuleLoaded = 0;
-static struct { pthread_once_t once; } onces[MAX_IB_DEVS];
+static struct {
+  pthread_once_t once;
+} onces[MAX_IB_DEVS];
 
 flagcxResult_t flagcxIbMakeVDeviceInternal(int *d,
                                            flagcxNetVDeviceProps_t *props,
@@ -1023,7 +1025,7 @@ flagcxUcxAcceptCheck:
 
 #define REG_ALIGN (4096)
 flagcxResult_t flagcxUcxRegMr(void *comm, void *data, size_t size, int type,
-                              void **mhandle) {
+                              int mrFlags, void **mhandle) {
   flagcxUcxCtx_t *ctx = (flagcxUcxCtx_t *)comm;
   uint64_t addr = (uint64_t)data;
   ucp_mem_map_params_t mmap_params;
@@ -1074,8 +1076,8 @@ flagcxResult_t flagcxUcxDeregMr(void *comm, void *mhandle) {
 
 flagcxResult_t flagcxUcxRegMrDmaBuf(void *comm, void *data, size_t size,
                                     int type, uint64_t offset, int fd,
-                                    void **mhandle) {
-  return flagcxUcxRegMr(comm, data, size, type, mhandle);
+                                    int mrFlags, void **mhandle) {
+  return flagcxUcxRegMr(comm, data, size, type, mrFlags, mhandle);
 }
 
 static flagcxUcxRequest_t *flagcxUcxRequestGet(flagcxUcxComm_t *comm) {
@@ -1481,6 +1483,17 @@ flagcxResult_t flagcxUcxGetDevFromName(char *name, int *dev) {
   }
   return flagcxSystemError;
 }
+// One-sided stubs (not supported by UCX adaptor)
+static flagcxResult_t flagcxUcxIput(void *, uint64_t, uint64_t, size_t, int,
+                                    int, void **, void **) {
+  return flagcxNotSupported;
+}
+static flagcxResult_t flagcxUcxIputSignal(void *, uint64_t, uint64_t, size_t,
+                                          int, int, void **, uint64_t, void **,
+                                          void **) {
+  return flagcxNotSupported;
+}
+
 // UCX network adaptor structure
 struct flagcxNetAdaptor flagcxNetUcx = {
     // Basic functions
@@ -1509,7 +1522,7 @@ struct flagcxNetAdaptor flagcxNetUcx = {
     flagcxUcxTest,   // test
 
     // One-sided functions
-    NULL, NULL, NULL, // put, putSignal, waitValue
+    flagcxUcxIput, flagcxUcxIputSignal,
 
     // Device name lookup
     flagcxUcxGetDevFromName // getDevFromName

--- a/flagcx/core/flagcx_hetero.cc
+++ b/flagcx/core/flagcx_hetero.cc
@@ -1,9 +1,12 @@
 #include "flagcx_hetero.h"
+#include "adaptor.h"
 #include "group.h"
 #include "ib_common.h"
 #include "net.h"
 #include "transport.h"
 #include "type.h"
+
+#include <sched.h>
 
 flagcxResult_t flagcxHeteroSend(const void *sendbuff, size_t count,
                                 flagcxDataType_t datatype, int peer,
@@ -70,8 +73,8 @@ flagcxResult_t flagcxHeteroRecv(void *recvbuff, size_t count,
 flagcxResult_t flagcxHeteroPut(flagcxHeteroComm_t comm, int peer,
                                size_t srcOffset, size_t dstOffset,
                                size_t size) {
-  // Check if netAdaptor->put is available
-  if (comm->netAdaptor != NULL && comm->netAdaptor->put != NULL) {
+  // Check if netAdaptor->iput is available
+  if (comm->netAdaptor != NULL && comm->netAdaptor->iput != NULL) {
     int channelId = 0;
     int connIndex = 0;
     // Get sendNetResources from connector
@@ -93,17 +96,25 @@ flagcxResult_t flagcxHeteroPut(flagcxHeteroComm_t comm, int peer,
     uint64_t dstOff = dstOffset;
     void **gHandles = (void **)globalOneSideHandles;
     void *request = NULL;
-    FLAGCXCHECK(comm->netAdaptor->put(sendComm, srcOff, dstOff, size, srcRank,
-                                      dstRank, gHandles, &request));
+    FLAGCXCHECK(comm->netAdaptor->iput(sendComm, srcOff, dstOff, size, srcRank,
+                                       dstRank, gHandles, &request));
+    // Poll completion to free the IB request
+    if (request != NULL) {
+      int done = 0;
+      while (!done) {
+        FLAGCXCHECK(comm->netAdaptor->test(request, &done, NULL));
+      }
+    }
     return flagcxSuccess;
   }
   return flagcxNotSupported;
 }
 
 flagcxResult_t flagcxHeteroPutSignal(flagcxHeteroComm_t comm, int peer,
-                                     size_t dstOffset) {
-  // Check if netAdaptor->putSignal is available
-  if (comm->netAdaptor != NULL && comm->netAdaptor->putSignal != NULL) {
+                                     size_t srcOffset, size_t dstOffset,
+                                     size_t size, size_t signalOffset) {
+  // Check if netAdaptor->iputSignal is available
+  if (comm->netAdaptor != NULL && comm->netAdaptor->iputSignal != NULL) {
     int channelId = 0;
     int connIndex = 0;
     // Get sendNetResources from connector
@@ -118,14 +129,99 @@ flagcxResult_t flagcxHeteroPutSignal(flagcxHeteroComm_t comm, int peer,
         (struct sendNetResources *)
             conn->proxyConn.connection->transportResources;
     void *sendComm = resources->netSendComm;
+    int srcRank = comm->rank;
     int dstRank = peer;
 
-    uint64_t dstOff = dstOffset;
-    void **gHandles = (void **)globalOneSideHandles;
+    void **dataHandles = (void **)globalOneSideHandles;
+    void **signalHandles = (void **)globalOneSideSignalHandles;
     void *request = NULL;
-    FLAGCXCHECK(comm->netAdaptor->putSignal(sendComm, dstOff, dstRank, gHandles,
-                                            &request));
+    FLAGCXCHECK(comm->netAdaptor->iputSignal(
+        sendComm, (uint64_t)srcOffset, (uint64_t)dstOffset, size, srcRank,
+        dstRank, dataHandles, (uint64_t)signalOffset, signalHandles, &request));
+    // Poll completion (single CQE for chained WRITE + ATOMIC)
+    if (request != NULL) {
+      int done = 0;
+      while (!done) {
+        FLAGCXCHECK(comm->netAdaptor->test(request, &done, NULL));
+      }
+    }
     return flagcxSuccess;
   }
   return flagcxNotSupported;
+}
+
+flagcxResult_t flagcxWaitValueLocal(void **gHandles, int rank, uint64_t offset,
+                                    uint64_t expected) {
+  struct flagcxIbGlobalHandleInfo *info =
+      (struct flagcxIbGlobalHandleInfo *)gHandles;
+  if (info == NULL || info->baseVas == NULL)
+    return flagcxNotSupported;
+  volatile uint64_t *addr = (volatile uint64_t *)(info->baseVas[rank] + offset);
+
+  while (__atomic_load_n(addr, __ATOMIC_ACQUIRE) < expected) {
+    sched_yield();
+  }
+
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxHeteroFlush(flagcxHeteroComm_t comm, void *gpuAddr,
+                                 size_t size, void *gHandleInfo) {
+  struct flagcxIbGlobalHandleInfo *info =
+      (struct flagcxIbGlobalHandleInfo *)gHandleInfo;
+  if (info == NULL || info->localRecvComm == NULL ||
+      info->localMrHandle == NULL)
+    return flagcxNotSupported;
+  if (comm->netAdaptor == NULL || comm->netAdaptor->iflush == NULL)
+    return flagcxNotSupported;
+
+  void *data_arr[1] = {gpuAddr};
+  int sizes_arr[1] = {(int)size};
+  void *mh_arr[1] = {info->localMrHandle};
+  void *request = NULL;
+  FLAGCXCHECK(comm->netAdaptor->iflush(info->localRecvComm, 1, data_arr,
+                                       sizes_arr, mh_arr, &request));
+  if (request != NULL) {
+    int done = 0;
+    while (!done) {
+      FLAGCXCHECK(comm->netAdaptor->test(request, &done, NULL));
+    }
+  }
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxHeteroWaitSignal(flagcxHeteroComm_t comm, int peer,
+                                      size_t signalOffset, uint64_t expected,
+                                      flagcxStream_t stream) {
+  struct flagcxIbGlobalHandleInfo *info =
+      (struct flagcxIbGlobalHandleInfo *)globalOneSideSignalHandles;
+  if (info == NULL || info->baseVas == NULL)
+    return flagcxNotSupported;
+
+  int myRank = comm->rank;
+  void *signalAddr = (void *)(info->baseVas[myRank] + signalOffset);
+
+  // Try device-side wait (streamWaitValue64) for GPU signal buffer
+  if (stream != NULL) {
+    flagcxResult_t res =
+        deviceAdaptor->streamWaitValue64(stream, signalAddr, expected, 0);
+    if (res == flagcxSuccess)
+      return flagcxSuccess;
+    // Fall through to host poll if flagcxNotSupported or error
+  }
+
+  // Host fallback: volatile poll
+  volatile uint64_t *addr = (volatile uint64_t *)signalAddr;
+  while (__atomic_load_n(addr, __ATOMIC_ACQUIRE) < expected) {
+    sched_yield();
+  }
+
+  // Flush data buffer after host-side signal confirmation
+  struct flagcxIbGlobalHandleInfo *dataInfo =
+      (struct flagcxIbGlobalHandleInfo *)globalOneSideHandles;
+  if (dataInfo != NULL) {
+    flagcxHeteroFlush(comm, (void *)dataInfo->baseVas[myRank], 1,
+                      (void *)dataInfo);
+  }
+  return flagcxSuccess;
 }

--- a/flagcx/core/flagcx_hetero.cc
+++ b/flagcx/core/flagcx_hetero.cc
@@ -6,6 +6,7 @@
 #include "transport.h"
 #include "type.h"
 
+#include <climits>
 #include <sched.h>
 
 flagcxResult_t flagcxHeteroSend(const void *sendbuff, size_t count,
@@ -173,6 +174,10 @@ flagcxResult_t flagcxHeteroFlush(flagcxHeteroComm_t comm, void *gpuAddr,
   if (comm->netAdaptor == NULL || comm->netAdaptor->iflush == NULL)
     return flagcxNotSupported;
 
+  if (size > (size_t)INT_MAX) {
+    WARN("flagcxHeteroFlush: size %zu exceeds int limit", size);
+    return flagcxInternalError;
+  }
   void *data_arr[1] = {gpuAddr};
   int sizes_arr[1] = {(int)size};
   void *mh_arr[1] = {info->localMrHandle};

--- a/flagcx/core/flagcx_hetero.cc
+++ b/flagcx/core/flagcx_hetero.cc
@@ -95,6 +95,10 @@ flagcxResult_t flagcxHeteroPut(flagcxHeteroComm_t comm, int peer,
     uint64_t srcOff = srcOffset;
     uint64_t dstOff = dstOffset;
     void **gHandles = (void **)globalOneSideHandles;
+    if (gHandles == NULL) {
+      WARN("flagcxHeteroPut: globalOneSideHandles not initialized");
+      return flagcxInternalError;
+    }
     void *request = NULL;
     FLAGCXCHECK(comm->netAdaptor->iput(sendComm, srcOff, dstOff, size, srcRank,
                                        dstRank, gHandles, &request));
@@ -134,6 +138,15 @@ flagcxResult_t flagcxHeteroPutSignal(flagcxHeteroComm_t comm, int peer,
 
     void **dataHandles = (void **)globalOneSideHandles;
     void **signalHandles = (void **)globalOneSideSignalHandles;
+    if (signalHandles == NULL) {
+      WARN("flagcxHeteroPutSignal: globalOneSideSignalHandles not initialized");
+      return flagcxInternalError;
+    }
+    if (size > 0 && dataHandles == NULL) {
+      WARN("flagcxHeteroPutSignal: globalOneSideHandles not initialized for "
+           "data transfer");
+      return flagcxInternalError;
+    }
     void *request = NULL;
     FLAGCXCHECK(comm->netAdaptor->iputSignal(
         sendComm, (uint64_t)srcOffset, (uint64_t)dstOffset, size, srcRank,
@@ -148,21 +161,6 @@ flagcxResult_t flagcxHeteroPutSignal(flagcxHeteroComm_t comm, int peer,
     return flagcxSuccess;
   }
   return flagcxNotSupported;
-}
-
-flagcxResult_t flagcxWaitValueLocal(void **gHandles, int rank, uint64_t offset,
-                                    uint64_t expected) {
-  struct flagcxIbGlobalHandleInfo *info =
-      (struct flagcxIbGlobalHandleInfo *)gHandles;
-  if (info == NULL || info->baseVas == NULL)
-    return flagcxNotSupported;
-  volatile uint64_t *addr = (volatile uint64_t *)(info->baseVas[rank] + offset);
-
-  while (__atomic_load_n(addr, __ATOMIC_ACQUIRE) < expected) {
-    sched_yield();
-  }
-
-  return flagcxSuccess;
 }
 
 flagcxResult_t flagcxHeteroFlush(flagcxHeteroComm_t comm, void *gpuAddr,
@@ -193,6 +191,7 @@ flagcxResult_t flagcxHeteroFlush(flagcxHeteroComm_t comm, void *gpuAddr,
 flagcxResult_t flagcxHeteroWaitSignal(flagcxHeteroComm_t comm, int peer,
                                       size_t signalOffset, uint64_t expected,
                                       flagcxStream_t stream) {
+  (void)peer;
   struct flagcxIbGlobalHandleInfo *info =
       (struct flagcxIbGlobalHandleInfo *)globalOneSideSignalHandles;
   if (info == NULL || info->baseVas == NULL)
@@ -201,27 +200,12 @@ flagcxResult_t flagcxHeteroWaitSignal(flagcxHeteroComm_t comm, int peer,
   int myRank = comm->rank;
   void *signalAddr = (void *)(info->baseVas[myRank] + signalOffset);
 
-  // Try device-side wait (streamWaitValue64) for GPU signal buffer
-  if (stream != NULL) {
-    flagcxResult_t res =
-        deviceAdaptor->streamWaitValue64(stream, signalAddr, expected, 0);
-    if (res == flagcxSuccess)
-      return flagcxSuccess;
-    // Fall through to host poll if flagcxNotSupported or error
-  }
+  // Device-side wait (streamWaitValue64) for GPU signal buffer.
+  // RMA signal buffers are GPU memory (flagcxMemAlloc) — host-side volatile
+  // polling would segfault. Non-CUDA platforms return flagcxNotSupported.
+  // No flush needed: FORCE_SO on signal MR guarantees PCIe ordering.
+  if (stream == NULL)
+    return flagcxInternalError;
 
-  // Host fallback: volatile poll
-  volatile uint64_t *addr = (volatile uint64_t *)signalAddr;
-  while (__atomic_load_n(addr, __ATOMIC_ACQUIRE) < expected) {
-    sched_yield();
-  }
-
-  // Flush data buffer after host-side signal confirmation
-  struct flagcxIbGlobalHandleInfo *dataInfo =
-      (struct flagcxIbGlobalHandleInfo *)globalOneSideHandles;
-  if (dataInfo != NULL) {
-    flagcxHeteroFlush(comm, (void *)dataInfo->baseVas[myRank], 1,
-                      (void *)dataInfo);
-  }
-  return flagcxSuccess;
+  return deviceAdaptor->streamWaitValue64(stream, signalAddr, expected, 0);
 }

--- a/flagcx/core/include/flagcx_hetero.h
+++ b/flagcx/core/include/flagcx_hetero.h
@@ -46,9 +46,6 @@ flagcxResult_t flagcxHeteroPutSignal(flagcxHeteroComm_t comm, int peer,
                                      size_t srcOffset, size_t dstOffset,
                                      size_t size, size_t signalOffset);
 
-flagcxResult_t flagcxWaitValueLocal(void **gHandles, int rank, uint64_t offset,
-                                    uint64_t expected);
-
 flagcxResult_t flagcxHeteroFlush(flagcxHeteroComm_t comm, void *gpuAddr,
                                  size_t size, void *gHandleInfo);
 

--- a/flagcx/core/include/flagcx_hetero.h
+++ b/flagcx/core/include/flagcx_hetero.h
@@ -40,7 +40,20 @@ flagcxResult_t flagcxHeteroCommDestroy(flagcxHeteroComm_t comm);
 flagcxResult_t flagcxHeteroPut(flagcxHeteroComm_t comm, int peer,
                                size_t srcOffset, size_t dstOffset, size_t size);
 
+// Data + signal combined (chained WRITE + ATOMIC in IB backend)
+// When size == 0, only signal ATOMIC is posted (signal-only mode)
 flagcxResult_t flagcxHeteroPutSignal(flagcxHeteroComm_t comm, int peer,
-                                     size_t dstOffset);
+                                     size_t srcOffset, size_t dstOffset,
+                                     size_t size, size_t signalOffset);
+
+flagcxResult_t flagcxWaitValueLocal(void **gHandles, int rank, uint64_t offset,
+                                    uint64_t expected);
+
+flagcxResult_t flagcxHeteroFlush(flagcxHeteroComm_t comm, void *gpuAddr,
+                                 size_t size, void *gHandleInfo);
+
+flagcxResult_t flagcxHeteroWaitSignal(flagcxHeteroComm_t comm, int peer,
+                                      size_t signalOffset, uint64_t expected,
+                                      flagcxStream_t stream);
 
 #endif

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -1189,6 +1189,12 @@ void *flagcxProxyKernelService(void *args) {
         size_t dstOffset = (size_t)ptr->getDstOffset();
         // TODO: integrate with flagcxDevicePrimPut for chained posting
         // For now, signal-only mode (size=0)
+        if (globalOneSideSignalHandles == NULL) {
+          WARN("flagcxDevicePrimSignal: globalOneSideSignalHandles not "
+               "initialized");
+          res = flagcxInternalError;
+          break;
+        }
         res = flagcxHeteroPutSignal(comm, peerRank, 0, 0, 0, dstOffset);
         break;
       }

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -1191,7 +1191,7 @@ void *flagcxProxyKernelService(void *args) {
         // For now, signal-only mode (size=0)
         if (globalOneSideSignalHandles == NULL) {
           WARN("flagcxDevicePrimSignal: globalOneSideSignalHandles not "
-               "initialized");
+               "initialized — call flagcxOneSideSignalRegister() before use");
           res = flagcxInternalError;
           break;
         }

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -581,18 +581,18 @@ static flagcxResult_t proxyProgressAsync(flagcxProxyAsyncOp **opHead,
                 resources->buffSizes[0], 0));
             FLAGCXCHECK(resources->netAdaptor->regMrDmaBuf(
                 resources->netSendComm, resources->buffers[0],
-                resources->buffSizes[0], 2, 0ULL, dmabuf_fd,
+                resources->buffSizes[0], 2, 0ULL, dmabuf_fd, 0,
                 &resources->mhandles[0]));
             (void)close(dmabuf_fd);
           } else {
             if (resources->netAdaptor == getUnifiedNetAdaptor(IBRC)) {
               FLAGCXCHECK(resources->netAdaptor->regMr(
                   resources->netSendComm, resources->buffers[0],
-                  resources->buffSizes[0], 2, &resources->mhandles[0]));
+                  resources->buffSizes[0], 2, 0, &resources->mhandles[0]));
             } else if (resources->netAdaptor == getUnifiedNetAdaptor(SOCKET)) {
               FLAGCXCHECK(resources->netAdaptor->regMr(
                   resources->netSendComm, resources->buffers[0],
-                  resources->buffSizes[0], 1, &resources->mhandles[0]));
+                  resources->buffSizes[0], 1, 0, &resources->mhandles[0]));
             }
           }
           done = 1;
@@ -613,18 +613,18 @@ static flagcxResult_t proxyProgressAsync(flagcxProxyAsyncOp **opHead,
                 resources->buffSizes[0], 0));
             FLAGCXCHECK(resources->netAdaptor->regMrDmaBuf(
                 resources->netRecvComm, resources->buffers[0],
-                resources->buffSizes[0], 2, 0ULL, dmabuf_fd,
+                resources->buffSizes[0], 2, 0ULL, dmabuf_fd, 0,
                 &resources->mhandles[0]));
             (void)close(dmabuf_fd);
           } else {
             if (resources->netAdaptor == getUnifiedNetAdaptor(IBRC)) {
               FLAGCXCHECK(resources->netAdaptor->regMr(
                   resources->netRecvComm, resources->buffers[0],
-                  resources->buffSizes[0], 2, &resources->mhandles[0]));
+                  resources->buffSizes[0], 2, 0, &resources->mhandles[0]));
             } else if (resources->netAdaptor == getUnifiedNetAdaptor(SOCKET)) {
               FLAGCXCHECK(resources->netAdaptor->regMr(
                   resources->netRecvComm, resources->buffers[0],
-                  resources->buffSizes[0], 1, &resources->mhandles[0]));
+                  resources->buffSizes[0], 1, 0, &resources->mhandles[0]));
             }
           }
           done = 1;
@@ -653,12 +653,12 @@ static flagcxResult_t proxyProgressAsync(flagcxProxyAsyncOp **opHead,
               (void *)&dmabuf_fd, (void *)info->buffer, info->size, 0));
           FLAGCXCHECK(resources->netAdaptor->regMrDmaBuf(
               resources->netSendComm, (void *)info->buffer, info->size, 2, 0ULL,
-              dmabuf_fd, &handle));
+              dmabuf_fd, 0, &handle));
           (void)close(dmabuf_fd);
         } else {
           FLAGCXCHECK(resources->netAdaptor->regMr(resources->netSendComm,
                                                    (void *)info->buffer,
-                                                   info->size, 2, &handle));
+                                                   info->size, 2, 0, &handle));
         }
       } else {
         // recv side
@@ -670,12 +670,12 @@ static flagcxResult_t proxyProgressAsync(flagcxProxyAsyncOp **opHead,
               (void *)&dmabuf_fd, (void *)info->buffer, info->size, 0));
           FLAGCXCHECK(resources->netAdaptor->regMrDmaBuf(
               resources->netRecvComm, (void *)info->buffer, info->size, 2, 0ULL,
-              dmabuf_fd, &handle));
+              dmabuf_fd, 0, &handle));
           (void)close(dmabuf_fd);
         } else {
           FLAGCXCHECK(resources->netAdaptor->regMr(resources->netRecvComm,
                                                    (void *)info->buffer,
-                                                   info->size, 2, &handle));
+                                                   info->size, 2, 0, &handle));
         }
       }
       memcpy(op->respBuff, (void *)&handle, sizeof(void *));
@@ -1187,7 +1187,9 @@ void *flagcxProxyKernelService(void *args) {
         if (res != flagcxSuccess)
           break;
         size_t dstOffset = (size_t)ptr->getDstOffset();
-        res = flagcxHeteroPutSignal(comm, peerRank, dstOffset);
+        // TODO: integrate with flagcxDevicePrimPut for chained posting
+        // For now, signal-only mode (size=0)
+        res = flagcxHeteroPutSignal(comm, peerRank, 0, 0, 0, dstOffset);
         break;
       }
       case flagcxDevicePrimWait:

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -204,6 +204,9 @@ flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
     return flagcxSuccess;
   }
 
+  if (globalOneSideHandles != NULL)
+    return flagcxSuccess;
+
   struct flagcxHeteroComm *heteroComm = comm->heteroComm;
   if (heteroComm == NULL || heteroComm->netAdaptor == NULL ||
       heteroComm->netAdaptor->iput == NULL ||
@@ -218,45 +221,49 @@ flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
     return flagcxNotSupported;
   }
 
+  flagcxResult_t res = flagcxSuccess;
   void *mrHandle = NULL;
   struct ibv_mr *mr = NULL;
+  void *sendComm = NULL;
+  void *recvComm = NULL;
+  void *listenComm = NULL;
+  void *regComm = NULL;
+  struct flagcxIbGlobalHandleInfo *info = NULL;
 
   int sendPeer = (heteroComm->rank + 1) % heteroComm->nRanks;
   int recvPeer =
       (heteroComm->rank - 1 + heteroComm->nRanks) % heteroComm->nRanks;
 
   flagcxNetHandle_t listenHandle = {};
-  void *listenComm = NULL;
   FLAGCXCHECK(heteroComm->netAdaptor->listen(
       heteroComm->netDev, (void *)listenHandle, &listenComm));
 
   flagcxNetHandle_t peerHandle = {};
-  FLAGCXCHECK(bootstrapSend(state, recvPeer, 1001, (void *)listenHandle,
-                            sizeof(flagcxNetHandle_t)));
-  FLAGCXCHECK(bootstrapRecv(state, sendPeer, 1001, (void *)peerHandle,
-                            sizeof(flagcxNetHandle_t)));
+  FLAGCXCHECKGOTO(bootstrapSend(state, recvPeer, 1001, (void *)listenHandle,
+                                sizeof(flagcxNetHandle_t)),
+                  res, fail_listen);
+  FLAGCXCHECKGOTO(bootstrapRecv(state, sendPeer, 1001, (void *)peerHandle,
+                                sizeof(flagcxNetHandle_t)),
+                  res, fail_listen);
 
   // Establish connections
-  void *sendComm = NULL;
-  void *recvComm = NULL;
   while (sendComm == NULL || recvComm == NULL) {
     if (sendComm == NULL) {
-      flagcxResult_t res = heteroComm->netAdaptor->connect(
-          heteroComm->netDev, (void *)peerHandle, &sendComm);
+      res = heteroComm->netAdaptor->connect(heteroComm->netDev,
+                                            (void *)peerHandle, &sendComm);
       if (res != flagcxSuccess && res != flagcxInProgress) {
         INFO(FLAGCX_REG,
              "flagcxOneSideRegister: connect to sendPeer failed, res=%d", res);
-        return res;
+        goto fail_listen;
       }
     }
 
     if (recvComm == NULL) {
-      flagcxResult_t res =
-          heteroComm->netAdaptor->accept(listenComm, &recvComm);
+      res = heteroComm->netAdaptor->accept(listenComm, &recvComm);
       if (res != flagcxSuccess && res != flagcxInProgress) {
         INFO(FLAGCX_REG,
              "flagcxOneSideRegister: accept from recvPeer failed, res=%d", res);
-        return res;
+        goto fail_listen;
       }
     }
 
@@ -264,10 +271,11 @@ flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
       sched_yield();
     }
   }
-  // Close listen comm
+  // Close listen comm — connections established
   heteroComm->netAdaptor->closeListen(listenComm);
+  listenComm = NULL;
 
-  void *regComm = recvComm;
+  regComm = recvComm;
   INFO(FLAGCX_REG, "flagcxOneSideRegister: sendComm and recvComm created, "
                    "using recvComm for registration");
 
@@ -277,44 +285,111 @@ flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
     regComm = (void *)&ibRecvComm->base;
   }
 
-  int type = FLAGCX_PTR_CUDA;
-  flagcxResult_t res = heteroComm->netAdaptor->regMr(
-      regComm, buff, size, type, FLAGCX_NET_MR_FLAG_NONE, &mrHandle);
+  {
+    int type = FLAGCX_PTR_CUDA;
+    res = heteroComm->netAdaptor->regMr(regComm, buff, size, type,
+                                        FLAGCX_NET_MR_FLAG_NONE, &mrHandle);
+  }
   if (res != flagcxSuccess || mrHandle == NULL) {
     INFO(FLAGCX_REG, "flagcxOneSideRegister: regMr failed, res=%d", res);
-    return flagcxNotSupported;
+    res = flagcxNotSupported;
+    goto fail_conn;
   }
 
-  struct flagcxIbMrHandle *localMrHandle = (struct flagcxIbMrHandle *)mrHandle;
-  mr = localMrHandle->mrs[0];
-
-  int nranks = state->nranks;
-  struct flagcxIbGlobalHandleInfo *info = NULL;
-  FLAGCXCHECK(flagcxCalloc(&info, 1));
-  FLAGCXCHECK(flagcxCalloc(&info->baseVas, nranks));
-  FLAGCXCHECK(flagcxCalloc(&info->rkeys, nranks));
-  FLAGCXCHECK(flagcxCalloc(&info->lkeys, nranks));
-
-  info->baseVas[state->rank] = (uintptr_t)buff;
-  info->rkeys[state->rank] = mr->rkey;
-  info->lkeys[state->rank] = mr->lkey;
-  info->localMrHandle = mrHandle;
-  info->localRecvComm = recvComm;
-
-  FLAGCXCHECK(
-      bootstrapAllGather(state, (void *)info->baseVas, sizeof(uintptr_t)));
-  FLAGCXCHECK(bootstrapAllGather(state, (void *)info->rkeys, sizeof(uint32_t)));
-  FLAGCXCHECK(bootstrapAllGather(state, (void *)info->lkeys, sizeof(uint32_t)));
-  // Store globalHandles in global variable
-  globalOneSideHandles = info;
-  INFO(FLAGCX_REG, "One-sided register allgather results (rank %d, nranks %d):",
-       state->rank, nranks);
-  for (int i = 0; i < nranks; i++) {
-    INFO(FLAGCX_REG, "  Rank %d: base_va=0x%lx, rkey=0x%x, lkey=0x%x", i,
-         info->baseVas[i], info->rkeys[i], info->lkeys[i]);
+  {
+    struct flagcxIbMrHandle *localMrHandle =
+        (struct flagcxIbMrHandle *)mrHandle;
+    mr = localMrHandle->mrs[0];
   }
-  INFO(FLAGCX_REG, "flagcxOneSideRegister: allgather results printed");
 
+  {
+    int nranks = state->nranks;
+    FLAGCXCHECKGOTO(flagcxCalloc(&info, 1), res, fail_mr);
+    FLAGCXCHECKGOTO(flagcxCalloc(&info->baseVas, nranks), res, fail_mr);
+    FLAGCXCHECKGOTO(flagcxCalloc(&info->rkeys, nranks), res, fail_mr);
+    FLAGCXCHECKGOTO(flagcxCalloc(&info->lkeys, nranks), res, fail_mr);
+
+    info->baseVas[state->rank] = (uintptr_t)buff;
+    info->rkeys[state->rank] = mr->rkey;
+    info->lkeys[state->rank] = mr->lkey;
+    info->localMrHandle = mrHandle;
+    info->localRecvComm = recvComm;
+    info->localSendComm = sendComm;
+
+    FLAGCXCHECKGOTO(
+        bootstrapAllGather(state, (void *)info->baseVas, sizeof(uintptr_t)),
+        res, fail_mr);
+    FLAGCXCHECKGOTO(
+        bootstrapAllGather(state, (void *)info->rkeys, sizeof(uint32_t)), res,
+        fail_mr);
+    FLAGCXCHECKGOTO(
+        bootstrapAllGather(state, (void *)info->lkeys, sizeof(uint32_t)), res,
+        fail_mr);
+    globalOneSideHandles = info;
+    INFO(FLAGCX_REG,
+         "One-sided register allgather results (rank %d, nranks %d):",
+         state->rank, nranks);
+    for (int i = 0; i < nranks; i++) {
+      INFO(FLAGCX_REG, "  Rank %d: base_va=0x%lx, rkey=0x%x, lkey=0x%x", i,
+           info->baseVas[i], info->rkeys[i], info->lkeys[i]);
+    }
+    INFO(FLAGCX_REG, "flagcxOneSideRegister: allgather results printed");
+  }
+
+  return flagcxSuccess;
+
+fail_mr:
+  if (info) {
+    free(info->lkeys);
+    free(info->rkeys);
+    free(info->baseVas);
+    free(info);
+  }
+  heteroComm->netAdaptor->deregMr(regComm, mrHandle);
+fail_conn:
+  heteroComm->netAdaptor->closeSend(sendComm);
+  heteroComm->netAdaptor->closeRecv(recvComm);
+  return res;
+fail_listen:
+  if (listenComm)
+    heteroComm->netAdaptor->closeListen(listenComm);
+  if (sendComm)
+    heteroComm->netAdaptor->closeSend(sendComm);
+  if (recvComm)
+    heteroComm->netAdaptor->closeRecv(recvComm);
+  return res;
+}
+
+flagcxResult_t flagcxOneSideDeregister(const flagcxComm_t comm) {
+  struct flagcxIbGlobalHandleInfo *info = globalOneSideHandles;
+  if (info == NULL)
+    return flagcxSuccess;
+  if (comm == NULL)
+    return flagcxInternalError;
+
+  struct flagcxHeteroComm *heteroComm = comm->heteroComm;
+  if (heteroComm != NULL && heteroComm->netAdaptor != NULL) {
+    if (info->localMrHandle != NULL && info->localRecvComm != NULL) {
+      void *regComm = info->localRecvComm;
+      if (heteroComm->netAdaptor->name &&
+          strcmp(heteroComm->netAdaptor->name, "IB") == 0) {
+        struct flagcxIbRecvComm *ibRecvComm =
+            (struct flagcxIbRecvComm *)regComm;
+        regComm = (void *)&ibRecvComm->base;
+      }
+      heteroComm->netAdaptor->deregMr(regComm, info->localMrHandle);
+    }
+    if (info->localSendComm != NULL)
+      heteroComm->netAdaptor->closeSend(info->localSendComm);
+    if (info->localRecvComm != NULL)
+      heteroComm->netAdaptor->closeRecv(info->localRecvComm);
+  }
+
+  free(info->baseVas);
+  free(info->rkeys);
+  free(info->lkeys);
+  free(info);
+  globalOneSideHandles = NULL;
   return flagcxSuccess;
 }
 
@@ -324,9 +399,12 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
     return flagcxSuccess;
   }
 
+  if (globalOneSideSignalHandles != NULL)
+    return flagcxSuccess;
+
   struct flagcxHeteroComm *heteroComm = comm->heteroComm;
   if (heteroComm == NULL || heteroComm->netAdaptor == NULL ||
-      heteroComm->netAdaptor->iput == NULL ||
+      heteroComm->netAdaptor->iputSignal == NULL ||
       heteroComm->netAdaptor->regMr == NULL) {
     INFO(FLAGCX_REG, "flagcxOneSideSignalRegister: heteroComm is NULL");
     return flagcxSuccess;
@@ -338,95 +416,170 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
     return flagcxNotSupported;
   }
 
+  flagcxResult_t res = flagcxSuccess;
   void *mrHandle = NULL;
   struct ibv_mr *mr = NULL;
+  void *sendComm = NULL;
+  void *recvComm = NULL;
+  void *listenComm = NULL;
+  void *regComm = NULL;
+  struct flagcxIbGlobalHandleInfo *info = NULL;
 
   int sendPeer = (heteroComm->rank + 1) % heteroComm->nRanks;
   int recvPeer =
       (heteroComm->rank - 1 + heteroComm->nRanks) % heteroComm->nRanks;
 
   flagcxNetHandle_t listenHandle = {};
-  void *listenComm = NULL;
   FLAGCXCHECK(heteroComm->netAdaptor->listen(
       heteroComm->netDev, (void *)listenHandle, &listenComm));
 
   flagcxNetHandle_t peerHandle = {};
-  FLAGCXCHECK(bootstrapSend(state, recvPeer, 1002, (void *)listenHandle,
-                            sizeof(flagcxNetHandle_t)));
-  FLAGCXCHECK(bootstrapRecv(state, sendPeer, 1002, (void *)peerHandle,
-                            sizeof(flagcxNetHandle_t)));
+  FLAGCXCHECKGOTO(bootstrapSend(state, recvPeer, 1002, (void *)listenHandle,
+                                sizeof(flagcxNetHandle_t)),
+                  res, fail_listen);
+  FLAGCXCHECKGOTO(bootstrapRecv(state, sendPeer, 1002, (void *)peerHandle,
+                                sizeof(flagcxNetHandle_t)),
+                  res, fail_listen);
 
-  void *sendComm = NULL;
-  void *recvComm = NULL;
   while (sendComm == NULL || recvComm == NULL) {
     if (sendComm == NULL) {
-      flagcxResult_t res = heteroComm->netAdaptor->connect(
-          heteroComm->netDev, (void *)peerHandle, &sendComm);
+      res = heteroComm->netAdaptor->connect(heteroComm->netDev,
+                                            (void *)peerHandle, &sendComm);
       if (res != flagcxSuccess && res != flagcxInProgress) {
         INFO(FLAGCX_REG, "flagcxOneSideSignalRegister: connect failed, res=%d",
              res);
-        return res;
+        goto fail_listen;
       }
     }
     if (recvComm == NULL) {
-      flagcxResult_t res =
-          heteroComm->netAdaptor->accept(listenComm, &recvComm);
+      res = heteroComm->netAdaptor->accept(listenComm, &recvComm);
       if (res != flagcxSuccess && res != flagcxInProgress) {
         INFO(FLAGCX_REG, "flagcxOneSideSignalRegister: accept failed, res=%d",
              res);
-        return res;
+        goto fail_listen;
       }
     }
     if (sendComm == NULL || recvComm == NULL) {
       sched_yield();
     }
   }
+  // Close listen comm — connections established
   heteroComm->netAdaptor->closeListen(listenComm);
+  listenComm = NULL;
 
-  void *regComm = recvComm;
+  regComm = recvComm;
   if (heteroComm->netAdaptor->name &&
       strcmp(heteroComm->netAdaptor->name, "IB") == 0) {
     struct flagcxIbRecvComm *ibRecvComm = (struct flagcxIbRecvComm *)regComm;
     regComm = (void *)&ibRecvComm->base;
   }
 
-  int type = FLAGCX_PTR_CUDA;
-  flagcxResult_t res = heteroComm->netAdaptor->regMr(
-      regComm, buff, size, type, FLAGCX_NET_MR_FLAG_FORCE_SO, &mrHandle);
+  {
+    int type = FLAGCX_PTR_CUDA;
+    res = heteroComm->netAdaptor->regMr(regComm, buff, size, type,
+                                        FLAGCX_NET_MR_FLAG_FORCE_SO, &mrHandle);
+  }
   if (res != flagcxSuccess || mrHandle == NULL) {
     INFO(FLAGCX_REG, "flagcxOneSideSignalRegister: regMr failed, res=%d", res);
-    return flagcxNotSupported;
+    res = flagcxNotSupported;
+    goto fail_conn;
   }
 
-  struct flagcxIbMrHandle *localMrHandle = (struct flagcxIbMrHandle *)mrHandle;
-  mr = localMrHandle->mrs[0];
-
-  int nranks = state->nranks;
-  struct flagcxIbGlobalHandleInfo *info = NULL;
-  FLAGCXCHECK(flagcxCalloc(&info, 1));
-  FLAGCXCHECK(flagcxCalloc(&info->baseVas, nranks));
-  FLAGCXCHECK(flagcxCalloc(&info->rkeys, nranks));
-  FLAGCXCHECK(flagcxCalloc(&info->lkeys, nranks));
-
-  info->baseVas[state->rank] = (uintptr_t)buff;
-  info->rkeys[state->rank] = mr->rkey;
-  info->lkeys[state->rank] = mr->lkey;
-  info->localMrHandle = mrHandle;
-  info->localRecvComm = recvComm;
-
-  FLAGCXCHECK(
-      bootstrapAllGather(state, (void *)info->baseVas, sizeof(uintptr_t)));
-  FLAGCXCHECK(bootstrapAllGather(state, (void *)info->rkeys, sizeof(uint32_t)));
-  FLAGCXCHECK(bootstrapAllGather(state, (void *)info->lkeys, sizeof(uint32_t)));
-  globalOneSideSignalHandles = info;
-  INFO(FLAGCX_REG,
-       "Signal register allgather results (rank %d, nranks %d):", state->rank,
-       nranks);
-  for (int i = 0; i < nranks; i++) {
-    INFO(FLAGCX_REG, "  Rank %d: base_va=0x%lx, rkey=0x%x, lkey=0x%x", i,
-         info->baseVas[i], info->rkeys[i], info->lkeys[i]);
+  {
+    struct flagcxIbMrHandle *localMrHandle =
+        (struct flagcxIbMrHandle *)mrHandle;
+    mr = localMrHandle->mrs[0];
   }
 
+  {
+    int nranks = state->nranks;
+    FLAGCXCHECKGOTO(flagcxCalloc(&info, 1), res, fail_mr);
+    FLAGCXCHECKGOTO(flagcxCalloc(&info->baseVas, nranks), res, fail_mr);
+    FLAGCXCHECKGOTO(flagcxCalloc(&info->rkeys, nranks), res, fail_mr);
+    FLAGCXCHECKGOTO(flagcxCalloc(&info->lkeys, nranks), res, fail_mr);
+
+    info->baseVas[state->rank] = (uintptr_t)buff;
+    info->rkeys[state->rank] = mr->rkey;
+    info->lkeys[state->rank] = mr->lkey;
+    info->localMrHandle = mrHandle;
+    info->localRecvComm = recvComm;
+    info->localSendComm = sendComm;
+
+    FLAGCXCHECKGOTO(
+        bootstrapAllGather(state, (void *)info->baseVas, sizeof(uintptr_t)),
+        res, fail_mr);
+    FLAGCXCHECKGOTO(
+        bootstrapAllGather(state, (void *)info->rkeys, sizeof(uint32_t)), res,
+        fail_mr);
+    FLAGCXCHECKGOTO(
+        bootstrapAllGather(state, (void *)info->lkeys, sizeof(uint32_t)), res,
+        fail_mr);
+    globalOneSideSignalHandles = info;
+    INFO(FLAGCX_REG,
+         "Signal register allgather results (rank %d, nranks %d):", state->rank,
+         nranks);
+    for (int i = 0; i < nranks; i++) {
+      INFO(FLAGCX_REG, "  Rank %d: base_va=0x%lx, rkey=0x%x, lkey=0x%x", i,
+           info->baseVas[i], info->rkeys[i], info->lkeys[i]);
+    }
+  }
+
+  return flagcxSuccess;
+
+fail_mr:
+  if (info) {
+    free(info->lkeys);
+    free(info->rkeys);
+    free(info->baseVas);
+    free(info);
+  }
+  heteroComm->netAdaptor->deregMr(regComm, mrHandle);
+fail_conn:
+  heteroComm->netAdaptor->closeSend(sendComm);
+  heteroComm->netAdaptor->closeRecv(recvComm);
+  return res;
+fail_listen:
+  if (listenComm)
+    heteroComm->netAdaptor->closeListen(listenComm);
+  if (sendComm)
+    heteroComm->netAdaptor->closeSend(sendComm);
+  if (recvComm)
+    heteroComm->netAdaptor->closeRecv(recvComm);
+  return res;
+}
+
+flagcxResult_t flagcxOneSideSignalDeregister(const flagcxComm_t comm) {
+  struct flagcxIbGlobalHandleInfo *info = globalOneSideSignalHandles;
+  if (info == NULL)
+    return flagcxSuccess;
+  if (comm == NULL)
+    return flagcxInternalError;
+
+  struct flagcxHeteroComm *heteroComm = comm->heteroComm;
+  if (heteroComm != NULL && heteroComm->netAdaptor != NULL) {
+    // Deregister MR
+    if (info->localMrHandle != NULL && info->localRecvComm != NULL) {
+      void *regComm = info->localRecvComm;
+      if (heteroComm->netAdaptor->name &&
+          strcmp(heteroComm->netAdaptor->name, "IB") == 0) {
+        struct flagcxIbRecvComm *ibRecvComm =
+            (struct flagcxIbRecvComm *)regComm;
+        regComm = (void *)&ibRecvComm->base;
+      }
+      heteroComm->netAdaptor->deregMr(regComm, info->localMrHandle);
+    }
+    // Close network connections
+    if (info->localSendComm != NULL)
+      heteroComm->netAdaptor->closeSend(info->localSendComm);
+    if (info->localRecvComm != NULL)
+      heteroComm->netAdaptor->closeRecv(info->localRecvComm);
+  }
+
+  free(info->baseVas);
+  free(info->rkeys);
+  free(info->lkeys);
+  free(info);
+  globalOneSideSignalHandles = NULL;
   return flagcxSuccess;
 }
 

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -25,6 +25,7 @@
 
 flagcxRegPool globalRegPool;
 struct flagcxIbGlobalHandleInfo *globalOneSideHandles = NULL;
+struct flagcxIbGlobalHandleInfo *globalOneSideSignalHandles = NULL;
 
 size_t getFlagcxDataTypeSize(flagcxDataType_t dtype) {
   switch (dtype) {
@@ -66,26 +67,38 @@ flagcxResult_t wrapper_deviceMemcpy(void *dst, void *src, size_t size,
   return deviceAdaptor->deviceMemcpy(dst, src, size, type, stream, NULL);
 }
 
-static struct flagcxDeviceHandle globalDeviceHandle {
-  // Basic functions
-  deviceAdaptor->deviceSynchronize, wrapper_deviceMemcpy,
-      deviceAdaptor->deviceMemset, deviceAdaptor->deviceMalloc,
-      deviceAdaptor->deviceFree, deviceAdaptor->setDevice,
-      deviceAdaptor->getDevice, deviceAdaptor->getDeviceCount,
-      deviceAdaptor->getVendor, deviceAdaptor->hostGetDevicePointer,
-      // Stream functions
-      deviceAdaptor->streamCreate, deviceAdaptor->streamDestroy,
-      deviceAdaptor->streamCopy, deviceAdaptor->streamFree,
-      deviceAdaptor->streamSynchronize, deviceAdaptor->streamQuery,
-      deviceAdaptor->streamWaitEvent,
-      // Event functions
-      deviceAdaptor->eventCreate, deviceAdaptor->eventDestroy,
-      deviceAdaptor->eventRecord, deviceAdaptor->eventSynchronize,
-      deviceAdaptor->eventQuery,
-      // IpcMemHandle functions
-      deviceAdaptor->ipcMemHandleCreate, deviceAdaptor->ipcMemHandleGet,
-      deviceAdaptor->ipcMemHandleOpen, deviceAdaptor->ipcMemHandleClose,
-      deviceAdaptor->ipcMemHandleFree,
+static struct flagcxDeviceHandle globalDeviceHandle{
+    // Basic functions
+    deviceAdaptor->deviceSynchronize,
+    wrapper_deviceMemcpy,
+    deviceAdaptor->deviceMemset,
+    deviceAdaptor->deviceMalloc,
+    deviceAdaptor->deviceFree,
+    deviceAdaptor->setDevice,
+    deviceAdaptor->getDevice,
+    deviceAdaptor->getDeviceCount,
+    deviceAdaptor->getVendor,
+    deviceAdaptor->hostGetDevicePointer,
+    // Stream functions
+    deviceAdaptor->streamCreate,
+    deviceAdaptor->streamDestroy,
+    deviceAdaptor->streamCopy,
+    deviceAdaptor->streamFree,
+    deviceAdaptor->streamSynchronize,
+    deviceAdaptor->streamQuery,
+    deviceAdaptor->streamWaitEvent,
+    // Event functions
+    deviceAdaptor->eventCreate,
+    deviceAdaptor->eventDestroy,
+    deviceAdaptor->eventRecord,
+    deviceAdaptor->eventSynchronize,
+    deviceAdaptor->eventQuery,
+    // IpcMemHandle functions
+    deviceAdaptor->ipcMemHandleCreate,
+    deviceAdaptor->ipcMemHandleGet,
+    deviceAdaptor->ipcMemHandleOpen,
+    deviceAdaptor->ipcMemHandleClose,
+    deviceAdaptor->ipcMemHandleFree,
 };
 
 flagcxResult_t flagcxEnsureCommReady(flagcxComm_t comm) {
@@ -193,7 +206,7 @@ flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
 
   struct flagcxHeteroComm *heteroComm = comm->heteroComm;
   if (heteroComm == NULL || heteroComm->netAdaptor == NULL ||
-      heteroComm->netAdaptor->put == NULL ||
+      heteroComm->netAdaptor->iput == NULL ||
       heteroComm->netAdaptor->regMr == NULL) {
     INFO(FLAGCX_REG, "flagcxOneSideRegister: heteroComm is NULL");
     return flagcxSuccess;
@@ -256,17 +269,17 @@ flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
 
   void *regComm = recvComm;
   INFO(FLAGCX_REG, "flagcxOneSideRegister: sendComm and recvComm created, "
-                   "using sendComm for registration");
+                   "using recvComm for registration");
 
   if (heteroComm->netAdaptor->name &&
       strcmp(heteroComm->netAdaptor->name, "IB") == 0) {
-    struct flagcxIbSendComm *ibSendComm = (struct flagcxIbSendComm *)regComm;
-    regComm = (void *)&ibSendComm->base;
+    struct flagcxIbRecvComm *ibRecvComm = (struct flagcxIbRecvComm *)regComm;
+    regComm = (void *)&ibRecvComm->base;
   }
 
-  int type = FLAGCX_PTR_HOST;
-  flagcxResult_t res =
-      heteroComm->netAdaptor->regMr(regComm, buff, size, type, &mrHandle);
+  int type = FLAGCX_PTR_CUDA;
+  flagcxResult_t res = heteroComm->netAdaptor->regMr(
+      regComm, buff, size, type, FLAGCX_NET_MR_FLAG_NONE, &mrHandle);
   if (res != flagcxSuccess || mrHandle == NULL) {
     INFO(FLAGCX_REG, "flagcxOneSideRegister: regMr failed, res=%d", res);
     return flagcxNotSupported;
@@ -285,6 +298,8 @@ flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
   info->baseVas[state->rank] = (uintptr_t)buff;
   info->rkeys[state->rank] = mr->rkey;
   info->lkeys[state->rank] = mr->lkey;
+  info->localMrHandle = mrHandle;
+  info->localRecvComm = recvComm;
 
   FLAGCXCHECK(
       bootstrapAllGather(state, (void *)info->baseVas, sizeof(uintptr_t)));
@@ -299,6 +314,118 @@ flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
          info->baseVas[i], info->rkeys[i], info->lkeys[i]);
   }
   INFO(FLAGCX_REG, "flagcxOneSideRegister: allgather results printed");
+
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
+                                           size_t size) {
+  if (useHomoComm(comm) && !useHeteroComm()) {
+    return flagcxSuccess;
+  }
+
+  struct flagcxHeteroComm *heteroComm = comm->heteroComm;
+  if (heteroComm == NULL || heteroComm->netAdaptor == NULL ||
+      heteroComm->netAdaptor->iput == NULL ||
+      heteroComm->netAdaptor->regMr == NULL) {
+    INFO(FLAGCX_REG, "flagcxOneSideSignalRegister: heteroComm is NULL");
+    return flagcxSuccess;
+  }
+
+  struct bootstrapState *state = heteroComm->bootstrap;
+  if (state == NULL) {
+    INFO(FLAGCX_REG, "flagcxOneSideSignalRegister: state is NULL");
+    return flagcxNotSupported;
+  }
+
+  void *mrHandle = NULL;
+  struct ibv_mr *mr = NULL;
+
+  int sendPeer = (heteroComm->rank + 1) % heteroComm->nRanks;
+  int recvPeer =
+      (heteroComm->rank - 1 + heteroComm->nRanks) % heteroComm->nRanks;
+
+  flagcxNetHandle_t listenHandle = {};
+  void *listenComm = NULL;
+  FLAGCXCHECK(heteroComm->netAdaptor->listen(
+      heteroComm->netDev, (void *)listenHandle, &listenComm));
+
+  flagcxNetHandle_t peerHandle = {};
+  FLAGCXCHECK(bootstrapSend(state, recvPeer, 1002, (void *)listenHandle,
+                            sizeof(flagcxNetHandle_t)));
+  FLAGCXCHECK(bootstrapRecv(state, sendPeer, 1002, (void *)peerHandle,
+                            sizeof(flagcxNetHandle_t)));
+
+  void *sendComm = NULL;
+  void *recvComm = NULL;
+  while (sendComm == NULL || recvComm == NULL) {
+    if (sendComm == NULL) {
+      flagcxResult_t res = heteroComm->netAdaptor->connect(
+          heteroComm->netDev, (void *)peerHandle, &sendComm);
+      if (res != flagcxSuccess && res != flagcxInProgress) {
+        INFO(FLAGCX_REG, "flagcxOneSideSignalRegister: connect failed, res=%d",
+             res);
+        return res;
+      }
+    }
+    if (recvComm == NULL) {
+      flagcxResult_t res =
+          heteroComm->netAdaptor->accept(listenComm, &recvComm);
+      if (res != flagcxSuccess && res != flagcxInProgress) {
+        INFO(FLAGCX_REG, "flagcxOneSideSignalRegister: accept failed, res=%d",
+             res);
+        return res;
+      }
+    }
+    if (sendComm == NULL || recvComm == NULL) {
+      sched_yield();
+    }
+  }
+  heteroComm->netAdaptor->closeListen(listenComm);
+
+  void *regComm = recvComm;
+  if (heteroComm->netAdaptor->name &&
+      strcmp(heteroComm->netAdaptor->name, "IB") == 0) {
+    struct flagcxIbRecvComm *ibRecvComm = (struct flagcxIbRecvComm *)regComm;
+    regComm = (void *)&ibRecvComm->base;
+  }
+
+  int type = FLAGCX_PTR_CUDA;
+  flagcxResult_t res = heteroComm->netAdaptor->regMr(
+      regComm, buff, size, type, FLAGCX_NET_MR_FLAG_FORCE_SO, &mrHandle);
+  if (res != flagcxSuccess || mrHandle == NULL) {
+    INFO(FLAGCX_REG, "flagcxOneSideSignalRegister: regMr failed, res=%d", res);
+    return flagcxNotSupported;
+  }
+
+  struct flagcxIbMrHandle *localMrHandle = (struct flagcxIbMrHandle *)mrHandle;
+  mr = localMrHandle->mrs[0];
+
+  int nranks = state->nranks;
+  struct flagcxIbGlobalHandleInfo *info = NULL;
+  FLAGCXCHECK(flagcxCalloc(&info, 1));
+  FLAGCXCHECK(flagcxCalloc(&info->baseVas, nranks));
+  FLAGCXCHECK(flagcxCalloc(&info->rkeys, nranks));
+  FLAGCXCHECK(flagcxCalloc(&info->lkeys, nranks));
+
+  info->baseVas[state->rank] = (uintptr_t)buff;
+  info->rkeys[state->rank] = mr->rkey;
+  info->lkeys[state->rank] = mr->lkey;
+  info->localMrHandle = mrHandle;
+  info->localRecvComm = recvComm;
+
+  FLAGCXCHECK(
+      bootstrapAllGather(state, (void *)info->baseVas, sizeof(uintptr_t)));
+  FLAGCXCHECK(bootstrapAllGather(state, (void *)info->rkeys, sizeof(uint32_t)));
+  FLAGCXCHECK(bootstrapAllGather(state, (void *)info->lkeys, sizeof(uint32_t)));
+  globalOneSideSignalHandles = info;
+  INFO(FLAGCX_REG,
+       "Signal register allgather results (rank %d, nranks %d):", state->rank,
+       nranks);
+  for (int i = 0; i < nranks; i++) {
+    INFO(FLAGCX_REG, "  Rank %d: base_va=0x%lx, rkey=0x%x, lkey=0x%x", i,
+         info->baseVas[i], info->rkeys[i], info->lkeys[i]);
+  }
 
   return flagcxSuccess;
 }

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -67,38 +67,26 @@ flagcxResult_t wrapper_deviceMemcpy(void *dst, void *src, size_t size,
   return deviceAdaptor->deviceMemcpy(dst, src, size, type, stream, NULL);
 }
 
-static struct flagcxDeviceHandle globalDeviceHandle{
-    // Basic functions
-    deviceAdaptor->deviceSynchronize,
-    wrapper_deviceMemcpy,
-    deviceAdaptor->deviceMemset,
-    deviceAdaptor->deviceMalloc,
-    deviceAdaptor->deviceFree,
-    deviceAdaptor->setDevice,
-    deviceAdaptor->getDevice,
-    deviceAdaptor->getDeviceCount,
-    deviceAdaptor->getVendor,
-    deviceAdaptor->hostGetDevicePointer,
-    // Stream functions
-    deviceAdaptor->streamCreate,
-    deviceAdaptor->streamDestroy,
-    deviceAdaptor->streamCopy,
-    deviceAdaptor->streamFree,
-    deviceAdaptor->streamSynchronize,
-    deviceAdaptor->streamQuery,
-    deviceAdaptor->streamWaitEvent,
-    // Event functions
-    deviceAdaptor->eventCreate,
-    deviceAdaptor->eventDestroy,
-    deviceAdaptor->eventRecord,
-    deviceAdaptor->eventSynchronize,
-    deviceAdaptor->eventQuery,
-    // IpcMemHandle functions
-    deviceAdaptor->ipcMemHandleCreate,
-    deviceAdaptor->ipcMemHandleGet,
-    deviceAdaptor->ipcMemHandleOpen,
-    deviceAdaptor->ipcMemHandleClose,
-    deviceAdaptor->ipcMemHandleFree,
+static struct flagcxDeviceHandle globalDeviceHandle {
+  // Basic functions
+  deviceAdaptor->deviceSynchronize, wrapper_deviceMemcpy,
+      deviceAdaptor->deviceMemset, deviceAdaptor->deviceMalloc,
+      deviceAdaptor->deviceFree, deviceAdaptor->setDevice,
+      deviceAdaptor->getDevice, deviceAdaptor->getDeviceCount,
+      deviceAdaptor->getVendor, deviceAdaptor->hostGetDevicePointer,
+      // Stream functions
+      deviceAdaptor->streamCreate, deviceAdaptor->streamDestroy,
+      deviceAdaptor->streamCopy, deviceAdaptor->streamFree,
+      deviceAdaptor->streamSynchronize, deviceAdaptor->streamQuery,
+      deviceAdaptor->streamWaitEvent,
+      // Event functions
+      deviceAdaptor->eventCreate, deviceAdaptor->eventDestroy,
+      deviceAdaptor->eventRecord, deviceAdaptor->eventSynchronize,
+      deviceAdaptor->eventQuery,
+      // IpcMemHandle functions
+      deviceAdaptor->ipcMemHandleCreate, deviceAdaptor->ipcMemHandleGet,
+      deviceAdaptor->ipcMemHandleOpen, deviceAdaptor->ipcMemHandleClose,
+      deviceAdaptor->ipcMemHandleFree,
 };
 
 flagcxResult_t flagcxEnsureCommReady(flagcxComm_t comm) {
@@ -204,8 +192,13 @@ flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
     return flagcxSuccess;
   }
 
-  if (globalOneSideHandles != NULL)
+  if (globalOneSideHandles != NULL) {
+    if (globalOneSideHandles->baseVas != NULL &&
+        globalOneSideHandles->baseVas[comm->rank] != (uintptr_t)buff) {
+      WARN("flagcxOneSideRegister: already registered with a different buffer");
+    }
     return flagcxSuccess;
+  }
 
   struct flagcxHeteroComm *heteroComm = comm->heteroComm;
   if (heteroComm == NULL || heteroComm->netAdaptor == NULL ||
@@ -399,8 +392,14 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
     return flagcxSuccess;
   }
 
-  if (globalOneSideSignalHandles != NULL)
+  if (globalOneSideSignalHandles != NULL) {
+    if (globalOneSideSignalHandles->baseVas != NULL &&
+        globalOneSideSignalHandles->baseVas[comm->rank] != (uintptr_t)buff) {
+      WARN("flagcxOneSideSignalRegister: already registered with a different "
+           "buffer");
+    }
     return flagcxSuccess;
+  }
 
   struct flagcxHeteroComm *heteroComm = comm->heteroComm;
   if (heteroComm == NULL || heteroComm->netAdaptor == NULL ||
@@ -586,11 +585,6 @@ flagcxResult_t flagcxOneSideSignalDeregister(const flagcxComm_t comm) {
 flagcxResult_t flagcxCommRegister(const flagcxComm_t comm, void *buff,
                                   size_t size, void **handle) {
   FLAGCXCHECK(flagcxEnsureCommReady(comm));
-  const char *enableOneSideReg =
-      flagcxGetEnv("FLAGCX_ENABLE_ONE_SIDE_REGISTER");
-  if (enableOneSideReg && strcmp(enableOneSideReg, "1") == 0) {
-    flagcxOneSideRegister(comm, buff, size);
-  }
 
   if (buff == NULL || size == 0) {
     WARN("Invalid buffer or size for buffer registration.");

--- a/flagcx/include/flagcx_kernel.h
+++ b/flagcx/include/flagcx_kernel.h
@@ -187,8 +187,8 @@ struct flagcxDevCommRequirements {
       0,     0, 0, /* barrierCount, intraBarrierCount, interBarrierCount */    \
       0,     0,    /* intraLLA2ABlockCount, intraLLA2ASlotCount */             \
       false, 4, 0,                                                             \
-      0 /* interForceEnable, interContextCount,                                \
-           interSignalCount, interCounterCount */                              \
+      0 /* interForceEnable, interContextCount, interSignalCount,              \
+           interCounterCount */                                                \
   }
 
 // Network type enumeration (maps to ncclGinType_t on NVIDIA backend).
@@ -209,7 +209,9 @@ struct flagcxCommProperties {
 };
 typedef struct flagcxCommProperties flagcxCommProperties_t;
 
-// Query communicator properties (Tier 1: delegates to ncclCommQueryProperties).
+// Query communicator properties.
+// Currently returns placeholder defaults; will delegate to backend
+// (e.g. ncclCommQueryProperties) when wired through the adaptor layer.
 flagcxResult_t flagcxCommQueryProperties(flagcxComm_t comm,
                                          flagcxCommProperties_t *props);
 
@@ -288,6 +290,22 @@ flagcxResult_t flagcxDevMemCreate(flagcxComm_t comm, void *buff, size_t size,
 
 // Destroy a device memory handle created by flagcxDevMemCreate.
 flagcxResult_t flagcxDevMemDestroy(flagcxComm_t comm, flagcxDevMem_t devMem);
+
+// One-sided data buffer registration.
+// Must be called after flagcxCommInitRank and before one-sided operations.
+// Note: also called internally via flagcxCommRegister when
+// FLAGCX_ENABLE_ONE_SIDE_REGISTER=1.
+flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
+                                     size_t size);
+// Release data buffer resources (MR, network connections, handle arrays).
+flagcxResult_t flagcxOneSideDeregister(const flagcxComm_t comm);
+
+// One-sided signal buffer registration (GPU memory with FORCE_SO).
+// Must be called after flagcxCommInitRank and before one-sided operations.
+flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
+                                           size_t size);
+// Release signal buffer resources (MR, network connections, handle arrays).
+flagcxResult_t flagcxOneSideSignalDeregister(const flagcxComm_t comm);
 
 // Intra-node AllReduce using FlagCX Device API.
 // The caller provides a registered buffer (via flagcxDevMemCreate)

--- a/flagcx/include/flagcx_kernel.h
+++ b/flagcx/include/flagcx_kernel.h
@@ -162,17 +162,78 @@ void flagcxLaunchCollectiveKernel(void *fifoBuffer, size_t nthreads,
 // ==========================================================================
 
 // Requirements for creating a device communicator.
-// Fixed 16-byte opaque blob — field interpretation is platform-specific.
-// On NVIDIA: fields[0]=lsaBarrierCount, fields[1]=lsaMultimem,
-//            fields[2]=ginBarrierCount,  fields[3]=ginSignalCount
-typedef struct {
-  int fields[4];
-} flagcxDevCommRequirements;
+// Named fields map to NCCL ncclDevCommRequirements (Tier 1).
+// Naming: NCCL "lsa" → FlagCX "intra", "gin" → "inter", "multimem" →
+// "multicast".
+struct flagcxDevCommRequirements {
+  bool intraMulticast; // → ncclReqs.lsaMultimem
+
+  int barrierCount;      // → ncclReqs.barrierCount (world barrier)
+  int intraBarrierCount; // → ncclReqs.lsaBarrierCount
+  int interBarrierCount; // → ncclReqs.railGinBarrierCount
+
+  int intraLLA2ABlockCount; // → ncclReqs.lsaLLA2ABlockCount
+  int intraLLA2ASlotCount;  // → ncclReqs.lsaLLA2ASlotCount
+
+  bool interForceEnable; // → ncclReqs.ginForceEnable
+  int interContextCount; // → ncclReqs.ginContextCount (hint, default 4)
+  int interSignalCount;  // → ncclReqs.ginSignalCount (start at id=0)
+  int interCounterCount; // → ncclReqs.ginCounterCount (start at id=0)
+};
 
 #define FLAGCX_DEV_COMM_REQUIREMENTS_INITIALIZER                               \
   {                                                                            \
-    { 0, 0, 0, 0 }                                                             \
+      false,       /* intraMulticast */                                        \
+      0,     0, 0, /* barrierCount, intraBarrierCount, interBarrierCount */    \
+      0,     0,    /* intraLLA2ABlockCount, intraLLA2ASlotCount */             \
+      false, 4, 0,                                                             \
+      0 /* interForceEnable, interContextCount,                                \
+           interSignalCount, interCounterCount */                              \
   }
+
+// Network type enumeration (maps to ncclGinType_t on NVIDIA backend).
+typedef enum {
+  flagcxNetTypeNone = 0,  // → NCCL_GIN_TYPE_NONE
+  flagcxNetTypeProxy = 2, // → NCCL_GIN_TYPE_PROXY
+  flagcxNetTypeGdaki = 3, // → NCCL_GIN_TYPE_GDAKI
+} flagcxNetType_t;
+
+// Communicator properties — host-side queryable attributes.
+struct flagcxCommProperties {
+  int rank;
+  int nRanks;
+  int deviceId;            // → ncclCommProperties.cudaDev (platform-neutral)
+  bool deviceApiSupport;   // → ncclCommProperties.deviceApiSupport
+  bool multicastSupport;   // → ncclCommProperties.multimemSupport
+  flagcxNetType_t netType; // → ncclCommProperties.ginType
+};
+typedef struct flagcxCommProperties flagcxCommProperties_t;
+
+// Query communicator properties (Tier 1: delegates to ncclCommQueryProperties).
+flagcxResult_t flagcxCommQueryProperties(flagcxComm_t comm,
+                                         flagcxCommProperties_t *props);
+
+// Forward declarations for types defined in flagcx_device.h.
+struct flagcxTeam;
+typedef struct flagcxTeam flagcxTeam_t;
+struct flagcxDevCommRequirements;
+struct flagcxIntraBarrierHandle;
+typedef struct flagcxIntraBarrierHandle flagcxIntraBarrierHandle_t;
+struct flagcxInterBarrierHandle;
+typedef struct flagcxInterBarrierHandle flagcxInterBarrierHandle_t;
+
+// Create barrier requirement handles (stub — returns flagcxNotSupported).
+// FlagCX currently uses intraBarrierCount in DevCommCreate directly;
+// the resource-handle model will be implemented when needed.
+flagcxResult_t
+flagcxIntraBarrierCreateRequirement(flagcxTeam_t team, int nBarriers,
+                                    flagcxIntraBarrierHandle_t *outHandle,
+                                    flagcxDevCommRequirements *outReq);
+
+flagcxResult_t flagcxInterBarrierCreateRequirement(
+    flagcxComm_t comm, flagcxTeam_t team, int nBarriers,
+    flagcxInterBarrierHandle_t *outHandle, flagcxDevCommRequirements *outReq);
+
 // Opaque handle to a device communicator (host-side lifetime management).
 // Internally wraps ncclDevComm on NVIDIA backend (Tier 1),
 // or IPC barrier state on fallback (Tier 2).

--- a/flagcx/include/flagcx_kernel.h
+++ b/flagcx/include/flagcx_kernel.h
@@ -183,12 +183,11 @@ struct flagcxDevCommRequirements {
 
 #define FLAGCX_DEV_COMM_REQUIREMENTS_INITIALIZER                               \
   {                                                                            \
-      false,       /* intraMulticast */                                        \
-      0,     0, 0, /* barrierCount, intraBarrierCount, interBarrierCount */    \
-      0,     0,    /* intraLLA2ABlockCount, intraLLA2ASlotCount */             \
-      false, 4, 0,                                                             \
-      0 /* interForceEnable, interContextCount, interSignalCount,              \
-           interCounterCount */                                                \
+    false,       /* intraMulticast */                                          \
+        0, 0, 0, /* barrierCount, intraBarrierCount, interBarrierCount */      \
+        0, 0,    /* intraLLA2ABlockCount, intraLLA2ASlotCount */               \
+        false, 4, 0, 0 /* interForceEnable, interContextCount,                 \
+                          interSignalCount, interCounterCount */               \
   }
 
 // Network type enumeration (maps to ncclGinType_t on NVIDIA backend).
@@ -293,8 +292,6 @@ flagcxResult_t flagcxDevMemDestroy(flagcxComm_t comm, flagcxDevMem_t devMem);
 
 // One-sided data buffer registration.
 // Must be called after flagcxCommInitRank and before one-sided operations.
-// Note: also called internally via flagcxCommRegister when
-// FLAGCX_ENABLE_ONE_SIDE_REGISTER=1.
 flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
                                      size_t size);
 // Release data buffer resources (MR, network connections, handle arrays).

--- a/test/kernel/test_device_api_allreduce.cpp
+++ b/test/kernel/test_device_api_allreduce.cpp
@@ -62,8 +62,7 @@ int main(int argc, char *argv[]) {
   // Create device communicator for custom kernel usage
   flagcxDevComm_t devComm = nullptr;
   flagcxDevCommRequirements reqs = FLAGCX_DEV_COMM_REQUIREMENTS_INITIALIZER;
-  reqs.fields[0] = FLAGCX_DEVICE_CTA_COUNT; // lsaBarrierCount
-  reqs.fields[1] = 0;                       // lsaMultimem
+  reqs.intraBarrierCount = FLAGCX_DEVICE_CTA_COUNT;
   FLAGCXCHECK(flagcxDevCommCreate(comm, &reqs, &devComm));
 
   flagcxStream_t stream;

--- a/test/kernel/test_internode_kernel.cpp
+++ b/test/kernel/test_internode_kernel.cpp
@@ -73,7 +73,7 @@ int main(int argc, char *argv[]) {
   // Create device communicator for AlltoAll demo
   // Request IPC barriers — bar.sync() uses signal-based intra barrier
   flagcxDevCommRequirements reqs = FLAGCX_DEV_COMM_REQUIREMENTS_INITIALIZER;
-  reqs.fields[0] = FLAGCX_DEVICE_CTA_COUNT;
+  reqs.intraBarrierCount = FLAGCX_DEVICE_CTA_COUNT;
   flagcxDevComm_t devComm = nullptr;
   FLAGCXCHECK(flagcxDevCommCreate(comm, &reqs, &devComm));
 
@@ -206,8 +206,8 @@ int main(int argc, char *argv[]) {
       // Create device communicator with barrier + signal requirements
       flagcxDevCommRequirements interReqs =
           FLAGCX_DEV_COMM_REQUIREMENTS_INITIALIZER;
-      interReqs.fields[2] = FLAGCX_DEVICE_CTA_COUNT; // barrierCount
-      interReqs.fields[3] = 1;                       // signalCount
+      interReqs.interBarrierCount = FLAGCX_DEVICE_CTA_COUNT;
+      interReqs.interSignalCount = 1;
       FLAGCXCHECK(flagcxDevCommCreate(comm, &interReqs, &a2aDevComm));
 
       // Create window-mode device memory handles
@@ -224,7 +224,7 @@ int main(int argc, char *argv[]) {
 
       flagcxDevCommRequirements fallbackReqs =
           FLAGCX_DEV_COMM_REQUIREMENTS_INITIALIZER;
-      fallbackReqs.fields[0] = FLAGCX_DEVICE_CTA_COUNT;
+      fallbackReqs.intraBarrierCount = FLAGCX_DEVICE_CTA_COUNT;
       FLAGCXCHECK(flagcxDevCommCreate(comm, &fallbackReqs, &a2aDevComm));
 
       FLAGCXCHECK(

--- a/test/kernel/test_intranode_kernel.cpp
+++ b/test/kernel/test_intranode_kernel.cpp
@@ -62,8 +62,7 @@ int main(int argc, char *argv[]) {
   // Create device communicator for custom kernel usage
   flagcxDevComm_t devComm = nullptr;
   flagcxDevCommRequirements reqs = FLAGCX_DEV_COMM_REQUIREMENTS_INITIALIZER;
-  reqs.fields[0] = FLAGCX_DEVICE_CTA_COUNT; // lsaBarrierCount
-  reqs.fields[1] = 0;                       // lsaMultimem
+  reqs.intraBarrierCount = FLAGCX_DEVICE_CTA_COUNT;
   FLAGCXCHECK(flagcxDevCommCreate(comm, &reqs, &devComm));
 
   flagcxStream_t stream;

--- a/test/kernel/test_kernel_put.cpp
+++ b/test/kernel/test_kernel_put.cpp
@@ -39,9 +39,6 @@ int main(int argc, char *argv[]) {
   MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  // Enable one-sided register (must be set before communicator initialization)
-  setenv("FLAGCX_ENABLE_ONE_SIDE_REGISTER", "1", 1);
-
   flagcxCommInitRank(&comm, totalProcs, uniqueId, proc);
 
   if (totalProcs < 2) {
@@ -64,12 +61,13 @@ int main(int argc, char *argv[]) {
   bool isSender = (proc == senderRank);
   bool isReceiver = (proc == receiverRank);
 
-  // Allocate and register window buffer for one-sided operations
+  // Allocate data and signal buffers for one-sided operations
   size_t signalBytes = sizeof(uint64_t);
   size_t max_iterations = std::max(num_warmup_iters, num_iters);
-  size_t window_bytes =
-      max_bytes * max_iterations + signalBytes * max_iterations;
+  size_t window_bytes = max_bytes * max_iterations;
+  size_t signal_total_bytes = signalBytes * max_iterations;
 
+  // Data buffer: host memory for RDMA data transfers
   void *window = nullptr;
   if (posix_memalign(&window, 64, window_bytes) != 0 || window == nullptr) {
     fprintf(stderr,
@@ -79,9 +77,25 @@ int main(int argc, char *argv[]) {
   }
   std::memset(window, 0, window_bytes);
 
-  // Register window buffer - this will automatically set up one-sided handles
+  // Signal buffer: GPU memory for RDMA atomic signal writes (FORCE_SO MR)
+  void *signalWindow = nullptr;
+  flagcxResult_t res = flagcxMemAlloc(&signalWindow, signal_total_bytes, comm);
+  if (res != flagcxSuccess || signalWindow == nullptr) {
+    fprintf(stderr, "[rank %d] flagcxMemAlloc failed for signal (size=%zu)\n",
+            proc, signal_total_bytes);
+    MPI_Abort(MPI_COMM_WORLD, 1);
+  }
+  devHandle->deviceMemset(signalWindow, 0, signal_total_bytes, flagcxMemDevice,
+                          NULL);
+
+  // Register data buffer in global reg pool and for one-sided operations
   void *windowHandle = nullptr;
   flagcxCommRegister(comm, window, window_bytes, &windowHandle);
+  FLAGCXCHECK(flagcxOneSideRegister(comm, window, window_bytes));
+
+  // Register signal buffer for one-sided operations
+  FLAGCXCHECK(
+      flagcxOneSideSignalRegister(comm, signalWindow, signal_total_bytes));
 
   flagcxStream_t stream;
   devHandle->streamCreate(&stream);
@@ -104,11 +118,9 @@ int main(int argc, char *argv[]) {
   flagcxDevCommRequirements reqs = FLAGCX_DEV_COMM_REQUIREMENTS_INITIALIZER;
   FLAGCXCHECK(flagcxDevCommCreate(comm, &reqs, &devComm));
 
-  size_t baseSignalOffset = max_bytes * max_iterations;
-
   // Warm-up iterations
   for (int i = 0; i < num_warmup_iters; ++i) {
-    size_t signalOffset = baseSignalOffset + i * signalBytes;
+    size_t signalOffset = i * signalBytes;
     size_t current_send_offset = i * max_bytes;
     size_t current_recv_offset = i * max_bytes;
 
@@ -125,7 +137,7 @@ int main(int argc, char *argv[]) {
                              devComm, stream);
     } else if (isReceiver) {
       volatile uint64_t *signalAddr =
-          (volatile uint64_t *)((char *)window + signalOffset);
+          (volatile uint64_t *)((char *)signalWindow + signalOffset);
       hostErrorFlag = 0;
       devHandle->deviceMemcpy(deviceErrorFlag, &hostErrorFlag, sizeof(int),
                               flagcxMemcpyHostToDevice, NULL);
@@ -167,7 +179,7 @@ int main(int argc, char *argv[]) {
 
     tim.reset();
     for (int i = 0; i < num_iters; ++i) {
-      size_t signalOffset = baseSignalOffset + i * signalBytes;
+      size_t signalOffset = i * signalBytes;
       size_t current_send_offset = i * size;
       size_t current_recv_offset = i * size;
 
@@ -183,7 +195,7 @@ int main(int argc, char *argv[]) {
                                DATATYPE, receiverRank, devComm, stream);
       } else if (isReceiver) {
         volatile uint64_t *signalAddr =
-            (volatile uint64_t *)((char *)window + signalOffset);
+            (volatile uint64_t *)((char *)signalWindow + signalOffset);
         hostErrorFlag = 0;
         devHandle->deviceMemcpy(deviceErrorFlag, &hostErrorFlag, sizeof(int),
                                 flagcxMemcpyHostToDevice, NULL);
@@ -238,10 +250,14 @@ int main(int argc, char *argv[]) {
   devHandle->deviceFree(srcbuff, flagcxMemDevice, NULL);
   free(hello);
 
+  flagcxOneSideDeregister(comm);
+  flagcxOneSideSignalDeregister(comm);
+
   if (windowHandle != nullptr) {
     flagcxCommDeregister(comm, windowHandle);
   }
   free(window);
+  flagcxMemFree(signalWindow, comm);
 
   devHandle->streamDestroy(stream);
   flagcxCommDestroy(comm);

--- a/test/perf/test_put.cpp
+++ b/test/perf/test_put.cpp
@@ -8,6 +8,7 @@
 #include "device.h"
 #include "flagcx/adaptor/include/adaptor.h"
 #include "flagcx/core/include/flagcx_hetero.h"
+#include "flagcx_kernel.h"
 #include "flagcx_net.h"
 #include "global_comm.h"
 #include "net.h"
@@ -21,10 +22,6 @@
 #include <cstring>
 #include <sched.h>
 #include <unistd.h>
-
-// Forward declaration — defined in flagcx.cc
-extern flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm,
-                                                  void *buff, size_t size);
 
 namespace {
 
@@ -313,6 +310,8 @@ int main(int argc, char *argv[]) {
   res = flagcxCommDeregister(comm, dataHandle);
   fatal(res, "flagcxCommDeregister failed", proc);
 
+  flagcxOneSideDeregister(comm);
+  flagcxOneSideSignalDeregister(comm);
   flagcxMemFree(dataWindow, comm);
   flagcxMemFree(signalWindow, comm);
   free(hostStaging);

--- a/test/perf/test_put.cpp
+++ b/test/perf/test_put.cpp
@@ -7,7 +7,6 @@
 #include "comm.h"
 #include "device.h"
 #include "flagcx/adaptor/include/adaptor.h"
-#include "flagcx/adaptor/include/ib_common.h"
 #include "flagcx/core/include/flagcx_hetero.h"
 #include "flagcx_net.h"
 #include "global_comm.h"
@@ -22,6 +21,10 @@
 #include <cstring>
 #include <sched.h>
 #include <unistd.h>
+
+// Forward declaration — defined in flagcx.cc
+extern flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm,
+                                                  void *buff, size_t size);
 
 namespace {
 
@@ -42,6 +45,14 @@ int main(int argc, char *argv[]) {
   int num_iters = args.getTestIters();
   int print_buffer = args.isPrintBuffer();
   uint64_t split_mask = args.getSplitMask();
+  int local_register = args.getLocalRegister();
+
+  // RMA requires flagcxMemAlloc (GDR memory with SYNC_MEMOPS)
+  if (local_register < 1) {
+    fprintf(stderr,
+            "test_put requires -R 1 or -R 2 for GDR buffer allocation.\n");
+    return 1;
+  }
 
   flagcxHandlerGroup_t handler;
   flagcxHandleInit(&handler);
@@ -84,9 +95,9 @@ int main(int argc, char *argv[]) {
   }
 
   struct flagcxNetAdaptor *netAdaptor = hetero->netAdaptor;
-  if (netAdaptor == nullptr || netAdaptor->put == nullptr) {
+  if (netAdaptor == nullptr || netAdaptor->iput == nullptr) {
     if (proc == 0)
-      fprintf(stderr, "Current network adaptor does not support put\n");
+      fprintf(stderr, "Current network adaptor does not support iput\n");
     MPI_Finalize();
     return 0;
   }
@@ -110,75 +121,56 @@ int main(int argc, char *argv[]) {
   bool isSender = (proc == senderRank);
   bool isReceiver = (proc == receiverRank);
 
-  int sendRank = (proc + 1) % totalProcs;
-  int recvRank = (proc - 1 + totalProcs) % totalProcs;
-
-  // Setup network connections
-  flagcxNetHandle_t listenHandle = {};
-  void *listenComm = nullptr;
-  flagcxResult_t res =
-      netAdaptor->listen(hetero->netDev, &listenHandle, &listenComm);
-  fatal(res, "listen failed", proc);
-
-  flagcxNetHandle_t peerHandle = {};
-  MPI_Sendrecv(&listenHandle, sizeof(listenHandle), MPI_BYTE, recvRank, 100,
-               &peerHandle, sizeof(peerHandle), MPI_BYTE, sendRank, 100,
-               MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-
-  void *sendComm = nullptr;
-  void *recvComm = nullptr;
-  while (sendComm == nullptr || recvComm == nullptr) {
-    if (sendComm == nullptr) {
-      res = netAdaptor->connect(hetero->netDev, &peerHandle, &sendComm);
-      fatal(res, "connect failed", proc);
-    }
-
-    if (recvComm == nullptr) {
-      res = netAdaptor->accept(listenComm, &recvComm);
-      fatal(res, "accept failed", proc);
-    }
-
-    if (sendComm == nullptr || recvComm == nullptr) {
-      sched_yield();
-    }
-  }
-
-  res = netAdaptor->closeListen(listenComm);
-  fatal(res, "closeListen failed", proc);
-
   // Check one-sided extensions support
-  if (netAdaptor->put == nullptr || netAdaptor->putSignal == nullptr ||
-      netAdaptor->waitValue == nullptr || netAdaptor->test == nullptr ||
-      netAdaptor->deregMr == nullptr) {
+  if (netAdaptor->iput == nullptr || netAdaptor->iputSignal == nullptr ||
+      netAdaptor->test == nullptr || netAdaptor->deregMr == nullptr) {
     fprintf(stderr,
             "[rank %d] Net adaptor does not support one-sided extensions\n",
             proc);
     MPI_Abort(MPI_COMM_WORLD, 1);
   }
 
+  flagcxResult_t res;
+
   // Enable one-sided register to set up globalOneSideHandles
   setenv("FLAGCX_ENABLE_ONE_SIDE_REGISTER", "1", 1);
 
   size_t signalBytes = sizeof(uint64_t);
-  size_t max_iterations = std::max(num_warmup_iters, num_iters);
-  size_t window_bytes =
-      max_bytes * max_iterations + signalBytes * max_iterations;
+  size_t total_iters_per_size = num_warmup_iters + num_iters;
+  size_t max_data_iters = std::max(num_warmup_iters, num_iters);
+  size_t data_bytes = max_bytes * max_data_iters;
+  size_t signal_total_bytes = signalBytes * total_iters_per_size;
 
-  void *window = nullptr;
-  if (posix_memalign(&window, 64, window_bytes) != 0 || window == nullptr) {
-    fprintf(stderr,
-            "[rank %d] posix_memalign failed for host window (size=%zu)\n",
-            proc, window_bytes);
+  // Data buffer: GDR memory (SYNC_MEMOPS ensures NIC visibility via GDR BAR)
+  void *dataWindow = nullptr;
+  res = flagcxMemAlloc(&dataWindow, data_bytes, comm);
+  if (res != flagcxSuccess || dataWindow == nullptr) {
+    fprintf(stderr, "[rank %d] flagcxMemAlloc failed for data (size=%zu)\n",
+            proc, data_bytes);
     MPI_Abort(MPI_COMM_WORLD, 1);
   }
-  std::memset(window, 0, window_bytes);
+  devHandle->deviceMemset(dataWindow, 0, data_bytes, flagcxMemDevice, NULL);
 
-  // Register window buffer using flagcxCommRegister
-  void *windowHandle = nullptr;
-  res = flagcxCommRegister(comm, window, window_bytes, &windowHandle);
-  fatal(res, "flagcxCommRegister failed", proc);
+  // Signal buffer: GDR memory (SYNC_MEMOPS for RDMA ATOMIC visibility)
+  void *signalWindow = nullptr;
+  res = flagcxMemAlloc(&signalWindow, signal_total_bytes, comm);
+  if (res != flagcxSuccess || signalWindow == nullptr) {
+    fprintf(stderr, "[rank %d] flagcxMemAlloc failed for signal (size=%zu)\n",
+            proc, signal_total_bytes);
+    MPI_Abort(MPI_COMM_WORLD, 1);
+  }
+  devHandle->deviceMemset(signalWindow, 0, signal_total_bytes, flagcxMemDevice,
+                          NULL);
 
-  void *globalHandles = (void *)globalOneSideHandles;
+  // Register data buffer via flagcxCommRegister → globalOneSideHandles
+  void *dataHandle = nullptr;
+  res = flagcxCommRegister(comm, dataWindow, data_bytes, &dataHandle);
+  fatal(res, "flagcxCommRegister (data) failed", proc);
+
+  // Register signal buffer via flagcxOneSideSignalRegister →
+  // globalOneSideSignalHandles
+  res = flagcxOneSideSignalRegister(comm, signalWindow, signal_total_bytes);
+  fatal(res, "flagcxOneSideSignalRegister failed", proc);
 
   flagcxStream_t stream;
   devHandle->streamCreate(&stream);
@@ -201,68 +193,94 @@ int main(int argc, char *argv[]) {
 
   // Additional barrier to ensure connection is ready
   MPI_Barrier(MPI_COMM_WORLD);
+
+  // Host staging buffer for sender data fill and receiver verification
+  void *hostStaging = nullptr;
+  if (posix_memalign(&hostStaging, 64, max_bytes) != 0 ||
+      hostStaging == nullptr) {
+    fprintf(stderr, "[rank %d] posix_memalign failed for staging (size=%zu)\n",
+            proc, max_bytes);
+    MPI_Abort(MPI_COMM_WORLD, 1);
+  }
+
+  // Create stream for receiver-side wait operations
+  flagcxStream_t waitStream = nullptr;
+  if (isReceiver) {
+    devHandle->streamCreate(&waitStream);
+  }
+
   // Benchmark loop
   timer tim;
-  size_t baseSignalOffset = max_bytes * max_iterations;
   for (size_t size = min_bytes; size <= max_bytes; size *= step_factor) {
     if (size == 0)
       break;
-    // Warmup iterations
+
+    // Reset signal buffer before each size iteration
+    devHandle->deviceMemset(signalWindow, 0, signal_total_bytes,
+                            flagcxMemDevice, NULL);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Warmup iterations (signal slots [0 .. num_warmup_iters-1])
     for (int i = 0; i < num_warmup_iters; ++i) {
-      size_t signalOffset = baseSignalOffset + i * signalBytes;
-      // Use different offset for each iteration to avoid address conflicts
+      size_t signalOffset = i * signalBytes;
       size_t current_send_offset = i * size;
       size_t current_recv_offset = i * size;
 
       if (isSender) {
-
+        // Fill host staging, then copy H2D to device data buffer
         uint8_t value = static_cast<uint8_t>((senderRank + i) & 0xff);
-        std::memset((char *)window + current_send_offset, value, size);
+        std::memset(hostStaging, value, size);
+        devHandle->deviceMemcpy((char *)dataWindow + current_send_offset,
+                                hostStaging, size, flagcxMemcpyHostToDevice,
+                                NULL);
 
-        res = flagcxHeteroPut(comm->heteroComm, receiverRank,
-                              current_send_offset, current_recv_offset, size);
-        fatal(res, "flagcxHeteroPut warmup failed", proc);
-        res = flagcxHeteroPutSignal(hetero, receiverRank, signalOffset);
+        res = flagcxHeteroPutSignal(comm->heteroComm, receiverRank,
+                                    current_send_offset, current_recv_offset,
+                                    size, signalOffset);
         fatal(res, "flagcxHeteroPutSignal warmup failed", proc);
       } else if (isReceiver) {
-        res = netAdaptor->waitValue((void **)globalHandles, receiverRank,
-                                    signalOffset, 1);
-        fatal(res, "netAdaptor->waitValue warmup failed", proc);
+        res = flagcxHeteroWaitSignal(hetero, senderRank, signalOffset, 1,
+                                     waitStream);
+        fatal(res, "flagcxHeteroWaitSignal warmup failed", proc);
+        devHandle->streamSynchronize(waitStream);
       }
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
     tim.reset();
 
-    // Benchmark iterations
+    // Benchmark iterations (signal slots [num_warmup_iters .. total_iters-1])
     for (int i = 0; i < num_iters; ++i) {
-      size_t signalOffset = baseSignalOffset + i * signalBytes;
-      // Use different offset for each iteration to avoid address conflicts
+      size_t signalOffset = (num_warmup_iters + i) * signalBytes;
       size_t current_send_offset = i * size;
       size_t current_recv_offset = i * size;
 
       if (isSender) {
-
         uint8_t value = static_cast<uint8_t>((senderRank + i) & 0xff);
-        std::memset((char *)window + current_send_offset, value, size);
+        std::memset(hostStaging, value, size);
+        devHandle->deviceMemcpy((char *)dataWindow + current_send_offset,
+                                hostStaging, size, flagcxMemcpyHostToDevice,
+                                NULL);
 
-        res = flagcxHeteroPut(comm->heteroComm, receiverRank,
-                              current_send_offset, current_recv_offset, size);
-        fatal(res, "flagcxHeteroPut failed", proc);
-
-        res =
-            flagcxHeteroPutSignal(comm->heteroComm, receiverRank, signalOffset);
+        res = flagcxHeteroPutSignal(comm->heteroComm, receiverRank,
+                                    current_send_offset, current_recv_offset,
+                                    size, signalOffset);
         fatal(res, "flagcxHeteroPutSignal failed", proc);
       } else if (isReceiver) {
-        res = netAdaptor->waitValue((void **)globalHandles, receiverRank,
-                                    signalOffset, 1);
-        fatal(res, "netAdaptor->waitValue failed", proc);
+        res = flagcxHeteroWaitSignal(hetero, senderRank, signalOffset, 1,
+                                     waitStream);
+        fatal(res, "flagcxHeteroWaitSignal failed", proc);
+        devHandle->streamSynchronize(waitStream);
 
         if (print_buffer) {
+          // Copy device data to host for verification
+          devHandle->deviceMemcpy(
+              hostStaging, (char *)dataWindow + current_recv_offset,
+              std::min(size, (size_t)64), flagcxMemcpyDeviceToHost, NULL);
           printf("[rank %d] Received data at offset %zu, size %zu:\n", proc,
                  current_recv_offset, size);
           for (size_t j = 0; j < size && j < 64; ++j) {
-            printf("%02x ", ((unsigned char *)window)[current_recv_offset + j]);
+            printf("%02x ", ((unsigned char *)hostStaging)[j]);
             if ((j + 1) % 16 == 0)
               printf("\n");
           }
@@ -289,26 +307,19 @@ int main(int argc, char *argv[]) {
 
     MPI_Barrier(MPI_COMM_WORLD);
   }
-  // Cleanup: Wait for all operations to complete before closing connections
+  // Cleanup
   MPI_Barrier(MPI_COMM_WORLD);
   sleep(1);
-  res = flagcxCommDeregister(comm, windowHandle);
+  res = flagcxCommDeregister(comm, dataHandle);
   fatal(res, "flagcxCommDeregister failed", proc);
 
-  // Close connections
-  if (sendComm != nullptr) {
-    res = netAdaptor->closeSend(sendComm);
-    if (res != flagcxSuccess) {
-      // Ignore error if already closed or not needed
-    }
+  flagcxMemFree(dataWindow, comm);
+  flagcxMemFree(signalWindow, comm);
+  free(hostStaging);
+
+  if (waitStream != nullptr) {
+    devHandle->streamDestroy(waitStream);
   }
-  if (recvComm != nullptr) {
-    res = netAdaptor->closeRecv(recvComm);
-    if (res != flagcxSuccess) {
-      // Ignore error if already closed or not needed
-    }
-  }
-  free(window);
 
   fatal(flagcxCommDestroy(comm), "flagcxCommDestroy failed", proc);
   fatal(flagcxHandleFree(handler), "flagcxHandleFree failed", proc);

--- a/test/perf/test_put.cpp
+++ b/test/perf/test_put.cpp
@@ -129,9 +129,6 @@ int main(int argc, char *argv[]) {
 
   flagcxResult_t res;
 
-  // Enable one-sided register to set up globalOneSideHandles
-  setenv("FLAGCX_ENABLE_ONE_SIDE_REGISTER", "1", 1);
-
   size_t signalBytes = sizeof(uint64_t);
   size_t total_iters_per_size = num_warmup_iters + num_iters;
   size_t max_data_iters = std::max(num_warmup_iters, num_iters);
@@ -159,13 +156,16 @@ int main(int argc, char *argv[]) {
   devHandle->deviceMemset(signalWindow, 0, signal_total_bytes, flagcxMemDevice,
                           NULL);
 
-  // Register data buffer via flagcxCommRegister → globalOneSideHandles
+  // Register data buffer in global reg pool
   void *dataHandle = nullptr;
   res = flagcxCommRegister(comm, dataWindow, data_bytes, &dataHandle);
   fatal(res, "flagcxCommRegister (data) failed", proc);
 
-  // Register signal buffer via flagcxOneSideSignalRegister →
-  // globalOneSideSignalHandles
+  // Register data buffer for one-sided operations
+  res = flagcxOneSideRegister(comm, dataWindow, data_bytes);
+  fatal(res, "flagcxOneSideRegister (data) failed", proc);
+
+  // Register signal buffer for one-sided operations
   res = flagcxOneSideSignalRegister(comm, signalWindow, signal_total_bytes);
   fatal(res, "flagcxOneSideSignalRegister failed", proc);
 

--- a/test/unittest/main.cpp
+++ b/test/unittest/main.cpp
@@ -353,7 +353,7 @@ TEST_F(FlagCXKernelTest, P2pDemo) {
   // Create device communicator for P2P demo
   // Request IPC barriers — needed by flagcxBarrierSession in the kernel
   flagcxDevCommRequirements reqs = FLAGCX_DEV_COMM_REQUIREMENTS_INITIALIZER;
-  reqs.fields[0] = FLAGCX_DEVICE_CTA_COUNT;
+  reqs.intraBarrierCount = FLAGCX_DEVICE_CTA_COUNT;
   flagcxDevComm_t devComm = nullptr;
   ASSERT_EQ(flagcxDevCommCreate(comm, &reqs, &devComm), flagcxSuccess);
 


### PR DESCRIPTION
### PR Category
CRL

### PR Types
New Features

### PR Description
This PR updates FlagCX’s one-sided RMA path to more closely mirror NCCL GIN semantics by introducing a chained data-write + signal (atomic) operation and splitting data vs. signal memory registrations, while also expanding the device API surface (requirements struct, cooperative groups, properties query).