### PR TITLE
[UIL] fix API version guard in nccl wrapper

### DIFF
--- a/plugin/nccl/README.md
+++ b/plugin/nccl/README.md
@@ -28,7 +28,7 @@ Real NCCL
 
 - **FlagCX** built and installed (the wrapper links against `libflagcx.so`)
 - **CUDA toolkit** (for `cuda_runtime.h` and `libcudart`)
-- **Real NCCL >= 2.21.0** installed somewhere on the system (the wrapper loads it via `dlopen` at runtime). The wrapper uses compile-time version guards (`NCCL_VERSION_CODE`) to adapt to the installed NCCL version — APIs introduced after 2.21.0 are only built when the system headers support them.
+- **Real NCCL >= 2.21.0** installed somewhere on the system (the wrapper loads it via `dlopen` at runtime). Supported NCCL versions: **2.21 through 2.27**. The wrapper uses compile-time version guards (`NCCL_VERSION_CODE`) to adapt to the installed NCCL version — APIs introduced after 2.21.0 are only built when the system headers support them.
 
 ## Building
 
@@ -102,12 +102,14 @@ The following NCCL APIs are intercepted and routed through FlagCX:
 
 The following APIs are exported but return `ncclInvalidUsage` (no FlagCX equivalent):
 
-`ncclBcast`, `ncclCommInitAll`, `ncclCommSplit`, `ncclCommInitRankScalable`, `ncclRedOpCreatePreMulSum`, `ncclRedOpDestroy`
+`ncclBcast`, `ncclCommInitAll`, `ncclCommSplit`, `ncclRedOpCreatePreMulSum`, `ncclRedOpDestroy`
 
 The following APIs are version-gated and only built when the system NCCL headers are new enough:
 
 | API | Minimum NCCL version |
 |---|---|
 | `ncclGroupSimulateEnd` | 2.22.0 |
-| `ncclCommShrink` | 2.25.0 |
+| `ncclCommInitRankScalable` | 2.23.0 |
+| `ncclResetDebugInit` | 2.24.0 |
+| `ncclCommShrink` | 2.27.0 |
 | `ncclCommWindowRegister`, `ncclCommWindowDeregister` | 2.27.0 |

--- a/plugin/nccl/README.md
+++ b/plugin/nccl/README.md
@@ -108,8 +108,8 @@ The following APIs are version-gated and only built when the system NCCL headers
 
 | API | Minimum NCCL version |
 |---|---|
-| `ncclGroupSimulateEnd` | 2.22.0 |
-| `ncclCommInitRankScalable` | 2.23.0 |
-| `ncclResetDebugInit` | 2.24.0 |
-| `ncclCommShrink` | 2.27.0 |
-| `ncclCommWindowRegister`, `ncclCommWindowDeregister` | 2.27.0 |
+| `ncclGroupSimulateEnd` | 2.22.3 |
+| `ncclCommInitRankScalable` | 2.23.4 |
+| `ncclResetDebugInit` | 2.24.3 |
+| `ncclCommShrink` | 2.27.3 |
+| `ncclCommWindowRegister`, `ncclCommWindowDeregister` | 2.27.3 |

--- a/plugin/nccl/src/nccl_wrapper.cc
+++ b/plugin/nccl/src/nccl_wrapper.cc
@@ -765,7 +765,7 @@ ncclResult_t ncclCommSplit(ncclComm_t comm, int color, int key,
   return ncclInvalidUsage;
 }
 
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 25, 0)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
 ncclResult_t ncclCommShrink(ncclComm_t comm, int *excludeRanksList,
                             int excludeRanksCount, ncclComm_t *newcomm,
                             ncclConfig_t *config, int shrinkFlags) {
@@ -773,12 +773,14 @@ ncclResult_t ncclCommShrink(ncclComm_t comm, int *excludeRanksList,
 }
 #endif
 
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 23, 0)
 ncclResult_t ncclCommInitRankScalable(ncclComm_t *newcomm, int nranks,
                                       int myrank, int nId,
                                       ncclUniqueId *commIds,
                                       ncclConfig_t *config) {
   return ncclInvalidUsage;
 }
+#endif
 
 ncclResult_t ncclRedOpCreatePreMulSum(ncclRedOp_t *op, void *scalar,
                                       ncclDataType_t datatype,
@@ -797,5 +799,7 @@ ncclResult_t ncclGroupSimulateEnd(ncclSimInfo_t *simInfo) {
 }
 #endif
 
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 24, 0)
 void ncclResetDebugInit() { /* Deprecated in NCCL, no-op */
 }
+#endif

--- a/plugin/nccl/src/nccl_wrapper.cc
+++ b/plugin/nccl/src/nccl_wrapper.cc
@@ -75,7 +75,7 @@ struct realNccl {
   ncclResult_t (*ncclMemFree)(void *);
   ncclResult_t (*ncclCommRegister)(const ncclComm_t, void *, size_t, void **);
   ncclResult_t (*ncclCommDeregister)(const ncclComm_t, void *);
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 3)
   ncclResult_t (*ncclCommWindowRegister)(ncclComm_t, void *, size_t,
                                          ncclWindow_t *, int);
   ncclResult_t (*ncclCommWindowDeregister)(ncclComm_t, ncclWindow_t);
@@ -136,7 +136,7 @@ static void initRealNccl() {
   LOAD_SYM(ncclMemFree)
   LOAD_SYM(ncclCommRegister)
   LOAD_SYM(ncclCommDeregister)
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 3)
   LOAD_SYM(ncclCommWindowRegister)
   LOAD_SYM(ncclCommWindowDeregister)
 #endif
@@ -531,7 +531,7 @@ ncclResult_t ncclCommDeregister(const ncclComm_t comm, void *handle) {
   return toNcclResult(flagcxCommDeregister(comm->handler->comm, handle));
 }
 
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 3)
 ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void *buff, size_t size,
                                     ncclWindow_t *win, int winFlags) {
   if (inWrapper) {
@@ -765,7 +765,7 @@ ncclResult_t ncclCommSplit(ncclComm_t comm, int color, int key,
   return ncclInvalidUsage;
 }
 
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 0)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 3)
 ncclResult_t ncclCommShrink(ncclComm_t comm, int *excludeRanksList,
                             int excludeRanksCount, ncclComm_t *newcomm,
                             ncclConfig_t *config, int shrinkFlags) {
@@ -773,7 +773,7 @@ ncclResult_t ncclCommShrink(ncclComm_t comm, int *excludeRanksList,
 }
 #endif
 
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 23, 0)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 23, 4)
 ncclResult_t ncclCommInitRankScalable(ncclComm_t *newcomm, int nranks,
                                       int myrank, int nId,
                                       ncclUniqueId *commIds,
@@ -793,13 +793,13 @@ ncclResult_t ncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm) {
   return ncclInvalidUsage;
 }
 
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 22, 0)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 22, 3)
 ncclResult_t ncclGroupSimulateEnd(ncclSimInfo_t *simInfo) {
   return ncclInvalidUsage;
 }
 #endif
 
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 24, 0)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 24, 3)
 void ncclResetDebugInit() { /* Deprecated in NCCL, no-op */
 }
 #endif


### PR DESCRIPTION
### PR Category
<!-- One of [ UIL (User Interface Layer) | CRL (Communication Runtime Layer) | PAL (Portable Abstraction Layer) | CICD | Others ] -->
UIL
### PR Types
<!-- One of [ New Features | Bug Fixes | Optimizations | Deprecations | Test Case | Docs | Others ] -->
Bug Fixes
### PR Description
<!-- Describe what you’ve done -->
This PR fixes some API version guards for APIs in flagcx NCCL wrapper implementation, so that the compiled nccl wrapper contains APIs that match the APIs in the corresponding NCCL header.