### PR TITLE
Add workflow for syncing code to other sites

### DIFF
--- a/.github/workflows/auto-sync.yaml
+++ b/.github/workflows/auto-sync.yaml
@@ -1,0 +1,35 @@
+name: Sync to remote site
+on:
+
+  workflow_dispatch:
+
+  # Note: use 'push' because we want to cover both manual push
+  # and PR merge events.
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    strategy:
+      matrix:
+        include:
+          - job_name: sync-to-gitcode
+            remote: gitcode.com
+            repository: FlagCX
+            branch: master
+          - job_name: sync-to-gitlink
+            remote: code.gitlink.org.cn
+            repository: FlagCX
+            branch: master
+    name: ${{ matrix.job_name }}
+    uses: flagos-ai/build-infra/.github/workflows/sync-to-remote.yaml@main
+    with:
+      remote: ${{ matrix.remote }}
+      repository: ${{ matrix.repository }}
+      branch: ${{ matrix.branch }}
+    secrets:
+      GITCODE_SSH_KEY: ${{ secrets.GITCODE_SSH_KEY }}


### PR DESCRIPTION
### PR Category

CI/CD

### PR Types

New Features

### PR Description

This PR adds a hook workflow that gets triggered when FlagCX main branch has `push` events (including `push` derived from PR merge). The operations triggered is to sync the latest code to GitCode.com and GitLink.org.cn.