### PR TITLE
Add Device API GET support: Coop-scope wrapper, kernel test, and bug fixes

### DIFF
--- a/flagcx/adaptor/include/device_api/flagcx_device.h
+++ b/flagcx/adaptor/include/device_api/flagcx_device.h
@@ -1878,6 +1878,25 @@ struct flagcxDevNet {
               alreadyReleased, expected_scope);
   }
 
+  // ---- get (Coop-scope, Fallback only) ----
+  // RDMA READ: pull data from remote peer's srcMem into local dstMem.
+  // GIN has no RDMA READ, so this is Fallback-only (no Vendor stub needed).
+  // No fused signal — caller coordinates via separate signal/waitSignal.
+  template <typename Coop = flagcxCoopBlock>
+  FLAGCX_DEVICE_INLINE_DECORATOR void
+  get(flagcxTeam_t team, int peer, const flagcxDevMem &srcMem, size_t srcOffset,
+      const flagcxDevMem &dstMem, size_t dstOffset, size_t bytes,
+      Coop coop = flagcxCoopBlock{}) const {
+    (void)team;
+    coop.sync();
+    if (coop.threadRank() == 0) {
+      size_t srcOff = _toDataOffset(srcMem, srcOffset);
+      size_t dstOff = _toDataOffset(dstMem, dstOffset);
+      get(srcOff, dstOff, bytes, peer, srcMem._mrIndex, dstMem._mrIndex);
+    }
+    coop.sync();
+  }
+
   // ---- putValue (raw ptr) ----
   template <typename T, typename RemoteAction = flagcxDevNet_None,
             typename Coop = flagcxCoopBlock,

--- a/flagcx/adaptor/include/ib_common.h
+++ b/flagcx/adaptor/include/ib_common.h
@@ -130,6 +130,7 @@ struct flagcxIbMrHandle {
 #define FLAGCX_NET_IB_REQ_RECV 2
 #define FLAGCX_NET_IB_REQ_FLUSH 3
 #define FLAGCX_NET_IB_REQ_IPUT 4
+#define FLAGCX_NET_IB_REQ_IGET 5
 
 extern const char *reqTypeStr[];
 

--- a/flagcx/adaptor/net/ibrc_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_adaptor.cc
@@ -602,7 +602,7 @@ fail:
   return ret;
 }
 
-const char *reqTypeStr[] = {"Unused", "Send", "Recv", "Flush"};
+const char *reqTypeStr[] = {"Unused", "Send", "Recv", "Flush", "IPut", "IGet"};
 
 static void flagcxIbAddEvent(struct flagcxIbRequest *req, int devIndex,
                              struct flagcxIbNetCommDevBase *base) {
@@ -2495,7 +2495,7 @@ flagcxResult_t flagcxIbIget(void *sendComm, uint64_t srcOff, uint64_t dstOff,
   int lkey = dstInfo->lkeys[dstRank]; // local key for the destination buffer
   struct flagcxIbRequest *req;
   FLAGCXCHECK(flagcxIbGetRequest(&comm->base, &req));
-  req->type = FLAGCX_NET_IB_REQ_IPUT;
+  req->type = FLAGCX_NET_IB_REQ_IGET;
   req->sock = &comm->base.sock;
   for (int i = 0; i < comm->base.ndevs; i++) {
     req->devBases[i] = &comm->devs[i].base;

--- a/flagcx/core/flagcx_hetero.cc
+++ b/flagcx/core/flagcx_hetero.cc
@@ -78,6 +78,13 @@ flagcxResult_t flagcxHeteroPut(flagcxHeteroComm_t comm, int peer,
   if (comm->netAdaptor == NULL || comm->netAdaptor->iput == NULL)
     return flagcxNotSupported;
 
+  // Validate peer range
+  if (peer < 0 || peer >= comm->nRanks) {
+    WARN("flagcxHeteroPut: peer %d out of range (nRanks=%d)", peer,
+         comm->nRanks);
+    return flagcxInvalidArgument;
+  }
+
   // Get sendComm from full-mesh connections (handle table slot 0 owns them)
   if (globalOneSideHandleCount == 0 ||
       globalOneSideHandleTable[0]->fullSendComms == NULL) {
@@ -121,6 +128,13 @@ flagcxResult_t flagcxHeteroGet(flagcxHeteroComm_t comm, int peer,
                                int srcMrIdx, int dstMrIdx) {
   if (comm->netAdaptor == NULL || comm->netAdaptor->iget == NULL)
     return flagcxNotSupported;
+
+  // Validate peer range
+  if (peer < 0 || peer >= comm->nRanks) {
+    WARN("flagcxHeteroGet: peer %d out of range (nRanks=%d)", peer,
+         comm->nRanks);
+    return flagcxInvalidArgument;
+  }
 
   if (globalOneSideHandleCount == 0 ||
       globalOneSideHandleTable[0]->fullSendComms == NULL) {

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -1945,6 +1945,8 @@ flagcxResult_t flagcxWaitSignal(flagcxComm_t comm, int peer,
                                 flagcxStream_t stream) {
   if (comm == NULL || comm->heteroComm == NULL)
     return flagcxInvalidArgument;
+  if (stream == NULL)
+    return flagcxInvalidArgument;
   return flagcxHeteroWaitSignal(comm->heteroComm, peer, signalOffset, expected,
                                 stream);
 }

--- a/flagcx/include/flagcx_kernel.h
+++ b/flagcx/include/flagcx_kernel.h
@@ -338,17 +338,15 @@ flagcxResult_t flagcxInterTwoSidedAlltoAll(flagcxDevMem_t sendMem,
 
 // Inter-node Device API test kernels.
 // Each kernel tests one API facet; host verifies after streamSynchronize.
-flagcxResult_t flagcxInterTestSignalInc(flagcxDevMem_t sendMem,
-                                        flagcxDevMem_t recvMem, size_t count,
-                                        flagcxDataType_t datatype,
-                                        flagcxDevComm_t devComm,
-                                        flagcxStream_t stream);
+flagcxResult_t flagcxInterTestPutSignalInc(flagcxDevMem_t sendMem,
+                                           flagcxDevMem_t recvMem, size_t count,
+                                           flagcxDataType_t datatype,
+                                           flagcxDevComm_t devComm,
+                                           flagcxStream_t stream);
 
-flagcxResult_t flagcxInterTestSignalAdd(flagcxDevMem_t sendMem,
-                                        flagcxDevMem_t recvMem, size_t count,
-                                        flagcxDataType_t datatype,
-                                        flagcxDevComm_t devComm,
-                                        flagcxStream_t stream);
+flagcxResult_t flagcxInterTestPutSignalAddDecoupled(
+    flagcxDevMem_t sendMem, flagcxDevMem_t recvMem, size_t count,
+    flagcxDataType_t datatype, flagcxDevComm_t devComm, flagcxStream_t stream);
 
 flagcxResult_t
 flagcxInterTestCounterPipeline(flagcxDevMem_t sendMem, flagcxDevMem_t recvMem,
@@ -361,8 +359,8 @@ flagcxResult_t flagcxInterTestPutValue(flagcxDevMem_t recvMem,
                                        flagcxStream_t stream,
                                        size_t putValBase);
 
-flagcxResult_t flagcxInterTestSignalOnly(flagcxDevComm_t devComm,
-                                         flagcxStream_t stream);
+flagcxResult_t flagcxInterTestSignal(flagcxDevComm_t devComm,
+                                     flagcxStream_t stream);
 
 flagcxResult_t
 flagcxInterTestFlushDecouple(flagcxDevMem_t sendMem, flagcxDevMem_t recvMem,
@@ -377,6 +375,12 @@ flagcxResult_t flagcxInterTestMeetShadow(flagcxDevComm_t devComm,
 
 flagcxResult_t flagcxInterTestReset(flagcxDevComm_t devComm,
                                     flagcxStream_t stream, uint64_t *resultBuf);
+
+flagcxResult_t flagcxInterTestGet(flagcxDevMem_t sendMem,
+                                  flagcxDevMem_t recvMem, size_t count,
+                                  flagcxDataType_t datatype,
+                                  flagcxDevComm_t devComm,
+                                  flagcxStream_t stream);
 
 // Kernel launch configuration constants.
 // Also defined in device_api/flagcx_device.h (with same include guard).

--- a/flagcx/kernels/device_api.cu
+++ b/flagcx/kernels/device_api.cu
@@ -321,7 +321,7 @@ ipcAlltoAll(const flagcxDevMem &sendMem, const flagcxDevMem &recvMem,
 
 // put + SignalInc
 FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
-    flagcxInterTestSignalIncKernel(flagcxDevMem sendMem, flagcxDevMem recvMem,
+    flagcxInterTestPutSignalIncKernel(flagcxDevMem sendMem, flagcxDevMem recvMem,
                                    size_t count, flagcxDataType_t datatype,
                                    flagcxDevComm devComm) {
   int nRanks = devComm.getSize();
@@ -368,7 +368,7 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
 // Fallback path: PrimPut + PrimSignal(value=2) (two FIFO entries, slot 0).
 // Contrast with K1 where both paths fuse into a single chained WR.
 FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
-    flagcxInterTestSignalAddKernel(flagcxDevMem sendMem, flagcxDevMem recvMem,
+    flagcxInterTestPutSignalAddDecoupledKernel(flagcxDevMem sendMem, flagcxDevMem recvMem,
                                    size_t count, flagcxDataType_t datatype,
                                    flagcxDevComm devComm) {
   int nRanks = devComm.getSize();
@@ -552,7 +552,7 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
 // signal standalone
 // Each rank signals all other peers on slot 1; waits for nRanks-1 incoming.
 FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
-    flagcxInterTestSignalOnlyKernel(flagcxDevComm devComm) {
+    flagcxInterTestSignalKernel(flagcxDevComm devComm) {
   int nRanks = devComm.getSize();
   int myRank = devComm.getRank();
   int intraSize = devComm.getIntraSize();
@@ -730,7 +730,7 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
 // Host wrappers
 // --------------------------------------------------------------------------
 
-flagcxResult_t flagcxInterTestSignalInc(flagcxDevMem_t sendMem,
+flagcxResult_t flagcxInterTestPutSignalInc(flagcxDevMem_t sendMem,
                                         flagcxDevMem_t recvMem, size_t count,
                                         flagcxDataType_t datatype,
                                         flagcxDevComm_t devComm,
@@ -738,7 +738,7 @@ flagcxResult_t flagcxInterTestSignalInc(flagcxDevMem_t sendMem,
   if (!devComm || !sendMem || !recvMem) return flagcxInternalError;
   flagcxDevComm dc(*devComm);
   flagcxDevMem sm(*sendMem), rm(*recvMem);
-  flagcxInterTestSignalIncKernel
+  flagcxInterTestPutSignalIncKernel
       <<<FLAGCX_DEVICE_CTA_COUNT, FLAGCX_DEVICE_THREADS_PER_CTA, 0,
          *(cudaStream_t *)stream>>>(sm, rm, count, datatype, dc);
   cudaError_t err = cudaGetLastError();
@@ -747,7 +747,7 @@ flagcxResult_t flagcxInterTestSignalInc(flagcxDevMem_t sendMem,
   return err == cudaSuccess ? flagcxSuccess : flagcxUnhandledDeviceError;
 }
 
-flagcxResult_t flagcxInterTestSignalAdd(flagcxDevMem_t sendMem,
+flagcxResult_t flagcxInterTestPutSignalAddDecoupled(flagcxDevMem_t sendMem,
                                         flagcxDevMem_t recvMem, size_t count,
                                         flagcxDataType_t datatype,
                                         flagcxDevComm_t devComm,
@@ -755,7 +755,7 @@ flagcxResult_t flagcxInterTestSignalAdd(flagcxDevMem_t sendMem,
   if (!devComm || !sendMem || !recvMem) return flagcxInternalError;
   flagcxDevComm dc(*devComm);
   flagcxDevMem sm(*sendMem), rm(*recvMem);
-  flagcxInterTestSignalAddKernel
+  flagcxInterTestPutSignalAddDecoupledKernel
       <<<FLAGCX_DEVICE_CTA_COUNT, FLAGCX_DEVICE_THREADS_PER_CTA, 0,
          *(cudaStream_t *)stream>>>(sm, rm, count, datatype, dc);
   cudaError_t err = cudaGetLastError();
@@ -801,11 +801,11 @@ flagcxResult_t flagcxInterTestPutValue(flagcxDevMem_t recvMem,
   return err == cudaSuccess ? flagcxSuccess : flagcxUnhandledDeviceError;
 }
 
-flagcxResult_t flagcxInterTestSignalOnly(flagcxDevComm_t devComm,
+flagcxResult_t flagcxInterTestSignal(flagcxDevComm_t devComm,
                                          flagcxStream_t stream) {
   if (!devComm) return flagcxInternalError;
   flagcxDevComm dc(*devComm);
-  flagcxInterTestSignalOnlyKernel
+  flagcxInterTestSignalKernel
       <<<FLAGCX_DEVICE_CTA_COUNT, FLAGCX_DEVICE_THREADS_PER_CTA, 0,
          *(cudaStream_t *)stream>>>(dc);
   cudaError_t err = cudaGetLastError();
@@ -884,6 +884,76 @@ flagcxResult_t flagcxInterTestReset(flagcxDevComm_t devComm,
   flagcxInterTestResetKernel
       <<<FLAGCX_DEVICE_CTA_COUNT, FLAGCX_DEVICE_THREADS_PER_CTA, 0,
          *(cudaStream_t *)stream>>>(dc, resultBuf);
+  cudaError_t err = cudaGetLastError();
+  advanceIntraEpoch(devComm, 2);
+  devComm->interBarrierEpoch += 2 * devComm->nInterPeers;
+  return err == cudaSuccess ? flagcxSuccess : flagcxUnhandledDeviceError;
+}
+
+// ==========================================================================
+// K8: get AlltoAll
+//
+// Each rank RDMA-READs peer's sendBuff[myRank*size..] into local
+// recvBuff[peer*size..].  Producer fills sendBuff, consumer pulls via get().
+// Synchronized by barrier.  No fused signal — get() has no signal action;
+// the post-barrier ensures completion visibility.
+// ==========================================================================
+
+FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
+    flagcxInterTestGetKernel(flagcxDevMem sendMem, flagcxDevMem recvMem,
+                                     size_t count, flagcxDataType_t datatype,
+                                     flagcxDevComm devComm) {
+  int nRanks = devComm.getSize();
+  int myRank = devComm.getRank();
+  int intraSize = devComm.getIntraSize();
+  int intraBase = myRank - devComm.getIntraRank();
+  flagcxTeam_t intra = flagcxTeamIntra(devComm);
+  size_t size = count * getFlagcxDataTypeSizeDevice(datatype);
+  int tid = FLAGCX_THREAD_IDX_X + FLAGCX_BLOCK_IDX_X * FLAGCX_BLOCK_DIM_X;
+  int nthreads = FLAGCX_BLOCK_DIM_X * FLAGCX_GRID_DIM_X;
+
+  if (devComm._nInterPeers > 0) {
+    flagcxDevNet net(devComm, 0);
+    flagcxBarrierSession<flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagWorld{}, net, FLAGCX_BLOCK_IDX_X);
+    bar.sync(flagcxCoopBlock(), flagcxDeviceMemoryOrderRelaxed);
+
+    // IPC for intra-node peers
+    ipcAlltoAll(sendMem, recvMem, intra, intraSize, intraBase, myRank, size);
+
+    // RDMA READ for inter-node peers: pull from peer's sendMem into my recvMem
+    for (int peer = tid; peer < nRanks; peer += nthreads) {
+      if (peer >= intraBase && peer < intraBase + intraSize) continue;
+      // src: peer's sendBuff at offset myRank*size (peer's data for me)
+      // dst: my recvBuff at offset peer*size (my slot for peer's data)
+      net.get(flagcxTeamWorld(devComm), peer,
+              sendMem, (size_t)myRank * size,
+              recvMem, (size_t)peer * size, size,
+              flagcxCoopThread{});
+    }
+    net.flush(flagcxCoopBlock{});
+    bar.sync(flagcxCoopBlock(), flagcxDeviceMemoryOrderRelaxed);
+  } else {
+    // Intra-only: use IPC
+    flagcxBarrierSession<flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagIntra{}, devComm, FLAGCX_BLOCK_IDX_X);
+    bar.sync(flagcxCoopBlock(), flagcxDeviceMemoryOrderRelaxed);
+    ipcAlltoAll(sendMem, recvMem, intra, intraSize, intraBase, myRank, size);
+    bar.sync(flagcxCoopBlock(), flagcxDeviceMemoryOrderRelaxed);
+  }
+}
+
+flagcxResult_t flagcxInterTestGet(flagcxDevMem_t sendMem,
+                                          flagcxDevMem_t recvMem, size_t count,
+                                          flagcxDataType_t datatype,
+                                          flagcxDevComm_t devComm,
+                                          flagcxStream_t stream) {
+  if (!devComm || !sendMem || !recvMem) return flagcxInternalError;
+  flagcxDevComm dc(*devComm);
+  flagcxDevMem sm(*sendMem), rm(*recvMem);
+  flagcxInterTestGetKernel
+      <<<FLAGCX_DEVICE_CTA_COUNT, FLAGCX_DEVICE_THREADS_PER_CTA, 0,
+         *(cudaStream_t *)stream>>>(sm, rm, count, datatype, dc);
   cudaError_t err = cudaGetLastError();
   advanceIntraEpoch(devComm, 2);
   devComm->interBarrierEpoch += 2 * devComm->nInterPeers;

--- a/test/kernel/test_device_api.cpp
+++ b/test/kernel/test_device_api.cpp
@@ -1,16 +1,17 @@
 /*************************************************************************
  * API correctness test for FlagCX inter-node one-sided Device API.
  *
- * Tests nine kernels, each covering one API facet:
- *   K1: put + SignalInc      (fused data+signal)
- *   K2: put data, SignalAdd (decoupled)
- *   K3: put + CounterInc
- *   K4: putValue
- *   K5: signal standalone
- *   K6: put + flush decoupled
- *   K7: resetSignal + resetCounter
- *   K8: waitSignalFollowShadow
- *   K9: increaseSignalShadow + waitSignalMeetShadow
+ * Tests ten kernels, each covering one API facet:
+ *   K1: putSignalInc          (fused data+signal)
+ *   K2: putSignalAddDecoupled (decoupled data+signal)
+ *   K3: PutValue              (8-byte atomic RDMA WRITE)
+ *   K4: Get                   (RDMA READ alltoall)
+ *   K5: Signal                (signal standalone)
+ *   K6: FlushDecouple         (put + flush decoupled)
+ *   K7: CounterPipeline       (put + CounterInc, two rounds)
+ *   K8: Reset                 (resetSignal + resetCounter)
+ *   K9: FollowShadow          (waitSignalFollowShadow)
+ *   K10: MeetShadow           (increaseSignalShadow + waitSignalMeetShadow)
  *
  * Usage: mpirun -np N ./test_devapi_internode_onesided [options]
  *   -b <minbytes>  -e <maxbytes>  -f <stepfactor>
@@ -63,7 +64,7 @@ static bool verifyAlltoAll(const float *buf, size_t countPerPeer, int nRanks,
   return true;
 }
 
-// Verify K3 counter pipeline:
+// Verify K7 counter pipeline:
 //   hResult[0] == 2 * hResult[1] (counter after 2 rounds, inter peers only)
 //   hResult[1] == nInterRanks as reported by the kernel
 //   recvbuff[src * countPerPeer] == 999.0f  (round-2 sentinel) for all src
@@ -78,7 +79,7 @@ static bool verifyCounterPipeline(const uint64_t *hResult, const float *buf,
   return true;
 }
 
-// Verify K4 putValue result:
+// Verify K3 putValue result:
 // recvbuff at putValBase + src*8 == src * 1000 + myRank
 static bool verifyPutValue(const void *buf, size_t putValBase, int nRanks,
                            int myRank) {
@@ -91,7 +92,7 @@ static bool verifyPutValue(const void *buf, size_t putValBase, int nRanks,
   return true;
 }
 
-// Verify K9 reset: all four entries must be 0
+// Verify K8 reset: all four entries must be 0
 static bool verifyReset(const uint64_t *r) {
   return r[0] == 0 && r[1] == 0 && r[2] == 0 && r[3] == 0;
 }
@@ -184,7 +185,7 @@ int main(int argc, char *argv[]) {
   void *hostBuff = malloc(recvBuffSize);
   memset(hostBuff, 0, recvBuffSize);
 
-  // Device result buffer: 4 × uint64_t used by K3 (counter) and K9 (reset)
+  // Device result buffer: 4 × uint64_t used by K7 (counter) and K8 (reset)
   uint64_t *dResultBuf = nullptr;
   FLAGCXCHECK(devHandle->deviceMalloc(
       (void **)&dResultBuf, 4 * sizeof(uint64_t), flagcxMemDevice, NULL));
@@ -209,10 +210,10 @@ int main(int argc, char *argv[]) {
     printf("# FlagCX Device API Test\n");
     printf("# nRanks: %d, regMode: %s\n", totalProcs,
            localRegister == 2 ? "window" : "ipc");
-    printf("# Kernels: K1=SignalInc  K2=SignalAdd  K4=PutValue"
-           "  K5=SignalOnly\n");
-    printf("#          K6=FlushDecouple  K7=Reset"
-           "  K3=CounterPipeline\n");
+    printf("# Kernels: K1=putSignalInc  K2=putSignalAddDecoupled"
+           "  K3=PutValue  K4=Get\n");
+    printf("#          K5=Signal  K6=FlushDecouple"
+           "  K7=CounterPipeline  K8=Reset\n");
     printf("#\n");
   }
 
@@ -220,12 +221,12 @@ int main(int argc, char *argv[]) {
   for (int i = 0; i < numWarmupIters; i++) {
     size_t cp =
         std::max((size_t)1, maxBytes / sizeof(float) / (size_t)totalProcs);
-    FLAGCXCHECK(flagcxInterTestSignalInc(sendMem, recvMem, cp, DATATYPE,
-                                         devComm, stream));
+    FLAGCXCHECK(flagcxInterTestPutSignalInc(sendMem, recvMem, cp, DATATYPE,
+                                            devComm, stream));
   }
   FLAGCXCHECK(devHandle->streamSynchronize(stream));
 
-  // Initial K9 reset — establishes clean signal/counter/shadow state
+  // Initial K8 reset — establishes clean signal/counter/shadow state
   FLAGCXCHECK(flagcxInterTestReset(devComm, stream, dResultBuf));
   FLAGCXCHECK(devHandle->streamSynchronize(stream));
 
@@ -241,37 +242,82 @@ int main(int argc, char *argv[]) {
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // --- K1: put + SignalInc ---
+    // --- K1: putSignalInc ---
     initSendBuff(sendBuff, countPerPeer, totalProcs, proc, devHandle, stream,
                  hostBuff);
     FLAGCXCHECK(
         devHandle->deviceMemset(recvBuff, 0, floatSize, flagcxMemDevice, NULL));
-    FLAGCXCHECK(flagcxInterTestSignalInc(sendMem, recvMem, countPerPeer,
-                                         DATATYPE, devComm, stream));
+    FLAGCXCHECK(flagcxInterTestPutSignalInc(sendMem, recvMem, countPerPeer,
+                                            DATATYPE, devComm, stream));
     FLAGCXCHECK(devHandle->streamSynchronize(stream));
     FLAGCXCHECK(devHandle->deviceMemcpy(hostBuff, recvBuff, floatSize,
                                         flagcxMemcpyDeviceToHost, NULL));
     bool k1Ok =
         verifyAlltoAll((const float *)hostBuff, countPerPeer, totalProcs, proc);
-    printResult("K1 SignalInc", k1Ok, proc);
+    printResult("K1 putSignalInc", k1Ok, proc);
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // --- K2: put + SignalAdd ---
+    // --- K2: putSignalAddDecoupled ---
     initSendBuff(sendBuff, countPerPeer, totalProcs, proc, devHandle, stream,
                  hostBuff);
     FLAGCXCHECK(
         devHandle->deviceMemset(recvBuff, 0, floatSize, flagcxMemDevice, NULL));
-    FLAGCXCHECK(flagcxInterTestSignalAdd(sendMem, recvMem, countPerPeer,
-                                         DATATYPE, devComm, stream));
+    FLAGCXCHECK(flagcxInterTestPutSignalAddDecoupled(
+        sendMem, recvMem, countPerPeer, DATATYPE, devComm, stream));
     FLAGCXCHECK(devHandle->streamSynchronize(stream));
     FLAGCXCHECK(devHandle->deviceMemcpy(hostBuff, recvBuff, floatSize,
                                         flagcxMemcpyDeviceToHost, NULL));
     bool k2Ok =
         verifyAlltoAll((const float *)hostBuff, countPerPeer, totalProcs, proc);
-    printResult("K2 SignalAdd", k2Ok, proc);
+    printResult("K2 putSignalAddDecoupled", k2Ok, proc);
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // --- K3: CounterInc two-round pipeline ---
+    // --- K3: PutValue ---
+    FLAGCXCHECK(devHandle->deviceMemset((char *)recvBuff + putValBase, 0,
+                                        (size_t)totalProcs * sizeof(uint64_t),
+                                        flagcxMemDevice, NULL));
+    FLAGCXCHECK(flagcxInterTestPutValue(recvMem, devComm, stream, putValBase));
+    FLAGCXCHECK(devHandle->streamSynchronize(stream));
+    FLAGCXCHECK(devHandle->deviceMemcpy(
+        (char *)hostBuff + putValBase, (char *)recvBuff + putValBase,
+        (size_t)totalProcs * sizeof(uint64_t), flagcxMemcpyDeviceToHost, NULL));
+    bool k3Ok = verifyPutValue(hostBuff, putValBase, totalProcs, proc);
+    printResult("K3 PutValue", k3Ok, proc);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // --- K4: Get ---
+    initSendBuff(sendBuff, countPerPeer, totalProcs, proc, devHandle, stream,
+                 hostBuff);
+    FLAGCXCHECK(
+        devHandle->deviceMemset(recvBuff, 0, floatSize, flagcxMemDevice, NULL));
+    FLAGCXCHECK(flagcxInterTestGet(sendMem, recvMem, countPerPeer, DATATYPE,
+                                   devComm, stream));
+    FLAGCXCHECK(devHandle->streamSynchronize(stream));
+    FLAGCXCHECK(devHandle->deviceMemcpy(hostBuff, recvBuff, floatSize,
+                                        flagcxMemcpyDeviceToHost, NULL));
+    bool k4Ok =
+        verifyAlltoAll((const float *)hostBuff, countPerPeer, totalProcs, proc);
+    printResult("K4 Get", k4Ok, proc);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // --- K5: Signal ---
+    FLAGCXCHECK(flagcxInterTestSignal(devComm, stream));
+    FLAGCXCHECK(devHandle->streamSynchronize(stream));
+    printResult("K5 Signal", true, proc); // hang-free = PASS
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // --- K6: FlushDecouple ---
+    initSendBuff(sendBuff, countPerPeer, totalProcs, proc, devHandle, stream,
+                 hostBuff);
+    FLAGCXCHECK(
+        devHandle->deviceMemset(recvBuff, 0, floatSize, flagcxMemDevice, NULL));
+    FLAGCXCHECK(flagcxInterTestFlushDecouple(sendMem, recvMem, countPerPeer,
+                                             DATATYPE, devComm, stream));
+    FLAGCXCHECK(devHandle->streamSynchronize(stream));
+    printResult("K6 FlushDecouple", true, proc); // hang-free = PASS
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // --- K7: CounterPipeline ---
     initSendBuff(sendBuff, countPerPeer, totalProcs, proc, devHandle, stream,
                  hostBuff);
     FLAGCXCHECK(
@@ -284,61 +330,31 @@ int main(int argc, char *argv[]) {
                                         flagcxMemcpyDeviceToHost, NULL));
     FLAGCXCHECK(devHandle->deviceMemcpy(hostBuff, recvBuff, floatSize,
                                         flagcxMemcpyDeviceToHost, NULL));
-    bool k3Ok = verifyCounterPipeline(hResultBuf, (const float *)hostBuff,
+    bool k7Ok = verifyCounterPipeline(hResultBuf, (const float *)hostBuff,
                                       countPerPeer, totalProcs);
-    printResult("K3 CounterPipeline", k3Ok, proc);
-
-    // --- K4: putValue ---
-    // Clear only the putValue area (floatSize area not touched by putValue)
-    FLAGCXCHECK(devHandle->deviceMemset((char *)recvBuff + putValBase, 0,
-                                        (size_t)totalProcs * sizeof(uint64_t),
-                                        flagcxMemDevice, NULL));
-    FLAGCXCHECK(flagcxInterTestPutValue(recvMem, devComm, stream, putValBase));
-    FLAGCXCHECK(devHandle->streamSynchronize(stream));
-    FLAGCXCHECK(devHandle->deviceMemcpy(
-        (char *)hostBuff + putValBase, (char *)recvBuff + putValBase,
-        (size_t)totalProcs * sizeof(uint64_t), flagcxMemcpyDeviceToHost, NULL));
-    bool k4Ok = verifyPutValue(hostBuff, putValBase, totalProcs, proc);
-    printResult("K4 PutValue", k4Ok, proc);
+    printResult("K7 CounterPipeline", k7Ok, proc);
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // --- K5: signal standalone ---
-    FLAGCXCHECK(flagcxInterTestSignalOnly(devComm, stream));
-    FLAGCXCHECK(devHandle->streamSynchronize(stream));
-    printResult("K5 SignalOnly", true, proc); // hang-free = PASS
-    MPI_Barrier(MPI_COMM_WORLD);
-
-    // --- K6: put + flush decoupled ---
-    initSendBuff(sendBuff, countPerPeer, totalProcs, proc, devHandle, stream,
-                 hostBuff);
-    FLAGCXCHECK(
-        devHandle->deviceMemset(recvBuff, 0, floatSize, flagcxMemDevice, NULL));
-    FLAGCXCHECK(flagcxInterTestFlushDecouple(sendMem, recvMem, countPerPeer,
-                                             DATATYPE, devComm, stream));
-    FLAGCXCHECK(devHandle->streamSynchronize(stream));
-    printResult("K6 FlushDecouple", true, proc); // hang-free = PASS
-    MPI_Barrier(MPI_COMM_WORLD);
-
-    // --- K7: resetSignal + resetCounter ---
+    // --- K8: Reset ---
     FLAGCXCHECK(flagcxInterTestReset(devComm, stream, dResultBuf));
     FLAGCXCHECK(devHandle->streamSynchronize(stream));
     FLAGCXCHECK(devHandle->deviceMemcpy(hResultBuf, dResultBuf,
                                         4 * sizeof(uint64_t),
                                         flagcxMemcpyDeviceToHost, NULL));
-    bool k7Ok = verifyReset(hResultBuf);
-    printResult("K7 Reset", k7Ok, proc);
+    bool k8Ok = verifyReset(hResultBuf);
+    printResult("K8 Reset", k8Ok, proc);
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // --- K8: waitSignalFollowShadow (§10.3.5 Part B) ---
+    // --- K9: FollowShadow (§10.3.5 Part B) ---
     // FLAGCXCHECK(flagcxInterTestFollowShadow(devComm, stream));
     // FLAGCXCHECK(devHandle->streamSynchronize(stream));
-    // printResult("K8 FollowShadow", true, proc); // hang-free = PASS
+    // printResult("K9 FollowShadow", true, proc); // hang-free = PASS
     // MPI_Barrier(MPI_COMM_WORLD);
 
-    // --- K9: increaseSignalShadow + waitSignalMeetShadow (§10.3.5 Part A) ---
+    // --- K10: MeetShadow (§10.3.5 Part A) ---
     // FLAGCXCHECK(flagcxInterTestMeetShadow(devComm, stream));
     // FLAGCXCHECK(devHandle->streamSynchronize(stream));
-    // printResult("K9 MeetShadow", true, proc); // hang-free = PASS
+    // printResult("K10 MeetShadow", true, proc); // hang-free = PASS
     // MPI_Barrier(MPI_COMM_WORLD);
 
     if (proc == 0 && color == 0)

--- a/test/perf/Makefile
+++ b/test/perf/Makefile
@@ -150,10 +150,10 @@ run-ipc-sendrecv:
 	@mpirun --allow-run-as-root -np 8 -x UCX_POSIX_USE_PROC_LINK=n -x ${DEV}_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 -x FLAGCX_DEBUG=INFO -x FLAGCX_DEBUG_SUBSYS=ALL ./test_ipc_sendrecv
 
 run-put:
-	@mpirun --allow-run-as-root -np 8 -x UCX_POSIX_USE_PROC_LINK=n -x ${DEV}_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 -x FLAGCX_DEBUG=INFO -x FLAGCX_DEBUG_SUBSYS=ALL ./test_put
+	@mpirun --allow-run-as-root -np 2 -x UCX_POSIX_USE_PROC_LINK=n -x ${DEV}_VISIBLE_DEVICES=0,1 -x FLAGCX_DEBUG=INFO -x FLAGCX_DEBUG_SUBSYS=ALL ./test_put
 
 run-get:
-	@mpirun --allow-run-as-root -np 8 -x UCX_POSIX_USE_PROC_LINK=n -x ${DEV}_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 -x FLAGCX_DEBUG=INFO -x FLAGCX_DEBUG_SUBSYS=ALL ./test_get
+	@mpirun --allow-run-as-root -np 2 -x UCX_POSIX_USE_PROC_LINK=n -x ${DEV}_VISIBLE_DEVICES=0,1 -x FLAGCX_DEBUG=INFO -x FLAGCX_DEBUG_SUBSYS=ALL ./test_get
 
 print_var:
 	@echo "INCLUDEDIR: $(INCLUDEDIR)"

--- a/test/perf/test_get.cpp
+++ b/test/perf/test_get.cpp
@@ -92,6 +92,8 @@ int main(int argc, char *argv[]) {
   if (totalProcs != 2) {
     if (proc == 0)
       printf("test_get requires exactly 2 ranks (producer=0, getter=1).\n");
+    flagcxCommDestroy(comm);
+    flagcxHandleFree(handler);
     MPI_Finalize();
     return 0;
   }


### PR DESCRIPTION
### PR Category
PAL

### PR Types
New Features

### PR Description
This PR adds device-side RDMA READ (“get”) coverage to the inter-node one-sided Device API test suite, and includes a few safety/robustness fixes across the one-sided host API and IB adaptor.