### PR TITLE
[CRL] Allow user to disable topology detection

### DIFF
--- a/flagcx/adaptor/ccl/gloo_adaptor.cc
+++ b/flagcx/adaptor/ccl/gloo_adaptor.cc
@@ -90,7 +90,7 @@ flagcxResult_t glooAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
   std::shared_ptr<::gloo::transport::Device> dev;
   flagcxNetProperties_t *properties =
       (flagcxNetProperties_t *)bootstrap->properties;
-  if (flagcxParamGlooIbDisable()) {
+  if (flagcxParamGlooIbDisable() || flagcxDisableTopoDetection()) {
     // Use transport tcp
     ::gloo::transport::tcp::attr attr;
     attr.iface = std::string(bootstrap->bootstrapNetIfName);

--- a/flagcx/adaptor/ccl/gloo_adaptor.cc
+++ b/flagcx/adaptor/ccl/gloo_adaptor.cc
@@ -90,7 +90,7 @@ flagcxResult_t glooAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
   std::shared_ptr<::gloo::transport::Device> dev;
   flagcxNetProperties_t *properties =
       (flagcxNetProperties_t *)bootstrap->properties;
-  if (flagcxParamGlooIbDisable() || flagcxTopoDetectionDisable()) {
+  if (flagcxParamGlooIbDisable() || flagcxParamTopoDetectionDisable()) {
     // Use transport tcp
     ::gloo::transport::tcp::attr attr;
     attr.iface = std::string(bootstrap->bootstrapNetIfName);

--- a/flagcx/adaptor/ccl/gloo_adaptor.cc
+++ b/flagcx/adaptor/ccl/gloo_adaptor.cc
@@ -90,7 +90,7 @@ flagcxResult_t glooAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
   std::shared_ptr<::gloo::transport::Device> dev;
   flagcxNetProperties_t *properties =
       (flagcxNetProperties_t *)bootstrap->properties;
-  if (flagcxParamGlooIbDisable() || flagcxDisableTopoDetection()) {
+  if (flagcxParamGlooIbDisable() || flagcxTopoDetectionDisable()) {
     // Use transport tcp
     ::gloo::transport::tcp::attr attr;
     attr.iface = std::string(bootstrap->bootstrapNetIfName);

--- a/flagcx/core/init.cc
+++ b/flagcx/core/init.cc
@@ -232,7 +232,7 @@ static flagcxResult_t initTransportsRank(flagcxHeteroComm_t comm,
     free(nodesFirstRank);
   }
 
-  if (!flagcxDisableTopoDetection()) {
+  if (!flagcxTopoDetectionDisable()) {
     INFO(FLAGCX_INIT, "start flagcxTopoGetServerTopo");
     FLAGCXCHECKGOTO(flagcxTopoGetServerTopo(comm, &comm->topoServer), ret,
                     fail);

--- a/flagcx/core/init.cc
+++ b/flagcx/core/init.cc
@@ -232,20 +232,27 @@ static flagcxResult_t initTransportsRank(flagcxHeteroComm_t comm,
     free(nodesFirstRank);
   }
 
-  INFO(FLAGCX_INIT, "start flagcxTopoGetServerTopo");
-  FLAGCXCHECKGOTO(flagcxTopoGetServerTopo(comm, &comm->topoServer), ret, fail);
-  FLAGCXCHECKGOTO(flagcxTopoComputePaths(comm->topoServer, comm), ret, fail);
-  if (comm->rank == 0) {
-    FLAGCXCHECK(flagcxTopoPrint(comm->topoServer));
-  }
-  INFO(FLAGCX_INIT, "start getting local net from gpu");
-  FLAGCXCHECKGOTO(flagcxGetLocalNetFromGpu(comm->cudaDev, &comm->netDev, comm),
-                  ret, fail);
+  if (!flagcxDisableTopoDetection()) {
+    INFO(FLAGCX_INIT, "start flagcxTopoGetServerTopo");
+    FLAGCXCHECKGOTO(flagcxTopoGetServerTopo(comm, &comm->topoServer), ret,
+                    fail);
+    FLAGCXCHECKGOTO(flagcxTopoComputePaths(comm->topoServer, comm), ret, fail);
+    if (comm->rank == 0) {
+      FLAGCXCHECK(flagcxTopoPrint(comm->topoServer));
+    }
+    INFO(FLAGCX_INIT, "start getting local net from gpu");
+    FLAGCXCHECKGOTO(
+        flagcxGetLocalNetFromGpu(comm->cudaDev, &comm->netDev, comm), ret,
+        fail);
 
-  INFO(FLAGCX_INIT, "start getting topoServer from other servers");
-  FLAGCXCHECKGOTO(
-      flagcxGetInterServerTopo(comm, &comm->interServerTopo, comm->topoServer),
-      ret, fail);
+    INFO(FLAGCX_INIT, "start getting topoServer from other servers");
+    FLAGCXCHECKGOTO(flagcxGetInterServerTopo(comm, &comm->interServerTopo,
+                                             comm->topoServer),
+                    ret, fail);
+  } else {
+    INFO(FLAGCX_INIT,
+         "topology detection disabled by FLAGCX_DISABLE_TOPO_DETECTION");
+  }
 
   return ret;
 fail:

--- a/flagcx/core/init.cc
+++ b/flagcx/core/init.cc
@@ -232,7 +232,7 @@ static flagcxResult_t initTransportsRank(flagcxHeteroComm_t comm,
     free(nodesFirstRank);
   }
 
-  if (!flagcxTopoDetectionDisable()) {
+  if (!flagcxParamTopoDetectionDisable()) {
     INFO(FLAGCX_INIT, "start flagcxTopoGetServerTopo");
     FLAGCXCHECKGOTO(flagcxTopoGetServerTopo(comm, &comm->topoServer), ret,
                     fail);

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -1390,7 +1390,7 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
 
     // Init host cclAdaptor
     if (useHostComm() || (*comm)->hasSingleRankHomoComm) {
-      if (!flagcxTopoDetectionDisable()) {
+      if (!flagcxParamTopoDetectionDisable()) {
         FLAGCXCHECK((*comm)->heteroComm->netAdaptor->getProperties(
             (*comm)->heteroComm->netDev, state->properties));
       }

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -1390,7 +1390,7 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
 
     // Init host cclAdaptor
     if (useHostComm() || (*comm)->hasSingleRankHomoComm) {
-      if (!flagcxDisableTopoDetection()) {
+      if (!flagcxTopoDetectionDisable()) {
         FLAGCXCHECK((*comm)->heteroComm->netAdaptor->getProperties(
             (*comm)->heteroComm->netDev, state->properties));
       }

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -1390,14 +1390,16 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
 
     // Init host cclAdaptor
     if (useHostComm() || (*comm)->hasSingleRankHomoComm) {
-      FLAGCXCHECK((*comm)->heteroComm->netAdaptor->getProperties(
-          (*comm)->heteroComm->netDev, state->properties));
+      if (!flagcxDisableTopoDetection()) {
+        FLAGCXCHECK((*comm)->heteroComm->netAdaptor->getProperties(
+            (*comm)->heteroComm->netDev, state->properties));
+      }
       FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorHost]->commInitRank(
           &(*comm)->hostComm, nranks, commId, rank, state));
     }
   }
 
-  if (!useHomoComm(*comm) || useHeteroComm()) {
+  if ((!useHomoComm(*comm) || useHeteroComm()) && !useHostComm()) {
     // Experimental for multi-nic support
     // Collect nic distance to ranks
     (*comm)->clusterInterRankList.resize((*comm)->nclusters);

--- a/flagcx/service/include/utils.h
+++ b/flagcx/service/include/utils.h
@@ -39,7 +39,7 @@ uint64_t getHostHash();
 uint64_t getPidHash();
 flagcxResult_t getRandomData(void *buffer, size_t bytes);
 
-bool flagcxDisableTopoDetection();
+bool flagcxTopoDetectionDisable();
 
 const char *flagcxOpToString(flagcxRedOp_t op);
 const char *flagcxDatatypeToString(flagcxDataType_t type);

--- a/flagcx/service/include/utils.h
+++ b/flagcx/service/include/utils.h
@@ -39,6 +39,8 @@ uint64_t getHostHash();
 uint64_t getPidHash();
 flagcxResult_t getRandomData(void *buffer, size_t bytes);
 
+bool flagcxDisableTopoDetection();
+
 const char *flagcxOpToString(flagcxRedOp_t op);
 const char *flagcxDatatypeToString(flagcxDataType_t type);
 const char *flagcxAlgoToString(int algo);

--- a/flagcx/service/include/utils.h
+++ b/flagcx/service/include/utils.h
@@ -39,7 +39,7 @@ uint64_t getHostHash();
 uint64_t getPidHash();
 flagcxResult_t getRandomData(void *buffer, size_t bytes);
 
-bool flagcxTopoDetectionDisable();
+int64_t flagcxParamTopoDetectionDisable();
 
 const char *flagcxOpToString(flagcxRedOp_t op);
 const char *flagcxDatatypeToString(flagcxDataType_t type);

--- a/flagcx/service/utils.cc
+++ b/flagcx/service/utils.cc
@@ -114,6 +114,14 @@ uint64_t getHostHash(void) {
   return getHash(hostHash, strlen(hostHash));
 }
 
+bool flagcxDisableTopoDetection() {
+  const char *env = flagcxGetEnv("FLAGCX_DISABLE_TOPO_DETECTION");
+  if (env) {
+    return std::stoi(env) == 1;
+  }
+  return false;
+}
+
 /* Generate a hash of the unique identifying string for this process
  * that will be unique for both bare-metal and container instances
  * Equivalent of a hash of;

--- a/flagcx/service/utils.cc
+++ b/flagcx/service/utils.cc
@@ -114,8 +114,8 @@ uint64_t getHostHash(void) {
   return getHash(hostHash, strlen(hostHash));
 }
 
-bool flagcxDisableTopoDetection() {
-  const char *env = flagcxGetEnv("FLAGCX_DISABLE_TOPO_DETECTION");
+bool flagcxTopoDetectionDisable() {
+  const char *env = flagcxGetEnv("FLAGCX_TOPO_DETECTION_DISABLE");
   if (env) {
     return std::stoi(env) == 1;
   }

--- a/flagcx/service/utils.cc
+++ b/flagcx/service/utils.cc
@@ -9,6 +9,7 @@
 #include "bootstrap.h"
 #include "core.h"
 #include "flagcx_common.h"
+#include "param.h"
 #include <fstream>
 #include <stdexcept>
 #include <stdlib.h>
@@ -114,13 +115,7 @@ uint64_t getHostHash(void) {
   return getHash(hostHash, strlen(hostHash));
 }
 
-bool flagcxTopoDetectionDisable() {
-  const char *env = flagcxGetEnv("FLAGCX_TOPO_DETECTION_DISABLE");
-  if (env) {
-    return std::stoi(env) == 1;
-  }
-  return false;
-}
+FLAGCX_PARAM(TopoDetectionDisable, "TOPO_DETECTION_DISABLE", 0);
 
 /* Generate a hash of the unique identifying string for this process
  * that will be unique for both bare-metal and container instances


### PR DESCRIPTION
### PR Category
<!-- One of [ UIL (User Interface Layer) | CRL (Communication Runtime Layer) | PAL (Portable Abstraction Layer) | CICD | Others ] -->
CRL
### PR Types
<!-- One of [ New Features | Bug Fixes | Optimizations | Deprecations | Test Case | Docs | Others ] -->
Others
### PR Description
<!-- Describe what you’ve done -->
This PR adds a guard around topology detection section, effectively skipping topology detection if using host comm for communication. This is a fix for the issue #422.