### PR TITLE
[UIL] add auto platform detection for pip install

### DIFF
--- a/plugin/torch/_build_config.py
+++ b/plugin/torch/_build_config.py
@@ -55,6 +55,7 @@ _PLATFORM_COMMANDS = [
     ("mx-smi", "metax"),
     ("hy-smi", "du"),
     ("xpu-smi", "klx"),
+    ("mthreads-gmi", "musa"),
     ("npu-smi", "ascend"),
     ("tsm_smi", "tsm"),
     ("efsmi", "enflame"),

--- a/plugin/torch/_build_config.py
+++ b/plugin/torch/_build_config.py
@@ -57,7 +57,7 @@ _PLATFORM_COMMANDS = [
     ("xpu-smi", "klx"),
     ("npu-smi", "ascend"),
     ("tsm_smi", "tsm"),
-    ("enflame-smi", "enflame"),
+    ("efsmi", "enflame"),
     ("rocm-smi", "amd"),
     ("nvidia-smi", "nvidia"),
 ]

--- a/plugin/torch/_build_config.py
+++ b/plugin/torch/_build_config.py
@@ -7,6 +7,7 @@ class selection logic.
 """
 
 import os
+import shutil
 import sys
 
 from packaging.version import Version, parse as vparse
@@ -46,6 +47,29 @@ ADAPTOR_TO_MAKE_FLAG = {
 
 VALID_ADAPTORS = list(ADAPTOR_MAP.keys())
 
+# Platform detection: command -> adaptor name
+# Order matters: nvidia-smi and rocm-smi last (some platforms are CUDA/ROCm compatible)
+_PLATFORM_COMMANDS = [
+    ("ixsmi", "iluvatar_corex"),
+    ("cnmon", "cambricon"),
+    ("mx-smi", "metax"),
+    ("hy-smi", "du"),
+    ("xpu-smi", "klx"),
+    ("npu-smi", "ascend"),
+    ("tsm_smi", "tsm"),
+    ("enflame-smi", "enflame"),
+    ("rocm-smi", "amd"),
+    ("nvidia-smi", "nvidia"),
+]
+
+
+def _detect_platform():
+    """Auto-detect hardware platform by checking for platform-specific CLI tools."""
+    for cmd, adaptor_name in _PLATFORM_COMMANDS:
+        if shutil.which(cmd) is not None:
+            return adaptor_name
+    return None
+
 
 def detect_adaptor():
     """Detect the adaptor from FLAGCX_ADAPTOR env var, --adaptor CLI arg, or
@@ -69,9 +93,22 @@ def detect_adaptor():
                 adaptor = name
                 break
 
-    # Default
+    # Auto-detect platform
     if not adaptor:
-        adaptor = "nvidia"
+        adaptor = _detect_platform()
+        if adaptor:
+            print(f"[flagcx] Auto-detected platform: {adaptor}")
+
+    # Fail with guidance if nothing detected
+    if not adaptor:
+        print(
+            "\n[flagcx] WARNING: Failed to auto-detect hardware platform.\n"
+            "Please specify the adaptor manually using one of:\n"
+            "  FLAGCX_ADAPTOR=<adaptor> pip install . --no-build-isolation\n"
+            "  pip install . --no-build-isolation --adaptor <adaptor>\n"
+            f"Valid adaptors: {VALID_ADAPTORS}\n"
+        )
+        sys.exit(1)
 
     assert adaptor in VALID_ADAPTORS, f"Invalid adaptor: {adaptor}. Valid: {VALID_ADAPTORS}"
     return adaptor


### PR DESCRIPTION
### PR Category
<!-- One of [ UIL (User Interface Layer) | CRL (Communication Runtime Layer) | PAL (Portable Abstraction Layer) | CICD | Others ] -->
UIL
### PR Types
<!-- One of [ New Features | Bug Fixes | Optimizations | Deprecations | Test Case | Docs | Others ] -->
New Features
### PR Description
<!-- Describe what you’ve done -->
This PR introduces automatic platform detection mechanism during flagcx pip build. This frees the user from manually specifying the platform through env variable when running `pip install`. The mechanism works by checking if the platform-specific command like `nvidia-smi` exists to determine which platform the user is currently operating on. Now, a user can simply run `pip install . --no-build-isolation` to build the vanilla version of flagcx with no advanced feature included. The user can still choose to explicitly specify env variables to enable advanced feature for the build. 