### PR TITLE
[PAL] Support Device API Transport

### DIFF
--- a/flagcx/adaptor/flagcx_device.cc
+++ b/flagcx/adaptor/flagcx_device.cc
@@ -696,9 +696,16 @@ flagcxResult_t flagcxDevCommCreate(flagcxComm_t comm,
     if (ret == flagcxSuccess)
       handle->devComm = innerDevComm;
   }
-  if (handle->devComm != nullptr && handle->intraSize > 0) {
-    int nNodes = handle->nRanks / handle->intraSize;
-    handle->nInterPeers = nNodes - 1;
+  if (handle->devComm != nullptr) {
+    int nNodes = 0;
+    if (comm->heteroComm != nullptr && comm->heteroComm->nNodes > 0) {
+      nNodes = comm->heteroComm->nNodes;
+    } else if (handle->intraSize > 0 &&
+               handle->nRanks % handle->intraSize == 0) {
+      nNodes = handle->nRanks / handle->intraSize;
+    }
+    if (nNodes > 0)
+      handle->nInterPeers = nNodes - 1;
   }
   if (handle->devComm == nullptr) {
     // ---- Fallback path: IPC barriers + inter-node signal relay + one-sided

--- a/flagcx/adaptor/flagcx_device.cc
+++ b/flagcx/adaptor/flagcx_device.cc
@@ -696,6 +696,10 @@ flagcxResult_t flagcxDevCommCreate(flagcxComm_t comm,
     if (ret == flagcxSuccess)
       handle->devComm = innerDevComm;
   }
+  if (handle->devComm != nullptr && handle->intraSize > 0) {
+    int nNodes = handle->nRanks / handle->intraSize;
+    handle->nInterPeers = nNodes - 1;
+  }
   if (handle->devComm == nullptr) {
     // ---- Fallback path: IPC barriers + inter-node signal relay + one-sided
     // ----

--- a/flagcx/adaptor/include/device_api/comm_traits.h
+++ b/flagcx/adaptor/include/device_api/comm_traits.h
@@ -5,7 +5,7 @@
  *
  * Architecture:
  *   PlatformTraits<P>         — platform-level: Intrin, Atomic
- *   CommTraits<D>             — backend-level:  Window, DevComm, Team, ...
+ *   CommTraits<D>             — backend-level:  Window, Comm, Team, ...
  *   Fallback<PlatformTag>     — common IPC fallback (partial specialization)
  *
  * CommTraits pulls in platform capabilities via using-aliases (not
@@ -14,7 +14,7 @@
  * types that work with any platform.
  *
  * Selection:
- *   NVIDIA + NCCL > 2.28:   DeviceAPI = CommTraits<NvidiaVendor>
+ *   NVIDIA + NCCL > 2.28:    DeviceAPI = CommTraits<NvidiaVendor>
  *   NVIDIA + fallback:       DeviceAPI = CommTraits<Fallback<NvidiaPlatform>>
  *
  * Kernel code uses DeviceAPI::* exclusively, no #ifdef branches.
@@ -65,11 +65,11 @@ struct flagcxDevTransport_DescriptorSmem {
 };
 
 // Fence level enum — available on all tiers for unified barrier API
-enum class flagcxGinFenceLevel { Relaxed };
+enum class flagcxTransportFenceLevel { Relaxed };
 
 // ============================================================
 // Unified team/barrier tag types.
-// Used as both DevBarrier<Backend, Tag> template parameter
+// Used as both Barrier<Backend, Tag> template parameter
 // and as ctor dispatch tags — eliminating the old two-tag redundancy.
 // ============================================================
 struct flagcxTeamTagIntra {};
@@ -78,7 +78,7 @@ struct flagcxTeamTagWorld {};
 
 // Primary template — each backend provides specializations
 template <typename Backend, typename Tag, typename Coop>
-struct DevBarrier;
+struct Barrier;
 
 // Vendor specializations + DeviceAPI selection
 #if defined(USE_NVIDIA_ADAPTOR)

--- a/flagcx/adaptor/include/device_api/comm_traits.h
+++ b/flagcx/adaptor/include/device_api/comm_traits.h
@@ -36,31 +36,31 @@ template <typename PlatformTag>
 struct Fallback {};
 
 // ============================================================
-// Action types for one-sided operations (needed by traits Net types).
+// Action types for one-sided operations (needed by traits Transport types).
 // Pure POD structs with no device builtins.
 // ============================================================
-typedef uint32_t flagcxDevNetSignal_t;
-typedef uint32_t flagcxDevNetCounter_t;
+typedef uint32_t flagcxDevTransportSignal_t;
+typedef uint32_t flagcxDevTransportCounter_t;
 
-struct flagcxDevNet_None {};
-struct flagcxDevNet_SignalInc {
-  flagcxDevNetSignal_t signal;
+struct flagcxDevTransport_None {};
+struct flagcxDevTransport_SignalInc {
+  flagcxDevTransportSignal_t signal;
 };
-struct flagcxDevNet_SignalAdd {
-  flagcxDevNetSignal_t signal;
+struct flagcxDevTransport_SignalAdd {
+  flagcxDevTransportSignal_t signal;
   uint64_t value;
 };
-struct flagcxDevNet_CounterInc {
-  flagcxDevNetCounter_t counter;
+struct flagcxDevTransport_CounterInc {
+  flagcxDevTransportCounter_t counter;
 };
 
 // Shared memory descriptor for NIC descriptor optimization.
-// Uses void* on all paths; vendor Net casts to native type in toNccl().
+// Uses void* on all paths; vendor Transport casts to native type in toNccl().
 struct flagcxDescriptorSmem {
   void *_impl = nullptr;
 };
 
-struct flagcxDevNet_DescriptorSmem {
+struct flagcxDevTransport_DescriptorSmem {
   flagcxDescriptorSmem smem;
 };
 
@@ -68,18 +68,16 @@ struct flagcxDevNet_DescriptorSmem {
 enum class flagcxGinFenceLevel { Relaxed };
 
 // ============================================================
-// Barrier tag types for DevBarrier<Backend, Tag> dispatch.
+// Unified team/barrier tag types.
+// Used as both DevBarrier<Backend, Tag> template parameter
+// and as ctor dispatch tags — eliminating the old two-tag redundancy.
 // ============================================================
-struct flagcxBarrierIntra {};
-struct flagcxBarrierInter {};
-struct flagcxBarrierWorld {
-  struct World {}; // tag for world-barrier ctor
-  struct Intra {}; // tag for intra-only ctor
-  struct Inter {}; // tag for inter-only ctor
-};
+struct flagcxTeamTagIntra {};
+struct flagcxTeamTagInter {};
+struct flagcxTeamTagWorld {};
 
 // Primary template — each backend provides specializations
-template <typename Backend, typename BarrierTag, typename Coop>
+template <typename Backend, typename Tag, typename Coop>
 struct DevBarrier;
 
 // Vendor specializations + DeviceAPI selection

--- a/flagcx/adaptor/include/device_api/fallback_comm_traits.h
+++ b/flagcx/adaptor/include/device_api/fallback_comm_traits.h
@@ -6,7 +6,7 @@
  * CommTraits<Fallback<PlatformTag>> provides:
  *   - Intrin, Atomic: inherited from PlatformTraits<PlatformTag> via using
  *   - Window:   IPC peer pointers + raw pointer
- *   - DevComm:  rank/size + IPC barriers + signal buffers
+ *   - Comm:  rank/size + IPC barriers + signal buffers
  *   - Team:     pure arithmetic (nRanks, rank, stride)
  *   - Multimem: placeholder (no multicast)
  *
@@ -73,7 +73,7 @@ struct CommTraits<Fallback<PlatformTag>> {
     }
 
     FLAGCX_HOST_DEVICE_INLINE bool hasAccess() const {
-      return rawPtr != nullptr || peerPtrs != nullptr;
+      return peerPtrs != nullptr;
     }
     FLAGCX_HOST_DEVICE_INLINE void *getRawPtr() const { return rawPtr; }
     FLAGCX_HOST_DEVICE_INLINE void **getDevPeerPtrs() const { return peerPtrs; }
@@ -87,8 +87,8 @@ struct CommTraits<Fallback<PlatformTag>> {
     }
   };
 
-  // ---- DevComm: All fallback layers ----
-  struct DevComm {
+  // ---- Comm: All fallback layers ----
+  struct Comm {
     // Baseline
     int rank, nRanks;
     int intraRank, intraSize;
@@ -127,7 +127,7 @@ struct CommTraits<Fallback<PlatformTag>> {
 
     // Populate from host-side handle (deferred template avoids forward-decl)
     template <typename DI>
-    static FLAGCX_HOST_DEVICE_INLINE void populateFromInternal(DevComm &dc,
+    static FLAGCX_HOST_DEVICE_INLINE void populateFromInternal(Comm &dc,
                                                                const DI &di) {
       dc.rank = di.rank;
       dc.nRanks = di.nRanks;
@@ -171,10 +171,10 @@ struct CommTraits<Fallback<PlatformTag>> {
   // ---- DescriptorSmem: empty on fallback ----
   struct DescriptorSmem {};
 
-  // ---- DevBarrier alias: delegates to standalone DevBarrier<Backend, Tag>
+  // ---- Barrier alias: delegates to standalone Barrier<Backend, Tag>
   // ----
   template <typename Tag, typename Coop>
-  using DevBarrier = ::DevBarrier<Fallback<PlatformTag>, Tag, Coop>;
+  using Barrier = ::Barrier<Fallback<PlatformTag>, Tag, Coop>;
 
   // ============================================================
   // Static FIFO helpers (used by Net and InterBarrierSession)
@@ -257,7 +257,7 @@ struct CommTraits<Fallback<PlatformTag>> {
   // Transport: FIFO-based two-sided + one-sided + GPU-spin signal/counter
   // ============================================================
   struct Transport {
-    DevComm _dc;
+    Comm _dc;
     void *fifoBuffer;
     uint64_t *signalBuffer;
     uint64_t *shadowBuffer;
@@ -267,7 +267,7 @@ struct CommTraits<Fallback<PlatformTag>> {
     int contextId;
 
     FLAGCX_DEVICE_INLINE_DECORATOR
-    Transport(const DevComm &dc, int contextIndex)
+    Transport(const Comm &dc, int contextIndex)
         : _dc(dc), fifoBuffer(dc.fifoBuffer), signalBuffer(dc.signalBuffer),
           shadowBuffer(dc.shadowBuffer), counterBuffer(dc.counterBuffer),
           signalCount(dc.signalCount), counterCount(dc.counterCount) {
@@ -282,20 +282,18 @@ struct CommTraits<Fallback<PlatformTag>> {
 
     // ---- store: write to peer's IPC pointer ----
     template <typename T>
-    FLAGCX_DEVICE_INLINE_DECORATOR void store(const Window &win,
-                                              size_t baseOffset, size_t idx,
-                                              int peer, T val) const {
-      T *ptr = (T *)win.getIntraPointer(baseOffset + idx * sizeof(T), peer);
+    FLAGCX_DEVICE_INLINE_DECORATOR void
+    store(const Window &win, size_t byteOffset, int peer, T val) const {
+      T *ptr = (T *)win.getIntraPointer(byteOffset, peer);
       if (ptr)
         *ptr = val;
     }
 
     // ---- load: read from peer's IPC pointer ----
     template <typename T>
-    FLAGCX_DEVICE_INLINE_DECORATOR T load(const Window &win, size_t baseOffset,
-                                          size_t idx, int peer) const {
-      const T *ptr =
-          (const T *)win.getIntraPointer(baseOffset + idx * sizeof(T), peer);
+    FLAGCX_DEVICE_INLINE_DECORATOR T load(const Window &win, size_t byteOffset,
+                                          int peer) const {
+      const T *ptr = (const T *)win.getIntraPointer(byteOffset, peer);
       return ptr ? *ptr : T{};
     }
 
@@ -737,19 +735,19 @@ struct CommTraits<Fallback<PlatformTag>> {
 };
 
 // ============================================================
-// DevBarrier specializations for Fallback<P>
+// Barrier specializations for Fallback<P>
 //
 // Standalone partial specializations (C++ forbids explicit specialization
 // of member templates inside a partial class specialization).
 // ============================================================
 
-// ---- DevBarrier<Fallback<P>, flagcxTeamTagIntra, Coop> ----
+// ---- Barrier<Fallback<P>, flagcxTeamTagIntra, Coop> ----
 // Thread-striped per-peer inbox barrier using IPC-mapped atomics.
 template <typename P, typename Coop>
-struct DevBarrier<Fallback<P>, flagcxTeamTagIntra, Coop> {
+struct Barrier<Fallback<P>, flagcxTeamTagIntra, Coop> {
   using Atomic = typename PlatformTraits<P>::Atomic;
   using Intrin = typename PlatformTraits<P>::Intrin;
-  using DevComm = typename CommTraits<Fallback<P>>::DevComm;
+  using Comm = typename CommTraits<Fallback<P>>::Comm;
   using Team = typename CommTraits<Fallback<P>>::Team;
   using Multimem = typename CommTraits<Fallback<P>>::Multimem;
 
@@ -762,14 +760,14 @@ struct DevBarrier<Fallback<P>, flagcxTeamTagIntra, Coop> {
 
   // Default ctor (no-op, for barrier composition)
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier()
+  Barrier()
       : _coop(), _peerBuffers(nullptr), _nRanks(0), _myRank(0), _nBarriers(0),
         _ctaIndex(0), _epoch(0) {}
 
   // Active ctor
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, const DevComm &dc, Team team, uint32_t index,
-             bool = false, const Multimem & = {})
+  Barrier(Coop coop, const Comm &dc, Team team, uint32_t index, bool = false,
+          const Multimem & = {})
       : _coop(coop), _peerBuffers(dc.barrierPeers), _nRanks(team.nRanks),
         _myRank(team.rank), _nBarriers(dc.nBarriers), _ctaIndex(index),
         _epoch(dc.intraBarrierEpoch) {}
@@ -812,14 +810,14 @@ struct DevBarrier<Fallback<P>, flagcxTeamTagIntra, Coop> {
   }
 };
 
-// ---- DevBarrier<Fallback<P>, flagcxTeamTagInter, Coop> ----
+// ---- Barrier<Fallback<P>, flagcxTeamTagInter, Coop> ----
 // Inter-node barrier via FIFO BarrierSignal + host-mapped interSignalFlags.
 // Only the inter leader actually sends/waits; non-leaders are no-ops.
 template <typename P, typename Coop>
-struct DevBarrier<Fallback<P>, flagcxTeamTagInter, Coop> {
+struct Barrier<Fallback<P>, flagcxTeamTagInter, Coop> {
   using Atomic = typename PlatformTraits<P>::Atomic;
   using Intrin = typename PlatformTraits<P>::Intrin;
-  using DevComm = typename CommTraits<Fallback<P>>::DevComm;
+  using Comm = typename CommTraits<Fallback<P>>::Comm;
   using Team = typename CommTraits<Fallback<P>>::Team;
   using Transport = typename CommTraits<Fallback<P>>::Transport;
 
@@ -833,14 +831,14 @@ struct DevBarrier<Fallback<P>, flagcxTeamTagInter, Coop> {
 
   // Default ctor (no-op)
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier()
+  Barrier()
       : _coop(), _interSignals(nullptr), _fifoBuffer(nullptr), _nInterPeers(0),
         _isLeader(false), _ctaIndex(0), _epoch(0) {}
 
   // Active ctor
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, const Transport &, const DevComm &dc, Team,
-             uint32_t index, int nInterPeers)
+  Barrier(Coop coop, const Transport &, const Comm &dc, Team, uint32_t index,
+          int nInterPeers)
       : _coop(coop), _interSignals(dc.interSignalFlags),
         _fifoBuffer(dc.fifoBuffer), _nInterPeers(nInterPeers),
         _isLeader(dc.isInterLeader), _ctaIndex(index),
@@ -849,7 +847,7 @@ struct DevBarrier<Fallback<P>, flagcxTeamTagInter, Coop> {
   // arrive: FIFO BarrierSignal (leader only)
   FLAGCX_DEVICE_INLINE_DECORATOR void
   arrive(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-         flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+         flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     _epoch += _nInterPeers;
     _coop.sync();
     if (_coop.threadRank() == 0 && _isLeader) {
@@ -864,7 +862,7 @@ struct DevBarrier<Fallback<P>, flagcxTeamTagInter, Coop> {
   // wait: spin on host-mapped inter signal array (leader only)
   FLAGCX_DEVICE_INLINE_DECORATOR void
   wait(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-       flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+       flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     _coop.sync();
     if (_coop.threadRank() == 0 && _isLeader) {
       int iter = 0;
@@ -879,31 +877,31 @@ struct DevBarrier<Fallback<P>, flagcxTeamTagInter, Coop> {
   // sync = arrive + wait
   FLAGCX_DEVICE_INLINE_DECORATOR void
   sync(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-       flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+       flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     arrive(order);
     wait(order);
   }
 };
 
-// ---- DevBarrier<Fallback<P>, flagcxTeamTagWorld, Coop> ----
+// ---- Barrier<Fallback<P>, flagcxTeamTagWorld, Coop> ----
 // Composes intra + inter barriers.
 // Three-phase pattern for multi-node: intra → inter → intra.
 // Single-node: just one intra sync.
 template <typename P, typename Coop>
-struct DevBarrier<Fallback<P>, flagcxTeamTagWorld, Coop> {
-  using DevComm = typename CommTraits<Fallback<P>>::DevComm;
+struct Barrier<Fallback<P>, flagcxTeamTagWorld, Coop> {
+  using Comm = typename CommTraits<Fallback<P>>::Comm;
   using Team = typename CommTraits<Fallback<P>>::Team;
   using Transport = typename CommTraits<Fallback<P>>::Transport;
 
   Coop _coop;
-  DevBarrier<Fallback<P>, flagcxTeamTagIntra, Coop> _intra;
-  DevBarrier<Fallback<P>, flagcxTeamTagInter, Coop> _inter;
+  Barrier<Fallback<P>, flagcxTeamTagIntra, Coop> _intra;
+  Barrier<Fallback<P>, flagcxTeamTagInter, Coop> _inter;
   int _nInterPeers;
 
   // World barrier: intra (IPC) + inter (FIFO Signal)
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, flagcxTeamTagWorld, const Transport &trans,
-             const DevComm &dc, uint32_t index, bool multimem, int nInterPeers)
+  Barrier(Coop coop, flagcxTeamTagWorld, const Transport &trans, const Comm &dc,
+          uint32_t index, bool multimem, int nInterPeers)
       : _coop(coop),
         _intra(coop, dc, Team{dc.intraSize, dc.intraRank, 1}, index),
         _inter(coop, trans, dc, Team{}, index, nInterPeers),
@@ -911,23 +909,23 @@ struct DevBarrier<Fallback<P>, flagcxTeamTagWorld, Coop> {
 
   // Intra-only barrier: inter is default constructed (no-op)
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, flagcxTeamTagIntra, const Transport &,
-             const DevComm &dc, uint32_t index, bool multimem, int)
+  Barrier(Coop coop, flagcxTeamTagIntra, const Transport &, const Comm &dc,
+          uint32_t index, bool multimem, int)
       : _coop(coop),
         _intra(coop, dc, Team{dc.intraSize, dc.intraRank, 1}, index), _inter(),
         _nInterPeers(0) {}
 
   // Inter-only barrier: intra is default constructed (no-op)
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, flagcxTeamTagInter, const Transport &trans,
-             const DevComm &dc, uint32_t index, bool, int nInterPeers)
+  Barrier(Coop coop, flagcxTeamTagInter, const Transport &trans, const Comm &dc,
+          uint32_t index, bool, int nInterPeers)
       : _coop(coop), _intra(),
         _inter(coop, trans, dc, Team{}, index, nInterPeers),
         _nInterPeers(nInterPeers) {}
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   arrive(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-         flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+         flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     if (_nInterPeers > 0) {
       _intra.arrive(flagcxDeviceMemoryOrderRelease);
       _intra.wait(flagcxDeviceMemoryOrderRelease);
@@ -939,7 +937,7 @@ struct DevBarrier<Fallback<P>, flagcxTeamTagWorld, Coop> {
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   wait(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-       flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+       flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     if (_nInterPeers > 0) {
       _inter.wait(order);
       _intra.arrive(flagcxDeviceMemoryOrderAcquire);
@@ -951,7 +949,7 @@ struct DevBarrier<Fallback<P>, flagcxTeamTagWorld, Coop> {
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   sync(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-       flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+       flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     if (_nInterPeers > 0) {
       // Phase 1: intra sync
       _intra.arrive(flagcxDeviceMemoryOrderRelease);

--- a/flagcx/adaptor/include/device_api/fallback_comm_traits.h
+++ b/flagcx/adaptor/include/device_api/fallback_comm_traits.h
@@ -254,9 +254,10 @@ struct CommTraits<Fallback<PlatformTag>> {
   }
 
   // ============================================================
-  // Net: FIFO-based two-sided + one-sided + GPU-spin signal/counter
+  // Transport: FIFO-based two-sided + one-sided + GPU-spin signal/counter
   // ============================================================
-  struct Net {
+  struct Transport {
+    DevComm _dc;
     void *fifoBuffer;
     uint64_t *signalBuffer;
     uint64_t *shadowBuffer;
@@ -266,12 +267,36 @@ struct CommTraits<Fallback<PlatformTag>> {
     int contextId;
 
     FLAGCX_DEVICE_INLINE_DECORATOR
-    Net(const DevComm &dc, int contextIndex)
-        : fifoBuffer(dc.fifoBuffer), signalBuffer(dc.signalBuffer),
+    Transport(const DevComm &dc, int contextIndex)
+        : _dc(dc), fifoBuffer(dc.fifoBuffer), signalBuffer(dc.signalBuffer),
           shadowBuffer(dc.shadowBuffer), counterBuffer(dc.counterBuffer),
           signalCount(dc.signalCount), counterCount(dc.counterCount) {
       int cnt = (dc.contextCount > 0) ? dc.contextCount : 1;
       contextId = contextIndex % cnt;
+    }
+
+    FLAGCX_DEVICE_INLINE_DECORATOR bool isIntraPeer(int peer) const {
+      int intraBase = _dc.rank - _dc.intraRank;
+      return peer >= intraBase && peer < intraBase + _dc.intraSize;
+    }
+
+    // ---- store: write to peer's IPC pointer ----
+    template <typename T>
+    FLAGCX_DEVICE_INLINE_DECORATOR void store(const Window &win,
+                                              size_t baseOffset, size_t idx,
+                                              int peer, T val) const {
+      T *ptr = (T *)win.getIntraPointer(baseOffset + idx * sizeof(T), peer);
+      if (ptr)
+        *ptr = val;
+    }
+
+    // ---- load: read from peer's IPC pointer ----
+    template <typename T>
+    FLAGCX_DEVICE_INLINE_DECORATOR T load(const Window &win, size_t baseOffset,
+                                          size_t idx, int peer) const {
+      const T *ptr =
+          (const T *)win.getIntraPointer(baseOffset + idx * sizeof(T), peer);
+      return ptr ? *ptr : T{};
     }
 
     // ---- Two-sided FIFO encoders ----
@@ -439,11 +464,11 @@ struct CommTraits<Fallback<PlatformTag>> {
       return false;
     }
     FLAGCX_DEVICE_INLINE_DECORATOR constexpr bool
-    isSignal(flagcxDevNet_SignalInc) const {
+    isSignal(flagcxDevTransport_SignalInc) const {
       return true;
     }
     FLAGCX_DEVICE_INLINE_DECORATOR constexpr bool
-    isSignal(flagcxDevNet_SignalAdd) const {
+    isSignal(flagcxDevTransport_SignalAdd) const {
       return true;
     }
 
@@ -452,11 +477,11 @@ struct CommTraits<Fallback<PlatformTag>> {
       return 0;
     }
     FLAGCX_DEVICE_INLINE_DECORATOR constexpr int
-    getSignalIdx(flagcxDevNet_SignalInc a) const {
+    getSignalIdx(flagcxDevTransport_SignalInc a) const {
       return a.signal;
     }
     FLAGCX_DEVICE_INLINE_DECORATOR constexpr int
-    getSignalIdx(flagcxDevNet_SignalAdd a) const {
+    getSignalIdx(flagcxDevTransport_SignalAdd a) const {
       return a.signal;
     }
 
@@ -465,11 +490,11 @@ struct CommTraits<Fallback<PlatformTag>> {
       return 0;
     }
     FLAGCX_DEVICE_INLINE_DECORATOR constexpr uint32_t
-    getSignalValue(flagcxDevNet_SignalInc) const {
+    getSignalValue(flagcxDevTransport_SignalInc) const {
       return 1;
     }
     FLAGCX_DEVICE_INLINE_DECORATOR constexpr uint32_t
-    getSignalValue(flagcxDevNet_SignalAdd a) const {
+    getSignalValue(flagcxDevTransport_SignalAdd a) const {
       return (uint32_t)a.value;
     }
 
@@ -478,11 +503,11 @@ struct CommTraits<Fallback<PlatformTag>> {
       return false;
     }
     FLAGCX_DEVICE_INLINE_DECORATOR constexpr bool
-    canFuseSignal(flagcxDevNet_SignalInc) const {
+    canFuseSignal(flagcxDevTransport_SignalInc) const {
       return true;
     }
     FLAGCX_DEVICE_INLINE_DECORATOR constexpr bool
-    canFuseSignal(flagcxDevNet_SignalAdd) const {
+    canFuseSignal(flagcxDevTransport_SignalAdd) const {
       return true;
     }
 
@@ -491,7 +516,7 @@ struct CommTraits<Fallback<PlatformTag>> {
       return false;
     }
     FLAGCX_DEVICE_INLINE_DECORATOR constexpr bool
-    isCounter(flagcxDevNet_CounterInc) const {
+    isCounter(flagcxDevTransport_CounterInc) const {
       return true;
     }
 
@@ -500,7 +525,7 @@ struct CommTraits<Fallback<PlatformTag>> {
       return 0;
     }
     FLAGCX_DEVICE_INLINE_DECORATOR constexpr int
-    getCounterIdx(flagcxDevNet_CounterInc a) const {
+    getCounterIdx(flagcxDevTransport_CounterInc a) const {
       return a.counter;
     }
 
@@ -603,7 +628,7 @@ struct CommTraits<Fallback<PlatformTag>> {
     // ---- waitSignal: GPU spin on signalBuffer[ctx*N+id] ----
     template <typename Coop>
     FLAGCX_DEVICE_INLINE_DECORATOR void
-    waitSignal(Coop coop, flagcxDevNetSignal_t signalId, uint64_t least,
+    waitSignal(Coop coop, flagcxDevTransportSignal_t signalId, uint64_t least,
                int bits, flagcxDeviceMemoryOrder_t order) const {
       (void)bits;
       (void)order;
@@ -621,8 +646,8 @@ struct CommTraits<Fallback<PlatformTag>> {
 
     template <typename Coop>
     FLAGCX_DEVICE_INLINE_DECORATOR void
-    waitSignalMeetShadow(Coop coop, flagcxDevNetSignal_t signalId, int bits,
-                         flagcxDeviceMemoryOrder_t order) const {
+    waitSignalMeetShadow(Coop coop, flagcxDevTransportSignal_t signalId,
+                         int bits, flagcxDeviceMemoryOrder_t order) const {
       int idx = contextId * signalCount + (int)signalId;
       uint64_t shadow = ((volatile uint64_t *)shadowBuffer)[idx];
       waitSignal(coop, signalId, shadow, bits, order);
@@ -630,8 +655,9 @@ struct CommTraits<Fallback<PlatformTag>> {
 
     template <typename Coop, typename Uint>
     FLAGCX_DEVICE_INLINE_DECORATOR void
-    waitSignalFollowShadow(Coop coop, flagcxDevNetSignal_t signalId, Uint delta,
-                           Uint *outSignalValue, Uint *outShadowValue, int bits,
+    waitSignalFollowShadow(Coop coop, flagcxDevTransportSignal_t signalId,
+                           Uint delta, Uint *outSignalValue,
+                           Uint *outShadowValue, int bits,
                            flagcxDeviceMemoryOrder_t order) const {
       int idx = contextId * signalCount + (int)signalId;
       uint64_t shadow = ((volatile uint64_t *)shadowBuffer)[idx];
@@ -646,17 +672,18 @@ struct CommTraits<Fallback<PlatformTag>> {
 
     // ---- Shadow manipulation ----
     FLAGCX_DEVICE_INLINE_DECORATOR uint64_t *
-    getSignalShadowPtr(flagcxDevNetSignal_t signalId) const {
+    getSignalShadowPtr(flagcxDevTransportSignal_t signalId) const {
       return &shadowBuffer[contextId * signalCount + (int)signalId];
     }
 
     FLAGCX_DEVICE_INLINE_DECORATOR void
-    increaseSignalShadow(flagcxDevNetSignal_t signalId, uint64_t delta) const {
+    increaseSignalShadow(flagcxDevTransportSignal_t signalId,
+                         uint64_t delta) const {
       shadowBuffer[contextId * signalCount + (int)signalId] += delta;
     }
 
     FLAGCX_DEVICE_INLINE_DECORATOR uint64_t
-    readSignal(flagcxDevNetSignal_t signalId, int bits,
+    readSignal(flagcxDevTransportSignal_t signalId, int bits,
                flagcxDeviceMemoryOrder_t order) const {
       (void)bits;
       (void)order;
@@ -665,7 +692,7 @@ struct CommTraits<Fallback<PlatformTag>> {
     }
 
     FLAGCX_DEVICE_INLINE_DECORATOR void
-    resetSignal(flagcxDevNetSignal_t signalId) const {
+    resetSignal(flagcxDevTransportSignal_t signalId) const {
       int idx = contextId * signalCount + (int)signalId;
       Atomic::store(&signalBuffer[idx], (uint64_t)0,
                     flagcxDeviceMemoryOrderRelease);
@@ -674,8 +701,9 @@ struct CommTraits<Fallback<PlatformTag>> {
     // ---- Counter: GPU spin on counterBuffer[ctx*N+id] ----
     template <typename Coop>
     FLAGCX_DEVICE_INLINE_DECORATOR void
-    waitCounter(Coop coop, flagcxDevNetCounter_t counterId, uint64_t least,
-                int bits, flagcxDeviceMemoryOrder_t order) const {
+    waitCounter(Coop coop, flagcxDevTransportCounter_t counterId,
+                uint64_t least, int bits,
+                flagcxDeviceMemoryOrder_t order) const {
       (void)bits;
       (void)order;
       coop.sync();
@@ -691,7 +719,7 @@ struct CommTraits<Fallback<PlatformTag>> {
     }
 
     FLAGCX_DEVICE_INLINE_DECORATOR uint64_t
-    readCounter(flagcxDevNetCounter_t counterId, int bits,
+    readCounter(flagcxDevTransportCounter_t counterId, int bits,
                 flagcxDeviceMemoryOrder_t order) const {
       (void)bits;
       (void)order;
@@ -700,7 +728,7 @@ struct CommTraits<Fallback<PlatformTag>> {
     }
 
     FLAGCX_DEVICE_INLINE_DECORATOR void
-    resetCounter(flagcxDevNetCounter_t counterId) const {
+    resetCounter(flagcxDevTransportCounter_t counterId) const {
       int idx = contextId * counterCount + (int)counterId;
       Atomic::store(&counterBuffer[idx], (uint64_t)0,
                     flagcxDeviceMemoryOrderRelease);
@@ -715,10 +743,10 @@ struct CommTraits<Fallback<PlatformTag>> {
 // of member templates inside a partial class specialization).
 // ============================================================
 
-// ---- DevBarrier<Fallback<P>, flagcxBarrierIntra, Coop> ----
+// ---- DevBarrier<Fallback<P>, flagcxTeamTagIntra, Coop> ----
 // Thread-striped per-peer inbox barrier using IPC-mapped atomics.
 template <typename P, typename Coop>
-struct DevBarrier<Fallback<P>, flagcxBarrierIntra, Coop> {
+struct DevBarrier<Fallback<P>, flagcxTeamTagIntra, Coop> {
   using Atomic = typename PlatformTraits<P>::Atomic;
   using Intrin = typename PlatformTraits<P>::Intrin;
   using DevComm = typename CommTraits<Fallback<P>>::DevComm;
@@ -784,16 +812,16 @@ struct DevBarrier<Fallback<P>, flagcxBarrierIntra, Coop> {
   }
 };
 
-// ---- DevBarrier<Fallback<P>, flagcxBarrierInter, Coop> ----
+// ---- DevBarrier<Fallback<P>, flagcxTeamTagInter, Coop> ----
 // Inter-node barrier via FIFO BarrierSignal + host-mapped interSignalFlags.
 // Only the inter leader actually sends/waits; non-leaders are no-ops.
 template <typename P, typename Coop>
-struct DevBarrier<Fallback<P>, flagcxBarrierInter, Coop> {
+struct DevBarrier<Fallback<P>, flagcxTeamTagInter, Coop> {
   using Atomic = typename PlatformTraits<P>::Atomic;
   using Intrin = typename PlatformTraits<P>::Intrin;
   using DevComm = typename CommTraits<Fallback<P>>::DevComm;
   using Team = typename CommTraits<Fallback<P>>::Team;
-  using Net = typename CommTraits<Fallback<P>>::Net;
+  using Transport = typename CommTraits<Fallback<P>>::Transport;
 
   Coop _coop;
   uint64_t *_interSignals;
@@ -811,8 +839,8 @@ struct DevBarrier<Fallback<P>, flagcxBarrierInter, Coop> {
 
   // Active ctor
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, const Net &net, const DevComm &dc, Team, uint32_t index,
-             int nInterPeers)
+  DevBarrier(Coop coop, const Transport &, const DevComm &dc, Team,
+             uint32_t index, int nInterPeers)
       : _coop(coop), _interSignals(dc.interSignalFlags),
         _fifoBuffer(dc.fifoBuffer), _nInterPeers(nInterPeers),
         _isLeader(dc.isInterLeader), _ctaIndex(index),
@@ -857,33 +885,33 @@ struct DevBarrier<Fallback<P>, flagcxBarrierInter, Coop> {
   }
 };
 
-// ---- DevBarrier<Fallback<P>, flagcxBarrierWorld, Coop> ----
+// ---- DevBarrier<Fallback<P>, flagcxTeamTagWorld, Coop> ----
 // Composes intra + inter barriers.
 // Three-phase pattern for multi-node: intra → inter → intra.
 // Single-node: just one intra sync.
 template <typename P, typename Coop>
-struct DevBarrier<Fallback<P>, flagcxBarrierWorld, Coop> {
+struct DevBarrier<Fallback<P>, flagcxTeamTagWorld, Coop> {
   using DevComm = typename CommTraits<Fallback<P>>::DevComm;
   using Team = typename CommTraits<Fallback<P>>::Team;
-  using Net = typename CommTraits<Fallback<P>>::Net;
+  using Transport = typename CommTraits<Fallback<P>>::Transport;
 
   Coop _coop;
-  DevBarrier<Fallback<P>, flagcxBarrierIntra, Coop> _intra;
-  DevBarrier<Fallback<P>, flagcxBarrierInter, Coop> _inter;
+  DevBarrier<Fallback<P>, flagcxTeamTagIntra, Coop> _intra;
+  DevBarrier<Fallback<P>, flagcxTeamTagInter, Coop> _inter;
   int _nInterPeers;
 
   // World barrier: intra (IPC) + inter (FIFO Signal)
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, flagcxBarrierWorld::World, const Net &net,
+  DevBarrier(Coop coop, flagcxTeamTagWorld, const Transport &trans,
              const DevComm &dc, uint32_t index, bool multimem, int nInterPeers)
       : _coop(coop),
         _intra(coop, dc, Team{dc.intraSize, dc.intraRank, 1}, index),
-        _inter(coop, net, dc, Team{}, index, nInterPeers),
+        _inter(coop, trans, dc, Team{}, index, nInterPeers),
         _nInterPeers(nInterPeers) {}
 
   // Intra-only barrier: inter is default constructed (no-op)
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, flagcxBarrierWorld::Intra, const Net &,
+  DevBarrier(Coop coop, flagcxTeamTagIntra, const Transport &,
              const DevComm &dc, uint32_t index, bool multimem, int)
       : _coop(coop),
         _intra(coop, dc, Team{dc.intraSize, dc.intraRank, 1}, index), _inter(),
@@ -891,10 +919,10 @@ struct DevBarrier<Fallback<P>, flagcxBarrierWorld, Coop> {
 
   // Inter-only barrier: intra is default constructed (no-op)
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, flagcxBarrierWorld::Inter, const Net &net,
+  DevBarrier(Coop coop, flagcxTeamTagInter, const Transport &trans,
              const DevComm &dc, uint32_t index, bool, int nInterPeers)
       : _coop(coop), _intra(),
-        _inter(coop, net, dc, Team{}, index, nInterPeers),
+        _inter(coop, trans, dc, Team{}, index, nInterPeers),
         _nInterPeers(nInterPeers) {}
 
   FLAGCX_DEVICE_INLINE_DECORATOR void

--- a/flagcx/adaptor/include/device_api/flagcx_device.h
+++ b/flagcx/adaptor/include/device_api/flagcx_device.h
@@ -25,7 +25,7 @@
 
 // Device traits — provides DeviceAPI with all type/function dispatch.
 // Also defines FLAGCX_DEVICE_API_VENDOR when vendor backend is active.
-// Action types (flagcxDevNet_*, flagcxDescriptorSmem, etc.) are defined
+// Action types (flagcxDevTransport_*, flagcxDescriptorSmem, etc.) are defined
 // inside comm_traits.h before the backend-specific trait includes.
 #include "comm_traits.h"
 
@@ -209,10 +209,12 @@ struct flagcxDevComm {
 // ============================================================
 struct flagcxDevMem {
   typename DeviceAPI::Window _winBase;
+  void *_rawPtr;
 
-  FLAGCX_HOST_DEVICE_INLINE flagcxDevMem() : _winBase() {}
+  FLAGCX_HOST_DEVICE_INLINE flagcxDevMem() : _winBase(), _rawPtr(nullptr) {}
 
-  FLAGCX_HOST_DEVICE_INLINE flagcxDevMem(const flagcxDevMemInternal &di) {
+  FLAGCX_HOST_DEVICE_INLINE flagcxDevMem(const flagcxDevMemInternal &di)
+      : _rawPtr(di.rawPtr) {
     if (di.window)
       _winBase = *(typename DeviceAPI::Window *)di.window;
   }
@@ -220,9 +222,7 @@ struct flagcxDevMem {
   FLAGCX_HOST_DEVICE_INLINE bool hasWindow() const {
     return _winBase.hasAccess();
   }
-  FLAGCX_HOST_DEVICE_INLINE void *getRawPtr() const {
-    return _winBase.getRawPtr();
-  }
+  FLAGCX_HOST_DEVICE_INLINE void *getRawPtr() const { return _rawPtr; }
   FLAGCX_HOST_DEVICE_INLINE void **getDevPeerPtrs() const {
     return _winBase.getDevPeerPtrs();
   }
@@ -284,10 +284,7 @@ struct flagcxInterBarrierHandle {
 };
 typedef struct flagcxInterBarrierHandle flagcxInterBarrierHandle_t;
 
-// Team tag types for barrier session constructors
-struct flagcxTeamTagWorld {};
-struct flagcxTeamTagIntra {};
-struct flagcxTeamTagInter {};
+// Team tag types for barrier session constructors are defined in comm_traits.h
 
 // ============================================================
 // Sections 5-8: Device-only functions
@@ -591,8 +588,8 @@ struct flagcxDevBarrier;
 
 // ---- Intra ----
 template <typename Coop>
-struct flagcxDevBarrier<flagcxBarrierIntra, Coop> {
-  typename DeviceAPI::template DevBarrier<flagcxBarrierIntra, Coop> _impl;
+struct flagcxDevBarrier<flagcxTeamTagIntra, Coop> {
+  typename DeviceAPI::template DevBarrier<flagcxTeamTagIntra, Coop> _impl;
 
   FLAGCX_DEVICE_INLINE_DECORATOR
   flagcxDevBarrier() : _impl() {}
@@ -815,236 +812,192 @@ FLAGCX_HOST_DEVICE_INLINE bool operator!=(flagcxSymPtr<T> a,
 #endif
 
 // ============================================================
-// Sections 9b-12: flagcxDevNet + Barriers (device-only)
+// Sections 9b-12: flagcxDevTransport + Barriers (device-only)
 // ============================================================
 #ifdef FLAGCX_DEVICE_COMPILE
 
 // ============================================================
-// Section 10: flagcxDevNet — Device Network (thin wrapper)
+// Section 10: flagcxDevTransport — Device Transport
 //
-// Delegates all operations to DeviceAPI::Net which contains
-// backend-specific logic (vendor ncclGin or fallback FIFO).
-// No #ifdef FLAGCX_DEVICE_API_VENDOR in this struct.
+// Thin wrapper around DeviceAPI::Transport. Adds flagcxDevComm-accepting
+// ctor and flagcxDevMem-accepting load/store overloads, defined here
+// after flagcxDevComm and flagcxDevMem are fully defined.
 // ============================================================
-struct flagcxDevNet {
-  const flagcxDevComm &_devComm; // for barrier sessions
-  typename DeviceAPI::Net _netBase;
-  int _contextId;
+struct flagcxDevTransport : DeviceAPI::Transport {
+  int _nInterPeers;
 
   FLAGCX_DEVICE_INLINE_DECORATOR
-  flagcxDevNet(const flagcxDevComm &dc, int contextIndex = 0)
-      : _devComm(dc), _netBase(dc._commBase, contextIndex) {
-    int cnt = (dc._contextCount > 0) ? dc._contextCount : 1;
-    _contextId = contextIndex % cnt;
+  flagcxDevTransport(const flagcxDevComm &devComm, int idx)
+      : DeviceAPI::Transport(devComm._commBase, idx),
+        _nInterPeers(devComm._nInterPeers) {}
+
+  template <typename T>
+  FLAGCX_DEVICE_INLINE_DECORATOR T load(const flagcxDevMem &mem,
+                                        size_t baseOffset, size_t idx,
+                                        int peer) const {
+    return DeviceAPI::Transport::load<T>(mem._winBase, baseOffset, idx, peer);
   }
 
-  // ---- Two-sided operations ----
-  template <typename Coop>
-  FLAGCX_DEVICE_INLINE_DECORATOR flagcxResult_t
-  send(Coop coop, const flagcxDevMem &mem, size_t offset, size_t count,
-       flagcxDataType_t datatype, int peer) const {
-    return _netBase.send(coop._base, mem._winBase, offset, count, datatype,
-                         peer);
-  }
-  template <typename Coop>
-  FLAGCX_DEVICE_INLINE_DECORATOR flagcxResult_t
-  recv(Coop coop, const flagcxDevMem &mem, size_t offset, size_t count,
-       flagcxDataType_t datatype, int peer) const {
-    return _netBase.recv(coop._base, mem._winBase, offset, count, datatype,
-                         peer);
-  }
-  template <typename Coop>
-  FLAGCX_DEVICE_INLINE_DECORATOR flagcxResult_t term(Coop coop) const {
-    return _netBase.term(coop._base);
-  }
-  template <typename Coop>
-  FLAGCX_DEVICE_INLINE_DECORATOR flagcxResult_t wait(Coop coop) const {
-    return _netBase.wait(coop._base);
+  template <typename T>
+  FLAGCX_DEVICE_INLINE_DECORATOR void store(const flagcxDevMem &mem,
+                                            size_t baseOffset, size_t idx,
+                                            int peer, T val) const {
+    DeviceAPI::Transport::store(mem._winBase, baseOffset, idx, peer, val);
   }
 
-  // ---- One-sided: put (raw ptr) ----
-  template <typename RemoteAction = flagcxDevNet_None,
-            typename LocalAction = flagcxDevNet_None,
-            typename Coop = flagcxCoopBlock,
-            typename DescriptorSmem = flagcxDevNet_None>
-  FLAGCX_DEVICE_INLINE_DECORATOR void
-  put(flagcxTeam_t team, int peer, const flagcxDevMem &dstMem, size_t dstOffset,
-      const flagcxDevMem &srcMem, size_t srcOffset, size_t bytes,
-      RemoteAction remoteAction = flagcxDevNet_None{},
-      LocalAction localAction = flagcxDevNet_None{},
-      Coop coop = flagcxCoopBlock{},
-      DescriptorSmem descriptor = flagcxDevNet_None{},
-      flagcxDeviceScope_t alreadyReleased = flagcxDeviceScopeThread,
-      flagcxDeviceScope_t expectedScope = flagcxDeviceScopeDevice) const {
-    _netBase.put(team._teamBase, peer, dstMem._winBase, dstOffset,
-                 srcMem._winBase, srcOffset, bytes, remoteAction, localAction,
-                 coop._base, descriptor, alreadyReleased, expectedScope);
+  FLAGCX_DEVICE_INLINE_DECORATOR uint64_t readSignal(
+      flagcxDevTransportSignal_t signalId, int bits = 64,
+      flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcquire) const {
+    return DeviceAPI::Transport::readSignal(signalId, bits, order);
   }
 
-  // ---- One-sided: put (SymPtr) ----
-  template <typename T, typename RemoteAction = flagcxDevNet_None,
-            typename LocalAction = flagcxDevNet_None,
-            typename Coop = flagcxCoopBlock,
-            typename DescriptorSmem = flagcxDevNet_None>
-  FLAGCX_DEVICE_INLINE_DECORATOR void
-  put(flagcxTeam_t team, int peer, flagcxSymPtr<T> dst, flagcxSymPtr<T> src,
-      size_t nElts, RemoteAction remoteAction = flagcxDevNet_None{},
-      LocalAction localAction = flagcxDevNet_None{},
-      Coop coop = flagcxCoopBlock{},
-      DescriptorSmem descriptor = flagcxDevNet_None{},
-      flagcxDeviceScope_t alreadyReleased = flagcxDeviceScopeThread,
-      flagcxDeviceScope_t expectedScope = flagcxDeviceScopeDevice) const {
-    this->put(team, peer, dst.mem, dst.offset, src.mem, src.offset,
-              nElts * sizeof(T), remoteAction, localAction, coop, descriptor,
-              alreadyReleased, expectedScope);
-  }
-
-  // ---- One-sided: putValue (raw ptr) ----
-  template <typename T, typename RemoteAction = flagcxDevNet_None,
-            typename Coop = flagcxCoopBlock,
-            typename DescriptorSmem = flagcxDevNet_None>
-  FLAGCX_DEVICE_INLINE_DECORATOR void
-  putValue(flagcxTeam_t team, int peer, const flagcxDevMem &dstMem,
-           size_t dstOffset, T value,
-           RemoteAction remoteAction = flagcxDevNet_None{},
-           Coop coop = flagcxCoopBlock{},
-           DescriptorSmem descriptor = flagcxDevNet_None{},
-           flagcxDeviceScope_t alreadyReleased = flagcxDeviceScopeThread,
-           flagcxDeviceScope_t expectedScope = flagcxDeviceScopeDevice) const {
-    _netBase.putValue(team._teamBase, peer, dstMem._winBase, dstOffset, value,
-                      remoteAction, coop._base, descriptor, alreadyReleased,
-                      expectedScope);
-  }
-
-  // ---- One-sided: putValue (SymPtr) ----
-  template <typename T, typename RemoteAction = flagcxDevNet_None,
-            typename Coop = flagcxCoopBlock,
-            typename DescriptorSmem = flagcxDevNet_None>
-  FLAGCX_DEVICE_INLINE_DECORATOR void
-  putValue(flagcxTeam_t team, int peer, flagcxSymPtr<T> dst, T value,
-           RemoteAction remoteAction = flagcxDevNet_None{},
-           Coop coop = flagcxCoopBlock{},
-           DescriptorSmem descriptor = flagcxDevNet_None{},
-           flagcxDeviceScope_t alreadyReleased = flagcxDeviceScopeThread,
-           flagcxDeviceScope_t expectedScope = flagcxDeviceScopeDevice) const {
-    this->putValue(team, peer, dst.mem, dst.offset, value, remoteAction, coop,
-                   descriptor, alreadyReleased, expectedScope);
-  }
-
-  // ---- One-sided: signal ----
-  template <typename RemoteAction, typename Coop = flagcxCoopBlock,
-            typename DescriptorSmem = flagcxDevNet_None>
-  FLAGCX_DEVICE_INLINE_DECORATOR void
-  signal(flagcxTeam_t team, int peer, RemoteAction remoteAction,
-         Coop coop = flagcxCoopBlock{},
-         DescriptorSmem descriptor = flagcxDevNet_None{},
-         flagcxDeviceScope_t alreadyReleased = flagcxDeviceScopeThread,
-         flagcxDeviceScope_t expectedScope = flagcxDeviceScopeDevice) const {
-    _netBase.signal(team._teamBase, peer, remoteAction, coop._base, descriptor,
-                    alreadyReleased, expectedScope);
-  }
-
-  // ---- One-sided: flush ----
   template <typename Coop>
   FLAGCX_DEVICE_INLINE_DECORATOR void flush(
       Coop coop,
       flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcquire) const {
-    _netBase.flush(coop._base, order);
+    DeviceAPI::Transport::flush(coop._base, order);
   }
 
-  // ---- One-sided: get (Fallback only, vendor stub exists for compilation)
-  // ----
-  template <typename Coop = flagcxCoopBlock>
-  FLAGCX_DEVICE_INLINE_DECORATOR void
-  get(flagcxTeam_t team, int peer, const flagcxDevMem &srcMem, size_t srcOffset,
-      const flagcxDevMem &dstMem, size_t dstOffset, size_t bytes,
-      Coop coop = flagcxCoopBlock{}) const {
-    _netBase.get(team._teamBase, peer, srcMem._winBase, srcOffset,
-                 dstMem._winBase, dstOffset, bytes, coop._base);
-  }
-
-  // ---- Signal operations ----
   template <typename Coop>
   FLAGCX_DEVICE_INLINE_DECORATOR void waitSignal(
-      Coop coop, flagcxDevNetSignal_t signal, uint64_t least, int bits = 64,
+      Coop coop, flagcxDevTransportSignal_t signalId, uint64_t least,
+      int bits = 64,
       flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcquire) const {
-    _netBase.waitSignal(coop._base, signal, least, bits, order);
+    DeviceAPI::Transport::waitSignal(coop._base, signalId, least, bits, order);
   }
 
   template <typename Coop>
   FLAGCX_DEVICE_INLINE_DECORATOR void waitSignalMeetShadow(
-      Coop coop, flagcxDevNetSignal_t signal, int bits = 64,
+      Coop coop, flagcxDevTransportSignal_t signalId, int bits = 64,
       flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcquire) const {
-    _netBase.waitSignalMeetShadow(coop._base, signal, bits, order);
+    DeviceAPI::Transport::waitSignalMeetShadow(coop._base, signalId, bits,
+                                               order);
   }
 
   template <typename Coop, typename Uint>
   FLAGCX_DEVICE_INLINE_DECORATOR void waitSignalFollowShadow(
-      Coop coop, flagcxDevNetSignal_t signal, Uint leastDelta, Uint *before,
-      Uint *delta, int bits = 64,
+      Coop coop, flagcxDevTransportSignal_t signalId, Uint leastDelta,
+      Uint *before, Uint *delta, int bits = 64,
       flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcquire) const {
-    _netBase.waitSignalFollowShadow(coop._base, signal, leastDelta, before,
-                                    delta, bits, order);
+    DeviceAPI::Transport::waitSignalFollowShadow(
+        coop._base, signalId, leastDelta, before, delta, bits, order);
   }
 
-  // ---- Shadow manipulation ----
-  FLAGCX_DEVICE_INLINE_DECORATOR uint64_t *
-  getSignalShadowPtr(flagcxDevNetSignal_t signal) const {
-    return _netBase.getSignalShadowPtr(signal);
-  }
-
-  FLAGCX_DEVICE_INLINE_DECORATOR void
-  increaseSignalShadow(flagcxDevNetSignal_t signal, uint64_t delta) const {
-    _netBase.increaseSignalShadow(signal, delta);
-  }
-
-  FLAGCX_DEVICE_INLINE_DECORATOR uint64_t readSignal(
-      flagcxDevNetSignal_t signal, int bits = 64,
-      flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcquire) const {
-    return _netBase.readSignal(signal, bits, order);
-  }
-
-  FLAGCX_DEVICE_INLINE_DECORATOR void
-  resetSignal(flagcxDevNetSignal_t signal) const {
-    _netBase.resetSignal(signal);
-  }
-
-  // ---- Counter operations ----
   template <typename Coop>
   FLAGCX_DEVICE_INLINE_DECORATOR void waitCounter(
-      Coop coop, flagcxDevNetCounter_t counter, uint64_t least, int bits = 56,
+      Coop coop, flagcxDevTransportCounter_t counterId, uint64_t least,
+      int bits = 56,
       flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcquire) const {
-    _netBase.waitCounter(coop._base, counter, least, bits, order);
+    DeviceAPI::Transport::waitCounter(coop._base, counterId, least, bits,
+                                      order);
   }
 
   FLAGCX_DEVICE_INLINE_DECORATOR uint64_t readCounter(
-      flagcxDevNetCounter_t counter, int bits = 56,
+      flagcxDevTransportCounter_t counterId, int bits = 56,
       flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcquire) const {
-    return _netBase.readCounter(counter, bits, order);
+    return DeviceAPI::Transport::readCounter(counterId, bits, order);
   }
 
+  // ---- Two-sided ----
+  template <typename Coop>
+  FLAGCX_DEVICE_INLINE_DECORATOR flagcxResult_t
+  send(Coop coop, const flagcxDevMem &mem, size_t offset, size_t count,
+       flagcxDataType_t datatype, int peer) const {
+    return DeviceAPI::Transport::send(coop._base, mem._winBase, offset, count,
+                                      datatype, peer);
+  }
+
+  template <typename Coop>
+  FLAGCX_DEVICE_INLINE_DECORATOR flagcxResult_t
+  recv(Coop coop, const flagcxDevMem &mem, size_t offset, size_t count,
+       flagcxDataType_t datatype, int peer) const {
+    return DeviceAPI::Transport::recv(coop._base, mem._winBase, offset, count,
+                                      datatype, peer);
+  }
+
+  template <typename Coop>
+  FLAGCX_DEVICE_INLINE_DECORATOR flagcxResult_t term(Coop coop) const {
+    return DeviceAPI::Transport::term(coop._base);
+  }
+
+  template <typename Coop>
+  FLAGCX_DEVICE_INLINE_DECORATOR flagcxResult_t wait(Coop coop) const {
+    return DeviceAPI::Transport::wait(coop._base);
+  }
+
+  // ---- One-sided: put ----
+  template <typename RemoteAction = flagcxDevTransport_None,
+            typename LocalAction = flagcxDevTransport_None,
+            typename Coop = flagcxCoopBlock,
+            typename Desc = flagcxDevTransport_None>
   FLAGCX_DEVICE_INLINE_DECORATOR void
-  resetCounter(flagcxDevNetCounter_t counter) const {
-    _netBase.resetCounter(counter);
+  put(flagcxTeam_t team, int peer, const flagcxDevMem &dst, size_t dstOffset,
+      const flagcxDevMem &src, size_t srcOffset, size_t bytes,
+      RemoteAction ra = flagcxDevTransport_None{},
+      LocalAction la = flagcxDevTransport_None{}, Coop coop = flagcxCoopBlock{},
+      Desc desc = flagcxDevTransport_None{},
+      flagcxDeviceScope_t ar = flagcxDeviceScopeThread,
+      flagcxDeviceScope_t es = flagcxDeviceScopeDevice) const {
+    DeviceAPI::Transport::put(team._teamBase, peer, dst._winBase, dstOffset,
+                              src._winBase, srcOffset, bytes, ra, la,
+                              coop._base, desc, ar, es);
+  }
+
+  // ---- One-sided: signal ----
+  template <typename RemoteAction, typename Coop = flagcxCoopBlock,
+            typename Desc = flagcxDevTransport_None>
+  FLAGCX_DEVICE_INLINE_DECORATOR void
+  signal(flagcxTeam_t team, int peer, RemoteAction ra,
+         Coop coop = flagcxCoopBlock{}, Desc desc = flagcxDevTransport_None{},
+         flagcxDeviceScope_t ar = flagcxDeviceScopeThread,
+         flagcxDeviceScope_t es = flagcxDeviceScopeDevice) const {
+    DeviceAPI::Transport::signal(team._teamBase, peer, ra, coop._base, desc, ar,
+                                 es);
+  }
+
+  // ---- One-sided: putValue ----
+  template <typename T, typename RemoteAction = flagcxDevTransport_None,
+            typename Coop = flagcxCoopBlock,
+            typename Desc = flagcxDevTransport_None>
+  FLAGCX_DEVICE_INLINE_DECORATOR void
+  putValue(flagcxTeam_t team, int peer, const flagcxDevMem &dst,
+           size_t dstOffset, T value,
+           RemoteAction ra = flagcxDevTransport_None{},
+           Coop coop = flagcxCoopBlock{}, Desc desc = flagcxDevTransport_None{},
+           flagcxDeviceScope_t ar = flagcxDeviceScopeThread,
+           flagcxDeviceScope_t es = flagcxDeviceScopeDevice) const {
+    DeviceAPI::Transport::putValue(team._teamBase, peer, dst._winBase,
+                                   dstOffset, value, ra, coop._base, desc, ar,
+                                   es);
+  }
+
+  // ---- One-sided: get (fallback only) ----
+  template <typename Coop = flagcxCoopBlock>
+  FLAGCX_DEVICE_INLINE_DECORATOR void
+  get(flagcxTeam_t team, int peer, const flagcxDevMem &src, size_t srcOffset,
+      const flagcxDevMem &dst, size_t dstOffset, size_t bytes,
+      Coop coop = flagcxCoopBlock{}) const {
+    DeviceAPI::Transport::get(team._teamBase, peer, src._winBase, srcOffset,
+                              dst._winBase, dstOffset, bytes, coop._base);
   }
 };
 
 // ============================================================
-// Section 11: flagcxDevBarrier<flagcxBarrierInter> — Inter-Node Barrier
+// Section 11: flagcxDevBarrier<flagcxTeamTagInter> — Inter-Node Barrier
 // ============================================================
 // ---- Inter ----
 template <typename Coop>
-struct flagcxDevBarrier<flagcxBarrierInter, Coop> {
-  typename DeviceAPI::template DevBarrier<flagcxBarrierInter, Coop> _impl;
+struct flagcxDevBarrier<flagcxTeamTagInter, Coop> {
+  typename DeviceAPI::template DevBarrier<flagcxTeamTagInter, Coop> _impl;
 
   FLAGCX_DEVICE_INLINE_DECORATOR
   flagcxDevBarrier() : _impl() {}
 
   FLAGCX_DEVICE_INLINE_DECORATOR
-  flagcxDevBarrier(Coop coop, const flagcxDevNet &net, flagcxTeam_t team,
-                   uint32_t index)
-      : _impl(coop, net._netBase, net._devComm._commBase, team._teamBase, index,
-              net._devComm._nInterPeers) {}
+  flagcxDevBarrier(Coop coop, const flagcxDevTransport &trans,
+                   flagcxTeam_t team, uint32_t index)
+      : _impl(coop, trans, trans._dc, team._teamBase, index,
+              trans._nInterPeers) {}
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   arrive(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
@@ -1067,32 +1020,32 @@ struct flagcxDevBarrier<flagcxBarrierInter, Coop> {
 
 // ---- World ----
 template <typename Coop>
-struct flagcxDevBarrier<flagcxBarrierWorld, Coop> {
-  typename DeviceAPI::template DevBarrier<flagcxBarrierWorld, Coop> _impl;
+struct flagcxDevBarrier<flagcxTeamTagWorld, Coop> {
+  typename DeviceAPI::template DevBarrier<flagcxTeamTagWorld, Coop> _impl;
 
   // World barrier (intra + inter)
   FLAGCX_DEVICE_INLINE_DECORATOR
-  flagcxDevBarrier(Coop coop, flagcxTeamTagWorld, const flagcxDevNet &net,
-                   uint32_t index, bool multimem = false)
-      : _impl(coop, flagcxBarrierWorld::World{}, net._netBase,
-              net._devComm._commBase, index, multimem,
-              net._devComm._nInterPeers) {}
+  flagcxDevBarrier(Coop coop, flagcxTeamTagWorld,
+                   const flagcxDevTransport &trans, uint32_t index,
+                   bool multimem = false)
+      : _impl(coop, flagcxTeamTagWorld{}, trans, trans._dc, index, multimem,
+              trans._nInterPeers) {}
 
   // Intra-only barrier
   FLAGCX_DEVICE_INLINE_DECORATOR
-  flagcxDevBarrier(Coop coop, flagcxTeamTagIntra, const flagcxDevComm &devComm,
-                   uint32_t index, bool multimem = false)
-      : _impl(coop, flagcxBarrierWorld::Intra{},
-              typename DeviceAPI::Net(devComm._commBase, 0), devComm._commBase,
-              index, multimem, 0) {}
+  flagcxDevBarrier(Coop coop, flagcxTeamTagIntra,
+                   const flagcxDevTransport &trans, uint32_t index,
+                   bool multimem = false)
+      : _impl(coop, flagcxTeamTagIntra{}, trans, trans._dc, index, multimem,
+              0) {}
 
-  // Inter-only barrier (ncclTeamTagRail on NVIDIA)
+  // Inter-only barrier
   FLAGCX_DEVICE_INLINE_DECORATOR
-  flagcxDevBarrier(Coop coop, flagcxTeamTagInter, const flagcxDevNet &net,
-                   uint32_t index, bool multimem = false)
-      : _impl(coop, flagcxBarrierWorld::Inter{}, net._netBase,
-              net._devComm._commBase, index, multimem,
-              net._devComm._nInterPeers) {}
+  flagcxDevBarrier(Coop coop, flagcxTeamTagInter,
+                   const flagcxDevTransport &trans, uint32_t index,
+                   bool multimem = false)
+      : _impl(coop, flagcxTeamTagInter{}, trans, trans._dc, index, multimem,
+              trans._nInterPeers) {}
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   arrive(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
@@ -1115,11 +1068,11 @@ struct flagcxDevBarrier<flagcxBarrierWorld, Coop> {
 
 // Backward-compatible aliases
 template <typename Coop>
-using flagcxIntraBarrierSession = flagcxDevBarrier<flagcxBarrierIntra, Coop>;
+using flagcxIntraBarrierSession = flagcxDevBarrier<flagcxTeamTagIntra, Coop>;
 template <typename Coop>
-using flagcxInterBarrierSession = flagcxDevBarrier<flagcxBarrierInter, Coop>;
+using flagcxInterBarrierSession = flagcxDevBarrier<flagcxTeamTagInter, Coop>;
 template <typename Coop>
-using flagcxBarrierSession = flagcxDevBarrier<flagcxBarrierWorld, Coop>;
+using flagcxBarrierSession = flagcxDevBarrier<flagcxTeamTagWorld, Coop>;
 
 #endif // FLAGCX_DEVICE_COMPILE (Sections 9b-12)
 

--- a/flagcx/adaptor/include/device_api/flagcx_device.h
+++ b/flagcx/adaptor/include/device_api/flagcx_device.h
@@ -150,12 +150,12 @@ typedef struct flagcxDevMemInternal *flagcxDevMem_t;
 // Section 3: flagcxDevComm — Device Communicator (kernel-facing)
 //
 // Value type passed to kernels by value.
-// Pure wrapper around DeviceAPI::DevComm which contains all fields.
-// On Vendor: DevComm = vendor DevComm
-// On default: DevComm = {rank, nRanks, fifoBuffer, barrierPeers, ...}
+// Pure wrapper around DeviceAPI::Comm which contains all fields.
+// On Vendor: Comm = vendor Comm
+// On default: Comm = {rank, nRanks, fifoBuffer, barrierPeers, ...}
 // ============================================================
 struct flagcxDevComm {
-  typename DeviceAPI::DevComm _commBase;
+  typename DeviceAPI::Comm _commBase;
 
   // Wrapper-level fields needed by FIFO encoding on all paths.
   // Populated from flagcxDevCommInternal; safe to be 0 when unused.
@@ -172,12 +172,12 @@ struct flagcxDevComm {
       : _signalCount(di.signalCount), _counterCount(di.counterCount),
         _contextCount(di.contextCount), _nInterPeers(di.nInterPeers) {
     if (di.devComm) {
-      _commBase = *(typename DeviceAPI::DevComm *)di.devComm;
+      _commBase = *(typename DeviceAPI::Comm *)di.devComm;
     } else {
       // Fallback: populate _commBase directly from handle fields.
       // Vendor path: no-op (devComm pointer always set).
-      // Dispatch resolved at compile time via DeviceAPI::DevComm.
-      DeviceAPI::DevComm::populateFromInternal(_commBase, di);
+      // Dispatch resolved at compile time via DeviceAPI::Comm.
+      DeviceAPI::Comm::populateFromInternal(_commBase, di);
     }
   }
 
@@ -390,7 +390,7 @@ FLAGCX_HOST_DEVICE_INLINE int flagcxTeamRankInDifference(flagcxTeam_t parent,
   }
 }
 
-// ---- DevComm-dependent team conversions ----
+// ---- Comm-dependent team conversions ----
 
 // Convert team rank to world rank.
 FLAGCX_DEVICE_INLINE_DECORATOR int
@@ -578,7 +578,7 @@ flagcxCoopCoalesced(flagcxCoopTile<N> coop) {
 // ============================================================
 // Section 7: flagcxDevBarrier — Barrier Session Wrappers
 //
-// Thin wrappers delegating to DeviceAPI::DevBarrier<Tag>.
+// Thin wrappers delegating to DeviceAPI::Barrier<Tag>.
 // No #ifdef FLAGCX_DEVICE_API_VENDOR — dispatch resolved by CommTraits.
 // ============================================================
 
@@ -589,7 +589,7 @@ struct flagcxDevBarrier;
 // ---- Intra ----
 template <typename Coop>
 struct flagcxDevBarrier<flagcxTeamTagIntra, Coop> {
-  typename DeviceAPI::template DevBarrier<flagcxTeamTagIntra, Coop> _impl;
+  typename DeviceAPI::template Barrier<flagcxTeamTagIntra, Coop> _impl;
 
   FLAGCX_DEVICE_INLINE_DECORATOR
   flagcxDevBarrier() : _impl() {}
@@ -828,21 +828,21 @@ struct flagcxDevTransport : DeviceAPI::Transport {
 
   FLAGCX_DEVICE_INLINE_DECORATOR
   flagcxDevTransport(const flagcxDevComm &devComm, int idx)
-      : DeviceAPI::Transport(devComm._commBase, idx),
+      : DeviceAPI::Transport(
+            devComm._commBase,
+            devComm._contextCount > 0 ? idx % devComm._contextCount : 0),
         _nInterPeers(devComm._nInterPeers) {}
 
   template <typename T>
   FLAGCX_DEVICE_INLINE_DECORATOR T load(const flagcxDevMem &mem,
-                                        size_t baseOffset, size_t idx,
-                                        int peer) const {
-    return DeviceAPI::Transport::load<T>(mem._winBase, baseOffset, idx, peer);
+                                        size_t byteOffset, int peer) const {
+    return DeviceAPI::Transport::load<T>(mem._winBase, byteOffset, peer);
   }
 
   template <typename T>
-  FLAGCX_DEVICE_INLINE_DECORATOR void store(const flagcxDevMem &mem,
-                                            size_t baseOffset, size_t idx,
-                                            int peer, T val) const {
-    DeviceAPI::Transport::store(mem._winBase, baseOffset, idx, peer, val);
+  FLAGCX_DEVICE_INLINE_DECORATOR void
+  store(const flagcxDevMem &mem, size_t byteOffset, int peer, T val) const {
+    DeviceAPI::Transport::store(mem._winBase, byteOffset, peer, val);
   }
 
   FLAGCX_DEVICE_INLINE_DECORATOR uint64_t readSignal(
@@ -988,7 +988,7 @@ struct flagcxDevTransport : DeviceAPI::Transport {
 // ---- Inter ----
 template <typename Coop>
 struct flagcxDevBarrier<flagcxTeamTagInter, Coop> {
-  typename DeviceAPI::template DevBarrier<flagcxTeamTagInter, Coop> _impl;
+  typename DeviceAPI::template Barrier<flagcxTeamTagInter, Coop> _impl;
 
   FLAGCX_DEVICE_INLINE_DECORATOR
   flagcxDevBarrier() : _impl() {}
@@ -1001,19 +1001,19 @@ struct flagcxDevBarrier<flagcxTeamTagInter, Coop> {
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   arrive(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-         flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+         flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     _impl.arrive(order, fence);
   }
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   wait(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-       flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+       flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     _impl.wait(order, fence);
   }
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   sync(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-       flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+       flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     _impl.sync(order, fence);
   }
 };
@@ -1021,7 +1021,7 @@ struct flagcxDevBarrier<flagcxTeamTagInter, Coop> {
 // ---- World ----
 template <typename Coop>
 struct flagcxDevBarrier<flagcxTeamTagWorld, Coop> {
-  typename DeviceAPI::template DevBarrier<flagcxTeamTagWorld, Coop> _impl;
+  typename DeviceAPI::template Barrier<flagcxTeamTagWorld, Coop> _impl;
 
   // World barrier (intra + inter)
   FLAGCX_DEVICE_INLINE_DECORATOR
@@ -1049,19 +1049,19 @@ struct flagcxDevBarrier<flagcxTeamTagWorld, Coop> {
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   arrive(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-         flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+         flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     _impl.arrive(order, fence);
   }
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   wait(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-       flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+       flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     _impl.wait(order, fence);
   }
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   sync(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-       flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+       flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     _impl.sync(order, fence);
   }
 };

--- a/flagcx/adaptor/include/device_api/nvidia_comm_traits.h
+++ b/flagcx/adaptor/include/device_api/nvidia_comm_traits.h
@@ -7,7 +7,7 @@
  * CommTraits<NvidiaVendor> provides:
  *   - Intrin, Atomic: from PlatformTraits<NvidiaPlatform> via using
  *   - Window:   wraps ncclWindow_t with member functions
- *   - DevComm:  wraps ncclDevComm with member functions
+ *   - Comm:  wraps ncclDevComm with member functions
  *   - Team:     wraps ncclTeam_t with member functions
  *   - Multimem: wraps ncclMultimemHandle_t
  *
@@ -110,11 +110,11 @@ struct CommTraits<NvidiaVendor> {
     }
   };
 
-  // ---- DevComm: wraps ncclDevComm ----
-  struct DevComm {
+  // ---- Comm: wraps ncclDevComm ----
+  struct Comm {
     ncclDevComm _impl;
 
-    FLAGCX_HOST_DEVICE_INLINE DevComm() : _impl() {}
+    FLAGCX_HOST_DEVICE_INLINE Comm() : _impl() {}
 
     // Implicit conversion to ncclDevComm for NCCL API calls
     FLAGCX_HOST_DEVICE_INLINE operator const ncclDevComm &() const {
@@ -133,9 +133,9 @@ struct CommTraits<NvidiaVendor> {
       return nullptr;
     }
 
-    // No-op: vendor DevComm is populated via devComm pointer cast
+    // No-op: vendor Comm is populated via devComm pointer cast
     template <typename DI>
-    static FLAGCX_HOST_DEVICE_INLINE void populateFromInternal(DevComm &,
+    static FLAGCX_HOST_DEVICE_INLINE void populateFromInternal(Comm &,
                                                                const DI &) {}
   };
 
@@ -232,13 +232,10 @@ struct CommTraits<NvidiaVendor> {
   };
 
 #if NCCL_CHECK_CUDACC
-  // ---- Barrier / GIN type aliases ----
-  using FenceLevel = ncclGinFenceLevel;
-
-  // ---- DevBarrier alias: delegates to standalone DevBarrier<Backend, Tag>
+  // ---- Barrier alias: delegates to standalone Barrier<Backend, Tag>
   // ----
   template <typename Tag, typename Coop>
-  using DevBarrier = ::DevBarrier<NvidiaVendor, Tag, Coop>;
+  using Barrier = ::Barrier<NvidiaVendor, Tag, Coop>;
 
   // ---- Action type conversion helpers (flagcx -> NCCL) ----
   FLAGCX_DEVICE_INLINE_DECORATOR static ncclGin_None
@@ -264,12 +261,12 @@ struct CommTraits<NvidiaVendor> {
 
   // ---- Transport: wraps ncclGin for one-sided operations ----
   struct Transport {
-    DevComm _dc;
+    Comm _dc;
     ncclGin _gin;
     int _contextId;
 
     FLAGCX_DEVICE_INLINE_DECORATOR
-    Transport(const DevComm &dc, int contextIndex)
+    Transport(const Comm &dc, int contextIndex)
         : _dc(dc), _gin(dc, contextIndex), _contextId(contextIndex) {}
 
     FLAGCX_DEVICE_INLINE_DECORATOR bool isIntraPeer(int peer) const {
@@ -279,20 +276,18 @@ struct CommTraits<NvidiaVendor> {
 
     // ---- store: write to peer's LSA pointer ----
     template <typename T>
-    FLAGCX_DEVICE_INLINE_DECORATOR void store(const Window &win,
-                                              size_t baseOffset, size_t idx,
-                                              int peer, T val) const {
-      T *ptr = (T *)win.getIntraPointer(baseOffset + idx * sizeof(T), peer);
+    FLAGCX_DEVICE_INLINE_DECORATOR void
+    store(const Window &win, size_t byteOffset, int peer, T val) const {
+      T *ptr = (T *)win.getIntraPointer(byteOffset, peer);
       if (ptr)
         *ptr = val;
     }
 
     // ---- load: read from peer's LSA pointer ----
     template <typename T>
-    FLAGCX_DEVICE_INLINE_DECORATOR T load(const Window &win, size_t baseOffset,
-                                          size_t idx, int peer) const {
-      const T *ptr =
-          (const T *)win.getIntraPointer(baseOffset + idx * sizeof(T), peer);
+    FLAGCX_DEVICE_INLINE_DECORATOR T load(const Window &win, size_t byteOffset,
+                                          int peer) const {
+      const T *ptr = (const T *)win.getIntraPointer(byteOffset, peer);
       return ptr ? *ptr : T{};
     }
 
@@ -436,24 +431,25 @@ struct CommTraits<NvidiaVendor> {
 // Fence level mapping (file scope for CUDA __constant__ compatibility)
 #if defined(FLAGCX_DEVICE_COMPILE) && NCCL_CHECK_CUDACC
 FLAGCX_MAYBE_UNUSED static FLAGCX_DEVICE_CONSTANT_DECORATOR ncclGinFenceLevel
-    flagcxGinFenceLevelMap[] = {ncclGinFenceLevel::Relaxed};
-static_assert(
-    sizeof(flagcxGinFenceLevelMap) / sizeof(flagcxGinFenceLevelMap[0]) ==
-        static_cast<int>(flagcxGinFenceLevel::Relaxed) + 1,
-    "flagcxGinFenceLevelMap must cover all flagcxGinFenceLevel values");
+    flagcxTransportFenceLevelMap[] = {ncclGinFenceLevel::Relaxed};
+static_assert(sizeof(flagcxTransportFenceLevelMap) /
+                      sizeof(flagcxTransportFenceLevelMap[0]) ==
+                  static_cast<int>(flagcxTransportFenceLevel::Relaxed) + 1,
+              "flagcxTransportFenceLevelMap must cover all "
+              "flagcxTransportFenceLevel values");
 #endif
 
 // ============================================================
-// DevBarrier specializations for NvidiaVendor
+// Barrier specializations for NvidiaVendor
 // ============================================================
 #if NCCL_CHECK_CUDACC
 
-// ---- DevBarrier<NvidiaVendor, flagcxTeamTagIntra, Coop> ----
+// ---- Barrier<NvidiaVendor, flagcxTeamTagIntra, Coop> ----
 // Wraps ncclLsaBarrierSession<ncclCoopCta> via placement new.
 template <typename Coop>
-struct DevBarrier<NvidiaVendor, flagcxTeamTagIntra, Coop> {
+struct Barrier<NvidiaVendor, flagcxTeamTagIntra, Coop> {
   using Atomic = PlatformTraits<NvidiaPlatform>::Atomic;
-  using DevComm = CommTraits<NvidiaVendor>::DevComm;
+  using Comm = CommTraits<NvidiaVendor>::Comm;
   using Team = CommTraits<NvidiaVendor>::Team;
   using Multimem = CommTraits<NvidiaVendor>::Multimem;
 
@@ -464,12 +460,12 @@ struct DevBarrier<NvidiaVendor, flagcxTeamTagIntra, Coop> {
 
   // Default ctor — inactive
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier() : _coop(), _active(false) {}
+  Barrier() : _coop(), _active(false) {}
 
   // Active ctor
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, const DevComm &dc, Team team, uint32_t index,
-             bool multimem = false, const Multimem &mm = {})
+  Barrier(Coop coop, const Comm &dc, Team team, uint32_t index,
+          bool multimem = false, const Multimem &mm = {})
       : _coop(coop), _active(true) {
     new (_implStorage) ncclLsaBarrierSession<ncclCoopCta>(
         ncclCoopCta(), dc, ncclTeamLsa(dc), dc._impl.lsaBarrier, index,
@@ -477,7 +473,7 @@ struct DevBarrier<NvidiaVendor, flagcxTeamTagIntra, Coop> {
   }
 
   FLAGCX_DEVICE_INLINE_DECORATOR
-  ~DevBarrier() {
+  ~Barrier() {
     if (_active)
       reinterpret_cast<ncclLsaBarrierSession<ncclCoopCta> *>(_implStorage)
           ->~ncclLsaBarrierSession();
@@ -502,12 +498,12 @@ struct DevBarrier<NvidiaVendor, flagcxTeamTagIntra, Coop> {
   }
 };
 
-// ---- DevBarrier<NvidiaVendor, flagcxTeamTagInter, Coop> ----
+// ---- Barrier<NvidiaVendor, flagcxTeamTagInter, Coop> ----
 // Wraps ncclGinBarrierSession<ncclCoopCta> via placement new.
 template <typename Coop>
-struct DevBarrier<NvidiaVendor, flagcxTeamTagInter, Coop> {
+struct Barrier<NvidiaVendor, flagcxTeamTagInter, Coop> {
   using Atomic = PlatformTraits<NvidiaPlatform>::Atomic;
-  using DevComm = CommTraits<NvidiaVendor>::DevComm;
+  using Comm = CommTraits<NvidiaVendor>::Comm;
   using Team = CommTraits<NvidiaVendor>::Team;
   using Transport = CommTraits<NvidiaVendor>::Transport;
 
@@ -517,18 +513,18 @@ struct DevBarrier<NvidiaVendor, flagcxTeamTagInter, Coop> {
   int _nInterPeers;
 
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier() : _coop(), _nInterPeers(0) {}
+  Barrier() : _coop(), _nInterPeers(0) {}
 
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, const Transport &trans, const DevComm &dc, Team team,
-             uint32_t index, int nInterPeers)
+  Barrier(Coop coop, const Transport &trans, const Comm &dc, Team team,
+          uint32_t index, int nInterPeers)
       : _coop(coop), _nInterPeers(nInterPeers) {
     new (_implStorage) ncclGinBarrierSession<ncclCoopCta>(
         ncclCoopCta(), trans._gin, team, trans._gin.comm.railGinBarrier, index);
   }
 
   FLAGCX_DEVICE_INLINE_DECORATOR
-  ~DevBarrier() {
+  ~Barrier() {
     if (_nInterPeers > 0)
       reinterpret_cast<ncclGinBarrierSession<ncclCoopCta> *>(_implStorage)
           ->~ncclGinBarrierSession();
@@ -536,34 +532,34 @@ struct DevBarrier<NvidiaVendor, flagcxTeamTagInter, Coop> {
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   arrive(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-         flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+         flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     // ncclGinBarrierSession only exposes sync; arrive is a no-op on vendor
   }
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   wait(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-       flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+       flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     // ncclGinBarrierSession only exposes sync; wait is a no-op on vendor
   }
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   sync(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-       flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+       flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     if (_nInterPeers > 0) {
       reinterpret_cast<ncclGinBarrierSession<ncclCoopCta> *>(_implStorage)
           ->sync(ncclCoopCta(), Atomic::toNativeOrder(order),
-                 flagcxGinFenceLevelMap[static_cast<int>(fence)]);
+                 flagcxTransportFenceLevelMap[static_cast<int>(fence)]);
     }
   }
 };
 
-// ---- DevBarrier<NvidiaVendor, flagcxTeamTagWorld, Coop> ----
+// ---- Barrier<NvidiaVendor, flagcxTeamTagWorld, Coop> ----
 // World: wraps ncclBarrierSession. Intra: wraps ncclLsaBarrierSession.
 // Uses placement new for the union of both types.
 template <typename Coop>
-struct DevBarrier<NvidiaVendor, flagcxTeamTagWorld, Coop> {
+struct Barrier<NvidiaVendor, flagcxTeamTagWorld, Coop> {
   using Atomic = PlatformTraits<NvidiaPlatform>::Atomic;
-  using DevComm = CommTraits<NvidiaVendor>::DevComm;
+  using Comm = CommTraits<NvidiaVendor>::Comm;
   using Transport = CommTraits<NvidiaVendor>::Transport;
 
   // Storage large enough for the larger of the two session types
@@ -585,8 +581,8 @@ struct DevBarrier<NvidiaVendor, flagcxTeamTagWorld, Coop> {
 
   // World barrier (intra + inter)
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, flagcxTeamTagWorld, const Transport &trans,
-             const DevComm &dc, uint32_t index, bool multimem, int)
+  Barrier(Coop coop, flagcxTeamTagWorld, const Transport &trans, const Comm &dc,
+          uint32_t index, bool multimem, int)
       : _coop(coop), _intraOnly(false) {
     new (_implStorage) ncclBarrierSession<ncclCoopCta>(
         ncclCoopCta(), ncclTeamTagWorld(), trans._gin, index, multimem);
@@ -594,8 +590,8 @@ struct DevBarrier<NvidiaVendor, flagcxTeamTagWorld, Coop> {
 
   // Intra-only barrier
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, flagcxTeamTagIntra, const Transport &,
-             const DevComm &dc, uint32_t index, bool multimem, int)
+  Barrier(Coop coop, flagcxTeamTagIntra, const Transport &, const Comm &dc,
+          uint32_t index, bool multimem, int)
       : _coop(coop), _intraOnly(true) {
     new (_implStorage) ncclLsaBarrierSession<ncclCoopCta>(
         ncclCoopCta(), dc, ncclTeamLsa(dc), dc._impl.lsaBarrier, index,
@@ -604,15 +600,15 @@ struct DevBarrier<NvidiaVendor, flagcxTeamTagWorld, Coop> {
 
   // Inter-only barrier (ncclTeamTagRail)
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, flagcxTeamTagInter, const Transport &trans,
-             const DevComm &, uint32_t index, bool, int)
+  Barrier(Coop coop, flagcxTeamTagInter, const Transport &trans, const Comm &,
+          uint32_t index, bool, int)
       : _coop(coop), _intraOnly(false) {
     new (_implStorage) ncclBarrierSession<ncclCoopCta>(
         ncclCoopCta(), ncclTeamTagRail(), trans._gin, index);
   }
 
   FLAGCX_DEVICE_INLINE_DECORATOR
-  ~DevBarrier() {
+  ~Barrier() {
     if (_intraOnly)
       reinterpret_cast<ncclLsaBarrierSession<ncclCoopCta> *>(_implStorage)
           ->~ncclLsaBarrierSession();
@@ -623,7 +619,7 @@ struct DevBarrier<NvidiaVendor, flagcxTeamTagWorld, Coop> {
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   arrive(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-         flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+         flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     if (_intraOnly) {
       reinterpret_cast<ncclLsaBarrierSession<ncclCoopCta> *>(_implStorage)
           ->arrive(ncclCoopCta(), Atomic::toNativeOrder(order));
@@ -633,7 +629,7 @@ struct DevBarrier<NvidiaVendor, flagcxTeamTagWorld, Coop> {
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   wait(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-       flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+       flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     if (_intraOnly) {
       reinterpret_cast<ncclLsaBarrierSession<ncclCoopCta> *>(_implStorage)
           ->wait(ncclCoopCta(), Atomic::toNativeOrder(order));
@@ -643,14 +639,14 @@ struct DevBarrier<NvidiaVendor, flagcxTeamTagWorld, Coop> {
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   sync(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel,
-       flagcxGinFenceLevel fence = flagcxGinFenceLevel::Relaxed) {
+       flagcxTransportFenceLevel fence = flagcxTransportFenceLevel::Relaxed) {
     if (_intraOnly) {
       reinterpret_cast<ncclLsaBarrierSession<ncclCoopCta> *>(_implStorage)
           ->sync(ncclCoopCta(), Atomic::toNativeOrder(order));
     } else {
       reinterpret_cast<ncclBarrierSession<ncclCoopCta> *>(_implStorage)
           ->sync(ncclCoopCta(), Atomic::toNativeOrder(order),
-                 flagcxGinFenceLevelMap[static_cast<int>(fence)]);
+                 flagcxTransportFenceLevelMap[static_cast<int>(fence)]);
     }
   }
 };

--- a/flagcx/adaptor/include/device_api/nvidia_comm_traits.h
+++ b/flagcx/adaptor/include/device_api/nvidia_comm_traits.h
@@ -72,6 +72,7 @@ struct CommTraits<NvidiaVendor> {
 
     FLAGCX_HOST_DEVICE_INLINE Window() : _impl() {}
 
+#if NCCL_CHECK_CUDACC
     FLAGCX_DEVICE_INLINE_DECORATOR void *
     getPeerPointer(size_t offset, const Team &team, int peer) const {
       return ncclGetPeerPointer(_impl, offset, (ncclTeam_t)team, peer);
@@ -90,20 +91,21 @@ struct CommTraits<NvidiaVendor> {
     getMulticastPointer(size_t offset, const Multimem &mm) const {
       return ncclGetMultimemPointer(_impl, offset, mm._impl);
     }
+#endif // NCCL_CHECK_CUDACC
 
     FLAGCX_HOST_DEVICE_INLINE bool hasAccess() const {
-      return _impl.base != 0 || _impl.size != 0;
+      return _impl != nullptr;
     }
     FLAGCX_HOST_DEVICE_INLINE void *getRawPtr() const {
-      return (void *)_impl.base;
+      return _impl ? _impl->winHost : nullptr;
     }
     FLAGCX_HOST_DEVICE_INLINE void **getDevPeerPtrs() const { return nullptr; }
     FLAGCX_HOST_DEVICE_INLINE int getMrIndex() const { return -1; }
 
-    FLAGCX_DEVICE_INLINE_DECORATOR bool operator==(const Window &o) const {
-      return _impl.base == o._impl.base && _impl.size == o._impl.size;
+    FLAGCX_HOST_DEVICE_INLINE bool operator==(const Window &o) const {
+      return _impl == o._impl;
     }
-    FLAGCX_DEVICE_INLINE_DECORATOR bool operator!=(const Window &o) const {
+    FLAGCX_HOST_DEVICE_INLINE bool operator!=(const Window &o) const {
       return !(*this == o);
     }
   };
@@ -137,6 +139,7 @@ struct CommTraits<NvidiaVendor> {
                                                                const DI &) {}
   };
 
+#if NCCL_CHECK_CUDACC
   // ---- CoopBlock: wraps ncclCoopCta ----
   struct CoopBlock {
     ncclCoopCta _impl;
@@ -218,6 +221,7 @@ struct CommTraits<NvidiaVendor> {
     FLAGCX_DEVICE_INLINE_DECORATOR int size() const { return _impl.size(); }
     FLAGCX_DEVICE_INLINE_DECORATOR void sync() { _impl.sync(); }
   };
+#endif // NCCL_CHECK_CUDACC
 
   // ---- Barrier handles ----
   struct IntraBarrierHandle {
@@ -227,10 +231,8 @@ struct CommTraits<NvidiaVendor> {
     ncclGinBarrierHandle _impl;
   };
 
+#if NCCL_CHECK_CUDACC
   // ---- Barrier / GIN type aliases ----
-  using Barrier = ncclLsaBarrier;
-  using RemoteAction = ncclGinRemoteAction;
-  using LocalAction = ncclGinLocalAction;
   using FenceLevel = ncclGinFenceLevel;
 
   // ---- DevBarrier alias: delegates to standalone DevBarrier<Backend, Tag>
@@ -239,34 +241,60 @@ struct CommTraits<NvidiaVendor> {
   using DevBarrier = ::DevBarrier<NvidiaVendor, Tag, Coop>;
 
   // ---- Action type conversion helpers (flagcx -> NCCL) ----
-  FLAGCX_DEVICE_INLINE_DECORATOR static ncclGin_None toNccl(flagcxDevNet_None) {
+  FLAGCX_DEVICE_INLINE_DECORATOR static ncclGin_None
+  toNccl(flagcxDevTransport_None) {
     return {};
   }
   FLAGCX_DEVICE_INLINE_DECORATOR static ncclGin_SignalInc
-  toNccl(flagcxDevNet_SignalInc a) {
+  toNccl(flagcxDevTransport_SignalInc a) {
     return {a.signal};
   }
   FLAGCX_DEVICE_INLINE_DECORATOR static ncclGin_SignalAdd
-  toNccl(flagcxDevNet_SignalAdd a) {
+  toNccl(flagcxDevTransport_SignalAdd a) {
     return {a.signal, a.value};
   }
   FLAGCX_DEVICE_INLINE_DECORATOR static ncclGin_CounterInc
-  toNccl(flagcxDevNet_CounterInc a) {
+  toNccl(flagcxDevTransport_CounterInc a) {
     return {a.counter};
   }
   FLAGCX_DEVICE_INLINE_DECORATOR static ncclGin_DescriptorSmem
-  toNccl(flagcxDevNet_DescriptorSmem a) {
+  toNccl(flagcxDevTransport_DescriptorSmem a) {
     return {(ncclGinDescriptorSmem *)a.smem._impl};
   }
 
-  // ---- Net: wraps ncclGin for one-sided operations ----
-  struct Net {
+  // ---- Transport: wraps ncclGin for one-sided operations ----
+  struct Transport {
+    DevComm _dc;
     ncclGin _gin;
     int _contextId;
 
     FLAGCX_DEVICE_INLINE_DECORATOR
-    Net(const DevComm &dc, int contextIndex)
-        : _gin(dc, contextIndex), _contextId(contextIndex) {}
+    Transport(const DevComm &dc, int contextIndex)
+        : _dc(dc), _gin(dc, contextIndex), _contextId(contextIndex) {}
+
+    FLAGCX_DEVICE_INLINE_DECORATOR bool isIntraPeer(int peer) const {
+      int intraBase = _dc.getRank() - _dc.getIntraRank();
+      return peer >= intraBase && peer < intraBase + _dc.getIntraSize();
+    }
+
+    // ---- store: write to peer's LSA pointer ----
+    template <typename T>
+    FLAGCX_DEVICE_INLINE_DECORATOR void store(const Window &win,
+                                              size_t baseOffset, size_t idx,
+                                              int peer, T val) const {
+      T *ptr = (T *)win.getIntraPointer(baseOffset + idx * sizeof(T), peer);
+      if (ptr)
+        *ptr = val;
+    }
+
+    // ---- load: read from peer's LSA pointer ----
+    template <typename T>
+    FLAGCX_DEVICE_INLINE_DECORATOR T load(const Window &win, size_t baseOffset,
+                                          size_t idx, int peer) const {
+      const T *ptr =
+          (const T *)win.getIntraPointer(baseOffset + idx * sizeof(T), peer);
+      return ptr ? *ptr : T{};
+    }
 
     // --- One-sided: put (raw Window) ---
     template <typename RA, typename LA, typename Coop, typename Desc>
@@ -309,15 +337,15 @@ struct CommTraits<NvidiaVendor> {
     // --- One-sided: waitSignal ---
     template <typename Coop>
     FLAGCX_DEVICE_INLINE_DECORATOR void
-    waitSignal(Coop coop, flagcxDevNetSignal_t signal, uint64_t least, int bits,
-               flagcxDeviceMemoryOrder_t order) const {
+    waitSignal(Coop coop, flagcxDevTransportSignal_t signal, uint64_t least,
+               int bits, flagcxDeviceMemoryOrder_t order) const {
       _gin.waitSignal(coop._impl, signal, least, bits,
                       Atomic::toNativeOrder(order));
     }
 
     template <typename Coop>
     FLAGCX_DEVICE_INLINE_DECORATOR void
-    waitSignalMeetShadow(Coop coop, flagcxDevNetSignal_t signal, int bits,
+    waitSignalMeetShadow(Coop coop, flagcxDevTransportSignal_t signal, int bits,
                          flagcxDeviceMemoryOrder_t order) const {
       _gin.waitSignalMeetShadow(coop._impl, signal, bits,
                                 Atomic::toNativeOrder(order));
@@ -325,7 +353,7 @@ struct CommTraits<NvidiaVendor> {
 
     template <typename Coop, typename Uint>
     FLAGCX_DEVICE_INLINE_DECORATOR void
-    waitSignalFollowShadow(Coop coop, flagcxDevNetSignal_t signal,
+    waitSignalFollowShadow(Coop coop, flagcxDevTransportSignal_t signal,
                            Uint leastDelta, Uint *before, Uint *delta, int bits,
                            flagcxDeviceMemoryOrder_t order) const {
       _gin.waitSignalFollowShadow(coop._impl, signal, leastDelta, before, delta,
@@ -334,43 +362,44 @@ struct CommTraits<NvidiaVendor> {
 
     // --- Shadow manipulation ---
     FLAGCX_DEVICE_INLINE_DECORATOR uint64_t *
-    getSignalShadowPtr(flagcxDevNetSignal_t signal) const {
+    getSignalShadowPtr(flagcxDevTransportSignal_t signal) const {
       return _gin.getSignalShadowPtr(signal);
     }
 
     FLAGCX_DEVICE_INLINE_DECORATOR void
-    increaseSignalShadow(flagcxDevNetSignal_t signal, uint64_t delta) const {
+    increaseSignalShadow(flagcxDevTransportSignal_t signal,
+                         uint64_t delta) const {
       _gin.increaseSignalShadow(signal, delta);
     }
 
     FLAGCX_DEVICE_INLINE_DECORATOR uint64_t
-    readSignal(flagcxDevNetSignal_t signal, int bits,
+    readSignal(flagcxDevTransportSignal_t signal, int bits,
                flagcxDeviceMemoryOrder_t order) const {
       return _gin.readSignal(signal, bits, Atomic::toNativeOrder(order));
     }
 
     FLAGCX_DEVICE_INLINE_DECORATOR void
-    resetSignal(flagcxDevNetSignal_t signal) const {
+    resetSignal(flagcxDevTransportSignal_t signal) const {
       _gin.resetSignal(signal);
     }
 
     // --- Counter ---
     template <typename Coop>
     FLAGCX_DEVICE_INLINE_DECORATOR void
-    waitCounter(Coop coop, flagcxDevNetCounter_t counter, uint64_t least,
+    waitCounter(Coop coop, flagcxDevTransportCounter_t counter, uint64_t least,
                 int bits, flagcxDeviceMemoryOrder_t order) const {
       _gin.waitCounter(coop._impl, counter, least, bits,
                        Atomic::toNativeOrder(order));
     }
 
     FLAGCX_DEVICE_INLINE_DECORATOR uint64_t
-    readCounter(flagcxDevNetCounter_t counter, int bits,
+    readCounter(flagcxDevTransportCounter_t counter, int bits,
                 flagcxDeviceMemoryOrder_t order) const {
       return _gin.readCounter(counter, bits, Atomic::toNativeOrder(order));
     }
 
     FLAGCX_DEVICE_INLINE_DECORATOR void
-    resetCounter(flagcxDevNetCounter_t counter) const {
+    resetCounter(flagcxDevTransportCounter_t counter) const {
       _gin.resetCounter(counter);
     }
 
@@ -401,10 +430,11 @@ struct CommTraits<NvidiaVendor> {
     FLAGCX_DEVICE_INLINE_DECORATOR void get(Team, int, Window, size_t, Window,
                                             size_t, size_t, Coop) const {}
   };
+#endif // NCCL_CHECK_CUDACC
 };
 
 // Fence level mapping (file scope for CUDA __constant__ compatibility)
-#ifdef FLAGCX_DEVICE_COMPILE
+#if defined(FLAGCX_DEVICE_COMPILE) && NCCL_CHECK_CUDACC
 FLAGCX_MAYBE_UNUSED static FLAGCX_DEVICE_CONSTANT_DECORATOR ncclGinFenceLevel
     flagcxGinFenceLevelMap[] = {ncclGinFenceLevel::Relaxed};
 static_assert(
@@ -416,71 +446,92 @@ static_assert(
 // ============================================================
 // DevBarrier specializations for NvidiaVendor
 // ============================================================
+#if NCCL_CHECK_CUDACC
 
-// ---- DevBarrier<NvidiaVendor, flagcxBarrierIntra, Coop> ----
-// Wraps ncclLsaBarrierSession<ncclCoopCta>.
+// ---- DevBarrier<NvidiaVendor, flagcxTeamTagIntra, Coop> ----
+// Wraps ncclLsaBarrierSession<ncclCoopCta> via placement new.
 template <typename Coop>
-struct DevBarrier<NvidiaVendor, flagcxBarrierIntra, Coop> {
+struct DevBarrier<NvidiaVendor, flagcxTeamTagIntra, Coop> {
   using Atomic = PlatformTraits<NvidiaPlatform>::Atomic;
   using DevComm = CommTraits<NvidiaVendor>::DevComm;
   using Team = CommTraits<NvidiaVendor>::Team;
   using Multimem = CommTraits<NvidiaVendor>::Multimem;
 
   Coop _coop;
-  ncclLsaBarrierSession<ncclCoopCta> _impl;
+  alignas(ncclLsaBarrierSession<ncclCoopCta>) char _implStorage[sizeof(
+      ncclLsaBarrierSession<ncclCoopCta>)];
+  bool _active;
 
-  // Default ctor
+  // Default ctor — inactive
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier() : _coop(), _impl() {}
+  DevBarrier() : _coop(), _active(false) {}
 
   // Active ctor
   FLAGCX_DEVICE_INLINE_DECORATOR
   DevBarrier(Coop coop, const DevComm &dc, Team team, uint32_t index,
              bool multimem = false, const Multimem &mm = {})
-      : _coop(coop), _impl(ncclCoopCta(), dc, ncclTeamLsa(dc),
-                           dc._impl.lsaBarrier, index, multimem, mm._impl) {}
+      : _coop(coop), _active(true) {
+    new (_implStorage) ncclLsaBarrierSession<ncclCoopCta>(
+        ncclCoopCta(), dc, ncclTeamLsa(dc), dc._impl.lsaBarrier, index,
+        multimem, mm._impl);
+  }
+
+  FLAGCX_DEVICE_INLINE_DECORATOR
+  ~DevBarrier() {
+    if (_active)
+      reinterpret_cast<ncclLsaBarrierSession<ncclCoopCta> *>(_implStorage)
+          ->~ncclLsaBarrierSession();
+  }
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   arrive(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel) {
-    _impl.arrive(ncclCoopCta(), Atomic::toNativeOrder(order));
+    reinterpret_cast<ncclLsaBarrierSession<ncclCoopCta> *>(_implStorage)
+        ->arrive(ncclCoopCta(), Atomic::toNativeOrder(order));
   }
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   wait(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel) {
-    _impl.wait(ncclCoopCta(), Atomic::toNativeOrder(order));
+    reinterpret_cast<ncclLsaBarrierSession<ncclCoopCta> *>(_implStorage)
+        ->wait(ncclCoopCta(), Atomic::toNativeOrder(order));
   }
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
   sync(flagcxDeviceMemoryOrder_t order = flagcxDeviceMemoryOrderAcqRel) {
-    _impl.sync(ncclCoopCta(), Atomic::toNativeOrder(order));
+    reinterpret_cast<ncclLsaBarrierSession<ncclCoopCta> *>(_implStorage)
+        ->sync(ncclCoopCta(), Atomic::toNativeOrder(order));
   }
 };
 
-// ---- DevBarrier<NvidiaVendor, flagcxBarrierInter, Coop> ----
+// ---- DevBarrier<NvidiaVendor, flagcxTeamTagInter, Coop> ----
 // Wraps ncclGinBarrierSession<ncclCoopCta> via placement new.
 template <typename Coop>
-struct DevBarrier<NvidiaVendor, flagcxBarrierInter, Coop> {
+struct DevBarrier<NvidiaVendor, flagcxTeamTagInter, Coop> {
   using Atomic = PlatformTraits<NvidiaPlatform>::Atomic;
   using DevComm = CommTraits<NvidiaVendor>::DevComm;
   using Team = CommTraits<NvidiaVendor>::Team;
-  using Net = CommTraits<NvidiaVendor>::Net;
+  using Transport = CommTraits<NvidiaVendor>::Transport;
 
   Coop _coop;
   alignas(ncclGinBarrierSession<ncclCoopCta>) char _implStorage[sizeof(
       ncclGinBarrierSession<ncclCoopCta>)];
   int _nInterPeers;
 
-  // Default ctor (no-op barrier)
   FLAGCX_DEVICE_INLINE_DECORATOR
   DevBarrier() : _coop(), _nInterPeers(0) {}
 
-  // Active ctor
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, const Net &net, const DevComm &dc, Team team,
+  DevBarrier(Coop coop, const Transport &trans, const DevComm &dc, Team team,
              uint32_t index, int nInterPeers)
       : _coop(coop), _nInterPeers(nInterPeers) {
     new (_implStorage) ncclGinBarrierSession<ncclCoopCta>(
-        ncclCoopCta(), net._gin, team, net._gin.comm.railGinBarrier, index);
+        ncclCoopCta(), trans._gin, team, trans._gin.comm.railGinBarrier, index);
+  }
+
+  FLAGCX_DEVICE_INLINE_DECORATOR
+  ~DevBarrier() {
+    if (_nInterPeers > 0)
+      reinterpret_cast<ncclGinBarrierSession<ncclCoopCta> *>(_implStorage)
+          ->~ncclGinBarrierSession();
   }
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
@@ -506,14 +557,14 @@ struct DevBarrier<NvidiaVendor, flagcxBarrierInter, Coop> {
   }
 };
 
-// ---- DevBarrier<NvidiaVendor, flagcxBarrierWorld, Coop> ----
+// ---- DevBarrier<NvidiaVendor, flagcxTeamTagWorld, Coop> ----
 // World: wraps ncclBarrierSession. Intra: wraps ncclLsaBarrierSession.
 // Uses placement new for the union of both types.
 template <typename Coop>
-struct DevBarrier<NvidiaVendor, flagcxBarrierWorld, Coop> {
+struct DevBarrier<NvidiaVendor, flagcxTeamTagWorld, Coop> {
   using Atomic = PlatformTraits<NvidiaPlatform>::Atomic;
   using DevComm = CommTraits<NvidiaVendor>::DevComm;
-  using Net = CommTraits<NvidiaVendor>::Net;
+  using Transport = CommTraits<NvidiaVendor>::Transport;
 
   // Storage large enough for the larger of the two session types
   static constexpr size_t kWorldSize = sizeof(ncclBarrierSession<ncclCoopCta>);
@@ -534,16 +585,16 @@ struct DevBarrier<NvidiaVendor, flagcxBarrierWorld, Coop> {
 
   // World barrier (intra + inter)
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, flagcxBarrierWorld::World, const Net &net,
+  DevBarrier(Coop coop, flagcxTeamTagWorld, const Transport &trans,
              const DevComm &dc, uint32_t index, bool multimem, int)
       : _coop(coop), _intraOnly(false) {
     new (_implStorage) ncclBarrierSession<ncclCoopCta>(
-        ncclCoopCta(), ncclTeamTagWorld(), net._gin, index, multimem);
+        ncclCoopCta(), ncclTeamTagWorld(), trans._gin, index, multimem);
   }
 
   // Intra-only barrier
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, flagcxBarrierWorld::Intra, const Net &,
+  DevBarrier(Coop coop, flagcxTeamTagIntra, const Transport &,
              const DevComm &dc, uint32_t index, bool multimem, int)
       : _coop(coop), _intraOnly(true) {
     new (_implStorage) ncclLsaBarrierSession<ncclCoopCta>(
@@ -553,11 +604,21 @@ struct DevBarrier<NvidiaVendor, flagcxBarrierWorld, Coop> {
 
   // Inter-only barrier (ncclTeamTagRail)
   FLAGCX_DEVICE_INLINE_DECORATOR
-  DevBarrier(Coop coop, flagcxBarrierWorld::Inter, const Net &net,
+  DevBarrier(Coop coop, flagcxTeamTagInter, const Transport &trans,
              const DevComm &, uint32_t index, bool, int)
       : _coop(coop), _intraOnly(false) {
     new (_implStorage) ncclBarrierSession<ncclCoopCta>(
-        ncclCoopCta(), ncclTeamTagRail(), net._gin, index);
+        ncclCoopCta(), ncclTeamTagRail(), trans._gin, index);
+  }
+
+  FLAGCX_DEVICE_INLINE_DECORATOR
+  ~DevBarrier() {
+    if (_intraOnly)
+      reinterpret_cast<ncclLsaBarrierSession<ncclCoopCta> *>(_implStorage)
+          ->~ncclLsaBarrierSession();
+    else
+      reinterpret_cast<ncclBarrierSession<ncclCoopCta> *>(_implStorage)
+          ->~ncclBarrierSession();
   }
 
   FLAGCX_DEVICE_INLINE_DECORATOR void
@@ -593,6 +654,7 @@ struct DevBarrier<NvidiaVendor, flagcxBarrierWorld, Coop> {
     }
   }
 };
+#endif // NCCL_CHECK_CUDACC
 
 #define FLAGCX_DEVICE_API_VENDOR 1
 using DeviceAPI = CommTraits<NvidiaVendor>;

--- a/flagcx/kernels/custom_allreduce.cu
+++ b/flagcx/kernels/custom_allreduce.cu
@@ -5,6 +5,7 @@
  ************************************************************************/
 
 #include "nvidia_adaptor.h"
+#include "device_utils.h"
 #if NCCL_VERSION_CODE > NCCL_VERSION(2, 28, 0)
 #include "nccl_device.h"
 #include <cuda_runtime.h>

--- a/flagcx/kernels/device_api.cu
+++ b/flagcx/kernels/device_api.cu
@@ -44,7 +44,7 @@ static inline void advanceIntraEpoch(flagcxDevComm_t devComm, int nBarSyncs) {
 // ==========================================================================
 
 // Intra-node AllReduce: each block reads from all peers via team-based
-// flagcxGetPeerPointer, reduces (sum), and writes result back to all peers.
+// flagcxDevTransport load/store, reduces (sum), and writes result back to all peers.
 template <typename T>
 __global__ void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
     flagcxIntraAllReduceKernel(flagcxDevComm devComm, flagcxDevMem mem,
@@ -59,9 +59,10 @@ __global__ void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
   }
 
   flagcxTeam_t intra = flagcxTeamIntra(devComm);
+  flagcxDevTransport trans(devComm, FLAGCX_BLOCK_IDX_X);
 
   // Create barrier session using simplified FlagCX API (4 params).
-  flagcxDevBarrier<flagcxBarrierIntra, flagcxCoopBlock> bar{
+  flagcxDevBarrier<flagcxTeamTagIntra, flagcxCoopBlock> bar{
       flagcxCoopBlock(), devComm, intra, FLAGCX_BLOCK_IDX_X};
 
   // Pre-reduce barrier (acquire — ensure peer writes are visible)
@@ -77,14 +78,10 @@ __global__ void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
   // Phase 2: Write — store result to all intra-node peers
   for (size_t o = globalTid; o < count; o += globalNthreads) {
     T v = T(0);
-    for (int peer = 0; peer < nRanks; peer++) {
-      T* inputPtr = (T*)flagcxGetPeerPointer(mem, offset, intra, peer);
-      v += inputPtr[o];
-    }
-    for (int peer = 0; peer < nRanks; peer++) {
-      T* outputPtr = (T*)flagcxGetPeerPointer(mem, offset, intra, peer);
-      outputPtr[o] = v;
-    }
+    for (int peer = 0; peer < nRanks; peer++)
+      v += trans.load<T>(mem, offset, o, peer);
+    for (int peer = 0; peer < nRanks; peer++)
+      trans.store(mem, offset, o, peer, v);
   }
 
   // Post-reduce barrier (release ordering — ensure writes are visible)
@@ -166,18 +163,18 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
 
   // contextIndex=0: all CTAs share signal slot 0. readSignal is taken before
   // bar.sync so the baseline is captured before any signals from this round arrive.
-  flagcxDevNet net(devComm, 0);
+  flagcxDevTransport trans(devComm, 0);
   // Unified barrier: intra (IPC) + inter (FIFO signal relay).
   // Single-node: intra sync only.  Multi-node: three-phase intra/inter/intra.
-  flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-      flagcxCoopBlock(), flagcxTeamTagWorld{}, net, FLAGCX_BLOCK_IDX_X);
+  flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+      flagcxCoopBlock(), flagcxTeamTagWorld{}, trans, FLAGCX_BLOCK_IDX_X);
 
   int nRanks = devComm.getSize();
   int myRank = devComm.getRank();
   size_t size = count * getFlagcxDataTypeSizeDevice(datatype);
 
   // Read signal baseline before pre-barrier so it reflects the pre-round state.
-  uint64_t signalValue = net.readSignal(0);
+  uint64_t signalValue = trans.readSignal(0);
 
   // Pre-communication barrier
   bar.sync(flagcxDeviceMemoryOrderRelaxed);
@@ -185,13 +182,13 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
   int tid = FLAGCX_THREAD_IDX_X + FLAGCX_BLOCK_IDX_X * FLAGCX_BLOCK_DIM_X;
   int nthreads = FLAGCX_BLOCK_DIM_X * FLAGCX_GRID_DIM_X;
   for (int peer = tid; peer < nRanks; peer += nthreads) {
-    net.put(flagcxTeamWorld(devComm), peer, recvMem, myRank * size,
-            sendMem, peer * size, size, flagcxDevNet_SignalInc{0},
-            flagcxDevNet_None{}, flagcxCoopThread{});
+    trans.put(flagcxTeamWorld(devComm), peer, recvMem, myRank * size,
+            sendMem, peer * size, size, flagcxDevTransport_SignalInc{0},
+            flagcxDevTransport_None{}, flagcxCoopThread{});
   }
 
-  net.waitSignal(flagcxCoopBlock{}, 0, signalValue + nRanks);
-  net.flush(flagcxCoopBlock{});
+  trans.waitSignal(flagcxCoopBlock{}, 0, signalValue + nRanks);
+  trans.flush(flagcxCoopBlock{});
 
   // Post-communication barrier
   bar.sync(flagcxDeviceMemoryOrderRelaxed);
@@ -211,11 +208,11 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
                                       size_t count, flagcxDataType_t datatype,
                                       flagcxDevComm devComm) {
 
-  flagcxDevNet net(devComm, FLAGCX_BLOCK_IDX_X);
+  flagcxDevTransport trans(devComm, FLAGCX_BLOCK_IDX_X);
   // Unified barrier: intra (IPC) + inter (FIFO signal relay).
   // Single-node: intra sync.  Multi-node: three-phase intra/inter/intra.
-  flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-      flagcxCoopBlock(), flagcxTeamTagWorld{}, net, FLAGCX_BLOCK_IDX_X);
+  flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+      flagcxCoopBlock(), flagcxTeamTagWorld{}, trans, FLAGCX_BLOCK_IDX_X);
 
   int nRanks = devComm.getSize();
   size_t size = count * getFlagcxDataTypeSizeDevice(datatype);
@@ -228,12 +225,12 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
   for (int peer = FLAGCX_BLOCK_IDX_X; peer < nRanks;
        peer += FLAGCX_GRID_DIM_X) {
     size_t offset = peer * size;
-    net.send(flagcxCoopBlock{}, sendMem, offset, count, datatype, peer);
-    net.recv(flagcxCoopBlock{}, recvMem, offset, count, datatype, peer);
+    trans.send(flagcxCoopBlock{}, sendMem, offset, count, datatype, peer);
+    trans.recv(flagcxCoopBlock{}, recvMem, offset, count, datatype, peer);
   }
 
-  net.term(flagcxCoopBlock{});
-  net.wait(flagcxCoopBlock{});
+  trans.term(flagcxCoopBlock{});
+  trans.wait(flagcxCoopBlock{});
 
   // Post-communication barrier
   bar.sync(flagcxDeviceMemoryOrderRelaxed);
@@ -259,7 +256,7 @@ flagcxResult_t flagcxInterOneSidedAlltoAll(flagcxDevMem_t sendMem,
   cudaError_t err = cudaGetLastError();
 
   // Advance barrier epochs: 2 bar.syncs per kernel.
-  // flagcxDevBarrier<flagcxBarrierWorld>::sync does (nInterPeers>0): 2 intra + 1 inter,
+  // flagcxDevBarrier<flagcxTeamTagWorld>::sync does (nInterPeers>0): 2 intra + 1 inter,
   //                              or (nInterPeers==0): 1 intra.
   advanceIntraEpoch(devComm, 2);
   devComm->interBarrierEpoch += 2 * devComm->nInterPeers;
@@ -330,30 +327,31 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
   size_t size = count * getFlagcxDataTypeSizeDevice(datatype);
 
   if (devComm._nInterPeers > 0) {
-    // Hybrid: DevNet for inter + IPC for intra
-    flagcxDevNet net(devComm, 0);
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagWorld{}, net, FLAGCX_BLOCK_IDX_X);
-    uint64_t s0 = net.readSignal(0);
+    // Hybrid: DevTransport for inter + IPC for intra
+    flagcxDevTransport trans(devComm, 0);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagWorld{}, trans, FLAGCX_BLOCK_IDX_X);
+    uint64_t s0 = trans.readSignal(0);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
     ipcAlltoAll(sendMem, recvMem, intra, intraSize, intraBase, myRank, size);
     int tid = FLAGCX_THREAD_IDX_X + FLAGCX_BLOCK_IDX_X * FLAGCX_BLOCK_DIM_X;
     int nthreads = FLAGCX_BLOCK_DIM_X * FLAGCX_GRID_DIM_X;
     for (int peer = tid; peer < nRanks; peer += nthreads) {
       if (peer >= intraBase && peer < intraBase + intraSize) continue;
-      net.put(flagcxTeamWorld(devComm), peer,
+      trans.put(flagcxTeamWorld(devComm), peer,
               recvMem, (size_t)myRank * size,
               sendMem, (size_t)peer * size, size,
-              flagcxDevNet_SignalInc{0}, flagcxDevNet_None{},
+              flagcxDevTransport_SignalInc{0}, flagcxDevTransport_None{},
               flagcxCoopThread{});
     }
-    net.waitSignal(flagcxCoopBlock{}, 0, s0 + (uint64_t)nInterRanks);
-    net.flush(flagcxCoopBlock{});
+    trans.waitSignal(flagcxCoopBlock{}, 0, s0 + (uint64_t)nInterRanks);
+    trans.flush(flagcxCoopBlock{});
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
   } else {
-    // Single-node: IPC only, no DevNet
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagIntra{}, devComm, FLAGCX_BLOCK_IDX_X);
+    // Single-node: IPC only, no DevTransport
+    flagcxDevTransport trans(devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagIntra{}, trans, FLAGCX_BLOCK_IDX_X);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
     ipcAlltoAll(sendMem, recvMem, intra, intraSize, intraBase, myRank, size);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
@@ -377,30 +375,31 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
   size_t size = count * getFlagcxDataTypeSizeDevice(datatype);
 
   if (devComm._nInterPeers > 0) {
-    flagcxDevNet net(devComm, 0);
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagWorld{}, net, FLAGCX_BLOCK_IDX_X);
-    uint64_t s0 = net.readSignal(0);
+    flagcxDevTransport trans(devComm, 0);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagWorld{}, trans, FLAGCX_BLOCK_IDX_X);
+    uint64_t s0 = trans.readSignal(0);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
     ipcAlltoAll(sendMem, recvMem, intra, intraSize, intraBase, myRank, size);
     int tid = FLAGCX_THREAD_IDX_X + FLAGCX_BLOCK_IDX_X * FLAGCX_BLOCK_DIM_X;
     int nthreads = FLAGCX_BLOCK_DIM_X * FLAGCX_GRID_DIM_X;
     for (int peer = tid; peer < nRanks; peer += nthreads) {
       if (peer >= intraBase && peer < intraBase + intraSize) continue;
-      net.put(flagcxTeamWorld(devComm), peer,
+      trans.put(flagcxTeamWorld(devComm), peer,
               recvMem, (size_t)myRank * size,
               sendMem, (size_t)peer * size, size,
-              flagcxDevNet_None{}, flagcxDevNet_None{},
+              flagcxDevTransport_None{}, flagcxDevTransport_None{},
               flagcxCoopThread{});
-      net.signal(flagcxTeamWorld(devComm), peer,
-                 flagcxDevNet_SignalAdd{0, 2}, flagcxCoopThread{});
+      trans.signal(flagcxTeamWorld(devComm), peer,
+                 flagcxDevTransport_SignalAdd{0, 2}, flagcxCoopThread{});
     }
-    net.waitSignal(flagcxCoopBlock{}, 0, s0 + (uint64_t)nInterRanks * 2);
-    net.flush(flagcxCoopBlock{});
+    trans.waitSignal(flagcxCoopBlock{}, 0, s0 + (uint64_t)nInterRanks * 2);
+    trans.flush(flagcxCoopBlock{});
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
   } else {
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagIntra{}, devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevTransport trans(devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagIntra{}, trans, FLAGCX_BLOCK_IDX_X);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
     ipcAlltoAll(sendMem, recvMem, intra, intraSize, intraBase, myRank, size);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
@@ -427,24 +426,24 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
   float *sendRaw = (float *)sendMem.getRawPtr();
 
   if (devComm._nInterPeers > 0) {
-    flagcxDevNet net(devComm, 0);
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagWorld{}, net, FLAGCX_BLOCK_IDX_X);
-    uint64_t s0 = net.readSignal(0);
-    uint64_t c0 = net.readCounter(0);
+    flagcxDevTransport trans(devComm, 0);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagWorld{}, trans, FLAGCX_BLOCK_IDX_X);
+    uint64_t s0 = trans.readSignal(0);
+    uint64_t c0 = trans.readCounter(0);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
 
-    // Round 1: IPC for intra + DevNet for inter
+    // Round 1: IPC for intra + DevTransport for inter
     ipcAlltoAll(sendMem, recvMem, intra, intraSize, intraBase, myRank, size);
     for (int peer = tid; peer < nRanks; peer += nthreads) {
       if (peer >= intraBase && peer < intraBase + intraSize) continue;
-      net.put(flagcxTeamWorld(devComm), peer,
+      trans.put(flagcxTeamWorld(devComm), peer,
               recvMem, (size_t)myRank * size,
               sendMem, (size_t)peer * size, size,
-              flagcxDevNet_SignalInc{0}, flagcxDevNet_CounterInc{0},
+              flagcxDevTransport_SignalInc{0}, flagcxDevTransport_CounterInc{0},
               flagcxCoopThread{});
     }
-    net.waitCounter(flagcxCoopBlock{}, 0, c0 + (uint64_t)nInterRanks);
+    trans.waitCounter(flagcxCoopBlock{}, 0, c0 + (uint64_t)nInterRanks);
 
     // Stamp sentinel
     for (int peer = tid; peer < nRanks; peer += nthreads)
@@ -455,24 +454,25 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
     ipcAlltoAll(sendMem, recvMem, intra, intraSize, intraBase, myRank, size);
     for (int peer = tid; peer < nRanks; peer += nthreads) {
       if (peer >= intraBase && peer < intraBase + intraSize) continue;
-      net.put(flagcxTeamWorld(devComm), peer,
+      trans.put(flagcxTeamWorld(devComm), peer,
               recvMem, (size_t)myRank * size,
               sendMem, (size_t)peer * size, size,
-              flagcxDevNet_SignalInc{0}, flagcxDevNet_CounterInc{0},
+              flagcxDevTransport_SignalInc{0}, flagcxDevTransport_CounterInc{0},
               flagcxCoopThread{});
     }
-    net.waitCounter(flagcxCoopBlock{}, 0, c0 + 2 * (uint64_t)nInterRanks);
-    net.waitSignal(flagcxCoopBlock{}, 0, s0 + 2 * (uint64_t)nInterRanks);
-    net.flush(flagcxCoopBlock{});
+    trans.waitCounter(flagcxCoopBlock{}, 0, c0 + 2 * (uint64_t)nInterRanks);
+    trans.waitSignal(flagcxCoopBlock{}, 0, s0 + 2 * (uint64_t)nInterRanks);
+    trans.flush(flagcxCoopBlock{});
 
     if (FLAGCX_BLOCK_IDX_X == 0 && FLAGCX_THREAD_IDX_X == 0) {
-      resultBuf[0] = net.readCounter(0);
+      resultBuf[0] = trans.readCounter(0);
       resultBuf[1] = (uint64_t)nInterRanks;
     }
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
   } else {
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagIntra{}, devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevTransport trans(devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagIntra{}, trans, FLAGCX_BLOCK_IDX_X);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
 
     // Round 1
@@ -509,10 +509,10 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
   int nthreads = FLAGCX_BLOCK_DIM_X * FLAGCX_GRID_DIM_X;
 
   if (devComm._nInterPeers > 0) {
-    flagcxDevNet net(devComm, 0);
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagWorld{}, net, FLAGCX_BLOCK_IDX_X);
-    uint64_t s1 = net.readSignal(1);
+    flagcxDevTransport trans(devComm, 0);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagWorld{}, trans, FLAGCX_BLOCK_IDX_X);
+    uint64_t s1 = trans.readSignal(1);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
     for (int peer = tid; peer < nRanks; peer += nthreads) {
       uint64_t val = (uint64_t)myRank * 1000u + (uint64_t)peer;
@@ -523,17 +523,18 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
             recvMem, putValBase + (size_t)myRank * sizeof(uint64_t), intra, lr);
         *dst = val;
       } else {
-        net.putValue(flagcxTeamWorld(devComm), peer,
+        trans.putValue(flagcxTeamWorld(devComm), peer,
                      recvMem, putValBase + (size_t)myRank * sizeof(uint64_t),
-                     val, flagcxDevNet_SignalInc{1}, flagcxCoopThread{});
+                     val, flagcxDevTransport_SignalInc{1}, flagcxCoopThread{});
       }
     }
     if (nInterRanks > 0)
-      net.waitSignal(flagcxCoopBlock{}, 1, s1 + (uint64_t)nInterRanks);
+      trans.waitSignal(flagcxCoopBlock{}, 1, s1 + (uint64_t)nInterRanks);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
   } else {
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagIntra{}, devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevTransport trans(devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagIntra{}, trans, FLAGCX_BLOCK_IDX_X);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
     for (int peer = tid; peer < nRanks; peer += nthreads) {
       uint64_t val = (uint64_t)myRank * 1000u + (uint64_t)peer;
@@ -557,23 +558,24 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
   int nInterRanks = nRanks - intraSize;
 
   if (devComm._nInterPeers > 0) {
-    flagcxDevNet net(devComm, 0);
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagWorld{}, net, FLAGCX_BLOCK_IDX_X);
-    uint64_t s1 = net.readSignal(1);
+    flagcxDevTransport trans(devComm, 0);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagWorld{}, trans, FLAGCX_BLOCK_IDX_X);
+    uint64_t s1 = trans.readSignal(1);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
     int tid = FLAGCX_THREAD_IDX_X + FLAGCX_BLOCK_IDX_X * FLAGCX_BLOCK_DIM_X;
     int nthreads = FLAGCX_BLOCK_DIM_X * FLAGCX_GRID_DIM_X;
     for (int peer = tid; peer < nRanks; peer += nthreads)
       if (peer != myRank && (peer < intraBase || peer >= intraBase + intraSize))
-        net.signal(flagcxTeamWorld(devComm), peer,
-                   flagcxDevNet_SignalInc{1}, flagcxCoopThread{});
+        trans.signal(flagcxTeamWorld(devComm), peer,
+                   flagcxDevTransport_SignalInc{1}, flagcxCoopThread{});
     if (nInterRanks > 0)
-      net.waitSignal(flagcxCoopBlock{}, 1, s1 + (uint64_t)nInterRanks);
+      trans.waitSignal(flagcxCoopBlock{}, 1, s1 + (uint64_t)nInterRanks);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
   } else {
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagIntra{}, devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevTransport trans(devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagIntra{}, trans, FLAGCX_BLOCK_IDX_X);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
   }
 }
@@ -593,40 +595,41 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
   size_t size = count * getFlagcxDataTypeSizeDevice(datatype);
 
   if (devComm._nInterPeers > 0) {
-    flagcxDevNet net(devComm, 0);
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagWorld{}, net, FLAGCX_BLOCK_IDX_X);
-    uint64_t s0 = net.readSignal(0);
+    flagcxDevTransport trans(devComm, 0);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagWorld{}, trans, FLAGCX_BLOCK_IDX_X);
+    uint64_t s0 = trans.readSignal(0);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
 
     // IPC for intra peers
     ipcAlltoAll(sendMem, recvMem, intra, intraSize, intraBase, myRank, size);
 
-    // DevNet puts (None,None) for inter peers only
+    // DevTransport puts (None,None) for inter peers only
     int tid = FLAGCX_THREAD_IDX_X + FLAGCX_BLOCK_IDX_X * FLAGCX_BLOCK_DIM_X;
     int nthreads = FLAGCX_BLOCK_DIM_X * FLAGCX_GRID_DIM_X;
     for (int peer = tid; peer < nRanks; peer += nthreads) {
       if (peer >= intraBase && peer < intraBase + intraSize) continue;
-      net.put(flagcxTeamWorld(devComm), peer,
+      trans.put(flagcxTeamWorld(devComm), peer,
               recvMem, (size_t)myRank * size,
               sendMem, (size_t)peer * size, size,
-              flagcxDevNet_None{}, flagcxDevNet_None{},
+              flagcxDevTransport_None{}, flagcxDevTransport_None{},
               flagcxCoopThread{});
     }
-    net.flush(flagcxCoopBlock{});
+    trans.flush(flagcxCoopBlock{});
 
     // Signal inter peers only
     for (int peer = tid; peer < nRanks; peer += nthreads) {
       if (peer >= intraBase && peer < intraBase + intraSize) continue;
-      net.signal(flagcxTeamWorld(devComm), peer,
-                 flagcxDevNet_SignalInc{0}, flagcxCoopThread{});
+      trans.signal(flagcxTeamWorld(devComm), peer,
+                 flagcxDevTransport_SignalInc{0}, flagcxCoopThread{});
     }
-    net.waitSignal(flagcxCoopBlock{}, 0, s0 + (uint64_t)nInterRanks);
-    net.flush(flagcxCoopBlock{});
+    trans.waitSignal(flagcxCoopBlock{}, 0, s0 + (uint64_t)nInterRanks);
+    trans.flush(flagcxCoopBlock{});
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
   } else {
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagIntra{}, devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevTransport trans(devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagIntra{}, trans, FLAGCX_BLOCK_IDX_X);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
     ipcAlltoAll(sendMem, recvMem, intra, intraSize, intraBase, myRank, size);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
@@ -638,23 +641,24 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
 FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
     flagcxInterTestFollowShadowKernel(flagcxDevComm devComm) {
   if (devComm._nInterPeers > 0) {
-    flagcxDevNet net(devComm, 0);
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagWorld{}, net, FLAGCX_BLOCK_IDX_X);
+    flagcxDevTransport trans(devComm, 0);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagWorld{}, trans, FLAGCX_BLOCK_IDX_X);
     int nRanks = devComm.getSize();
     int tid = FLAGCX_THREAD_IDX_X + FLAGCX_BLOCK_IDX_X * FLAGCX_BLOCK_DIM_X;
     int nthreads = FLAGCX_BLOCK_DIM_X * FLAGCX_GRID_DIM_X;
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
     for (int peer = tid; peer < nRanks; peer += nthreads)
-      net.signal(flagcxTeamWorld(devComm), peer,
-                 flagcxDevNet_SignalInc{2}, flagcxCoopThread{});
+      trans.signal(flagcxTeamWorld(devComm), peer,
+                 flagcxDevTransport_SignalInc{2}, flagcxCoopThread{});
     uint64_t before, delta;
-    net.waitSignalFollowShadow(flagcxCoopBlock{}, (flagcxDevNetSignal_t)2,
+    trans.waitSignalFollowShadow(flagcxCoopBlock{}, (flagcxDevTransportSignal_t)2,
                                 (uint64_t)nRanks, &before, &delta);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
   } else {
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagIntra{}, devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevTransport trans(devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagIntra{}, trans, FLAGCX_BLOCK_IDX_X);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
   }
 }
@@ -664,25 +668,26 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
 FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
     flagcxInterTestMeetShadowKernel(flagcxDevComm devComm) {
   if (devComm._nInterPeers > 0) {
-    flagcxDevNet net(devComm, 0);
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagWorld{}, net, FLAGCX_BLOCK_IDX_X);
+    flagcxDevTransport trans(devComm, 0);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagWorld{}, trans, FLAGCX_BLOCK_IDX_X);
     int nRanks = devComm.getSize();
     int tid = FLAGCX_THREAD_IDX_X + FLAGCX_BLOCK_IDX_X * FLAGCX_BLOCK_DIM_X;
     int nthreads = FLAGCX_BLOCK_DIM_X * FLAGCX_GRID_DIM_X;
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
     if (FLAGCX_BLOCK_IDX_X == 0 && FLAGCX_THREAD_IDX_X == 0) {
-      net.increaseSignalShadow((flagcxDevNetSignal_t)2, (uint64_t)nRanks);
+      trans.increaseSignalShadow((flagcxDevTransportSignal_t)2, (uint64_t)nRanks);
       __threadfence();
     }
     for (int peer = tid; peer < nRanks; peer += nthreads)
-      net.signal(flagcxTeamWorld(devComm), peer,
-                 flagcxDevNet_SignalInc{2}, flagcxCoopThread{});
-    net.waitSignalMeetShadow(flagcxCoopBlock{}, (flagcxDevNetSignal_t)2);
+      trans.signal(flagcxTeamWorld(devComm), peer,
+                 flagcxDevTransport_SignalInc{2}, flagcxCoopThread{});
+    trans.waitSignalMeetShadow(flagcxCoopBlock{}, (flagcxDevTransportSignal_t)2);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
   } else {
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagIntra{}, devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevTransport trans(devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagIntra{}, trans, FLAGCX_BLOCK_IDX_X);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
   }
 }
@@ -692,26 +697,27 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
 FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
     flagcxInterTestResetKernel(flagcxDevComm devComm, uint64_t *resultBuf) {
   if (devComm._nInterPeers > 0) {
-    flagcxDevNet net(devComm, 0);
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagWorld{}, net, FLAGCX_BLOCK_IDX_X);
+    flagcxDevTransport trans(devComm, 0);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagWorld{}, trans, FLAGCX_BLOCK_IDX_X);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
     if (FLAGCX_BLOCK_IDX_X == 0 && FLAGCX_THREAD_IDX_X == 0) {
-      net.resetSignal(0);
-      net.resetSignal(1);
-      net.resetSignal(2);
-      net.resetCounter(0);
-      *net.getSignalShadowPtr(2) = 0;
-      (void)net.readSignal(0, 32);
-      resultBuf[0] = net.readSignal(0);
-      resultBuf[1] = net.readSignal(1);
-      resultBuf[2] = net.readSignal(2);
-      resultBuf[3] = net.readCounter(0);
+      trans.resetSignal(0);
+      trans.resetSignal(1);
+      trans.resetSignal(2);
+      trans.resetCounter(0);
+      *trans.getSignalShadowPtr(2) = 0;
+      (void)trans.readSignal(0, 32);
+      resultBuf[0] = trans.readSignal(0);
+      resultBuf[1] = trans.readSignal(1);
+      resultBuf[2] = trans.readSignal(2);
+      resultBuf[3] = trans.readCounter(0);
     }
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
   } else {
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagIntra{}, devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevTransport trans(devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagIntra{}, trans, FLAGCX_BLOCK_IDX_X);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
     if (FLAGCX_BLOCK_IDX_X == 0 && FLAGCX_THREAD_IDX_X == 0) {
       resultBuf[0] = 0;
@@ -910,9 +916,9 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
   int nthreads = FLAGCX_BLOCK_DIM_X * FLAGCX_GRID_DIM_X;
 
   if (devComm._nInterPeers > 0) {
-    flagcxDevNet net(devComm, 0);
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagWorld{}, net, FLAGCX_BLOCK_IDX_X);
+    flagcxDevTransport trans(devComm, 0);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagWorld{}, trans, FLAGCX_BLOCK_IDX_X);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
 
     // IPC for intra-node peers
@@ -923,17 +929,18 @@ FLAGCX_GLOBAL_DECORATOR void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
       if (peer >= intraBase && peer < intraBase + intraSize) continue;
       // src: peer's sendBuff at offset myRank*size (peer's data for me)
       // dst: my recvBuff at offset peer*size (my slot for peer's data)
-      net.get(flagcxTeamWorld(devComm), peer,
+      trans.get(flagcxTeamWorld(devComm), peer,
               sendMem, (size_t)myRank * size,
               recvMem, (size_t)peer * size, size,
               flagcxCoopThread{});
     }
-    net.flush(flagcxCoopBlock{});
+    trans.flush(flagcxCoopBlock{});
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
   } else {
     // Intra-only: use IPC
-    flagcxDevBarrier<flagcxBarrierWorld, flagcxCoopBlock> bar(
-        flagcxCoopBlock(), flagcxTeamTagIntra{}, devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevTransport trans(devComm, FLAGCX_BLOCK_IDX_X);
+    flagcxDevBarrier<flagcxTeamTagWorld, flagcxCoopBlock> bar(
+        flagcxCoopBlock(), flagcxTeamTagIntra{}, trans, FLAGCX_BLOCK_IDX_X);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);
     ipcAlltoAll(sendMem, recvMem, intra, intraSize, intraBase, myRank, size);
     bar.sync(flagcxDeviceMemoryOrderRelaxed);

--- a/flagcx/kernels/device_api.cu
+++ b/flagcx/kernels/device_api.cu
@@ -79,9 +79,9 @@ __global__ void __launch_bounds__(FLAGCX_DEVICE_THREADS_PER_CTA)
   for (size_t o = globalTid; o < count; o += globalNthreads) {
     T v = T(0);
     for (int peer = 0; peer < nRanks; peer++)
-      v += trans.load<T>(mem, offset, o, peer);
+      v += trans.load<T>(mem, offset + o * sizeof(T), peer);
     for (int peer = 0; peer < nRanks; peer++)
-      trans.store(mem, offset, o, peer, v);
+      trans.store(mem, offset + o * sizeof(T), peer, v);
   }
 
   // Post-reduce barrier (release ordering — ensure writes are visible)


### PR DESCRIPTION
### PR Category
PAL

### PR Types
New Features

### PR Description
This PR updates the device-side abstraction layer to use a unified Device Transport interface (replacing flagcxDevNet) and aligns barrier/session tagging accordingly, enabling transport-backed load/store and one-sided operations across vendor and fallback backends.