### PR TITLE
[CRL] Refactor One-Sided Memory Registration with Global Handle Indexing and HeteroComm Isolation

### DIFF
--- a/flagcx/adaptor/flagcx_device.cc
+++ b/flagcx/adaptor/flagcx_device.cc
@@ -911,7 +911,7 @@ flagcxResult_t flagcxDevCommDestroy(flagcxComm_t comm,
   if (comm != nullptr && comm->heteroComm != nullptr &&
       comm->heteroComm->devCommHandle == devComm) {
     if (devComm->signalBuffer) {
-      flagcxOneSideSignalDeregister(comm);
+      flagcxOneSideSignalDeregister(comm->heteroComm);
     }
     comm->heteroComm->devCommHandle = nullptr;
   }
@@ -963,19 +963,20 @@ flagcxResult_t flagcxDevMemCreate(flagcxComm_t comm, void *buff, size_t size,
   handle->rawPtr = buff;
   handle->ipcIndex = -1;
 
-  // ---- Per-window MR layer: lookup buff in globalOneSideHandleTable ----
+  // ---- Per-comm MR layer: lookup buff in heteroComm->oneSideHandles ----
   handle->mrIndex = -1;
   handle->mrBase = 0;
-  if (comm != nullptr) {
-    for (int i = 0; i < globalOneSideHandleCount; i++) {
-      struct flagcxOneSideHandleInfo *info = globalOneSideHandleTable[i];
+  if (comm != nullptr && comm->heteroComm != nullptr) {
+    struct flagcxHeteroComm *hc = comm->heteroComm;
+    for (int i = 0; i < hc->oneSideHandleCount; i++) {
+      struct flagcxOneSideHandleInfo *info = hc->oneSideHandles[i];
       if (info != NULL && info->baseVas != NULL) {
         uintptr_t base = info->baseVas[comm->rank];
         if ((uintptr_t)buff == base) {
           handle->mrIndex = i;
           handle->mrBase = base;
           INFO(FLAGCX_INIT,
-               "flagcxDevMemCreate: buff %p matched handleTable[%d], "
+               "flagcxDevMemCreate: buff %p matched oneSideHandles[%d], "
                "mrBase=0x%lx",
                buff, i, (unsigned long)base);
           break;

--- a/flagcx/adaptor/include/device_api/flagcx_device.h
+++ b/flagcx/adaptor/include/device_api/flagcx_device.h
@@ -129,8 +129,8 @@ struct flagcxDevMemInternal {
   bool isSymmetric; // true only for FLAGCX_WIN_COLL_SYMMETRIC (enables
                     // one-sided)
 
-  // ---- Per-window MR layer (set by flagcxDevMemCreate from handle table) ----
-  int mrIndex; // index into globalOneSideHandleTable (-1 if not registered)
+  // ---- Per-comm MR layer (set by flagcxDevMemCreate from handle table) ----
+  int mrIndex; // index into heteroComm->oneSideHandles (-1 if not registered)
   uintptr_t mrBase; // handles[mrIndex]->baseVas[myRank] (cached for device)
 
   // ---- IPC layer (set if IPC exchange succeeds, else nullptr) ----

--- a/flagcx/core/flagcx_hetero.cc
+++ b/flagcx/core/flagcx_hetero.cc
@@ -154,8 +154,7 @@ static void *flagcxRmaProgressThread(void *arg) {
           break;
 
         case FLAGCX_RMA_PUT_VALUE: {
-          struct flagcxOneSideHandleInfo *stagingH =
-              comm->stagingHandle;
+          struct flagcxOneSideHandleInfo *stagingH = comm->stagingHandle;
           if (stagingH == NULL || stagingH->baseVas == NULL) {
             WARN("flagcxRmaProgressThread: staging handles not initialized");
             res = flagcxInternalError;

--- a/flagcx/core/flagcx_hetero.cc
+++ b/flagcx/core/flagcx_hetero.cc
@@ -177,7 +177,7 @@ static void *flagcxRmaProgressThread(void *arg) {
           INFO(FLAGCX_ALL,
                "flagcxRmaProgressThread: request pool full, "
                "re-enqueue peer=%d type=%d",
-                p, (int)desc->type);
+               p, (int)desc->type);
           enqueuePending(proxy, desc);
         } else {
           WARN("flagcxRmaProgressThread: op failed peer=%d type=%d res=%d", p,

--- a/flagcx/core/flagcx_hetero.cc
+++ b/flagcx/core/flagcx_hetero.cc
@@ -111,9 +111,9 @@ static void *flagcxRmaProgressThread(void *arg) {
 
       // Resolve sendComm from desc->peer.
       void *sendComm = NULL;
-      if (globalOneSideHandleCount > 0 && globalOneSideHandleTable[0] != NULL &&
-          globalOneSideHandleTable[0]->fullSendComms != NULL) {
-        sendComm = globalOneSideHandleTable[0]->fullSendComms[p];
+      if (comm->oneSideHandleCount > 0 && comm->oneSideHandles[0] != NULL &&
+          comm->oneSideHandles[0]->fullSendComms != NULL) {
+        sendComm = comm->oneSideHandles[0]->fullSendComms[p];
       }
       if (sendComm == NULL) {
         WARN("flagcxRmaProgressThread: no sendComm for peer %d", p);
@@ -126,8 +126,8 @@ static void *flagcxRmaProgressThread(void *arg) {
       // Resolve data MR handles (NULL when size==0 or not applicable).
       void **srcHandles = NULL, **dstHandles = NULL;
       if (desc->size > 0 && desc->srcMrIdx >= 0) {
-        srcHandles = (void **)globalOneSideHandleTable[desc->srcMrIdx];
-        dstHandles = (void **)globalOneSideHandleTable[desc->dstMrIdx];
+        srcHandles = (void **)comm->oneSideHandles[desc->srcMrIdx];
+        dstHandles = (void **)comm->oneSideHandles[desc->dstMrIdx];
       }
 
       flagcxResult_t res = flagcxSuccess;
@@ -139,7 +139,7 @@ static void *flagcxRmaProgressThread(void *arg) {
           break;
 
         case FLAGCX_RMA_PUT_SIGNAL: {
-          void **sigHandles = (void **)globalOneSideSignalHandles;
+          void **sigHandles = (void **)comm->signalHandle;
           res = comm->netAdaptor->iputSignal(
               sendComm, desc->srcOff, desc->dstOff, desc->size, comm->rank, p,
               srcHandles, dstHandles, desc->signalOff, sigHandles,
@@ -155,7 +155,7 @@ static void *flagcxRmaProgressThread(void *arg) {
 
         case FLAGCX_RMA_PUT_VALUE: {
           struct flagcxOneSideHandleInfo *stagingH =
-              globalOneSideStagingHandles;
+              comm->stagingHandle;
           if (stagingH == NULL || stagingH->baseVas == NULL) {
             WARN("flagcxRmaProgressThread: staging handles not initialized");
             res = flagcxInternalError;
@@ -164,7 +164,7 @@ static void *flagcxRmaProgressThread(void *arg) {
           *(volatile uint64_t *)(stagingH->baseVas[comm->rank]) =
               desc->putValue;
           void **stagingHandles = (void **)stagingH;
-          void **dstH = (void **)globalOneSideHandleTable[desc->dstMrIdx];
+          void **dstH = (void **)comm->oneSideHandles[desc->dstMrIdx];
           res = comm->netAdaptor->iput(sendComm, 0, desc->dstOff,
                                        sizeof(uint64_t), comm->rank, p,
                                        stagingHandles, dstH, &desc->request);
@@ -508,8 +508,7 @@ flagcxResult_t flagcxHeteroWaitSignal(flagcxHeteroComm_t comm, int peer,
                                       size_t signalOffset, uint64_t expected,
                                       flagcxStream_t stream) {
   (void)peer;
-  struct flagcxOneSideHandleInfo *info =
-      (struct flagcxOneSideHandleInfo *)globalOneSideSignalHandles;
+  struct flagcxOneSideHandleInfo *info = comm->signalHandle;
   if (info == NULL || info->baseVas == NULL)
     return flagcxNotSupported;
 
@@ -536,9 +535,9 @@ flagcxResult_t flagcxHeteroPutValue(flagcxHeteroComm_t comm, int peer,
          comm->nRanks);
     return flagcxInvalidArgument;
   }
-  if (dstMrIdx < 0 || dstMrIdx >= globalOneSideHandleCount) {
+  if (dstMrIdx < 0 || dstMrIdx >= comm->oneSideHandleCount) {
     WARN("flagcxHeteroPutValue: dstMrIdx %d out of range (count=%d)", dstMrIdx,
-         globalOneSideHandleCount);
+         comm->oneSideHandleCount);
     return flagcxInvalidArgument;
   }
   if (comm->rmaProxy == NULL) {

--- a/flagcx/core/flagcx_hetero.cc
+++ b/flagcx/core/flagcx_hetero.cc
@@ -172,10 +172,19 @@ static void *flagcxRmaProgressThread(void *arg) {
       }
 
       if (res != flagcxSuccess) {
-        WARN("flagcxRmaProgressThread: op failed peer=%d type=%d res=%d", p,
-             (int)desc->type, (int)res);
-        __atomic_store_n(&proxy->rmaError, 1, __ATOMIC_RELEASE);
-        free(desc);
+        if (res == flagcxInternalError) {
+          // Request pool exhausted — put desc back to pending for retry
+          INFO(FLAGCX_ALL,
+               "flagcxRmaProgressThread: request pool full, "
+               "re-enqueue peer=%d type=%d",
+                p, (int)desc->type);
+          enqueuePending(proxy, desc);
+        } else {
+          WARN("flagcxRmaProgressThread: op failed peer=%d type=%d res=%d", p,
+               (int)desc->type, (int)res);
+          __atomic_store_n(&proxy->rmaError, 1, __ATOMIC_RELEASE);
+          free(desc);
+        }
       } else {
         // Enqueue to inProgress for later polling.
         if (proxy->inProgressTail != NULL) {

--- a/flagcx/core/include/comm.h
+++ b/flagcx/core/include/comm.h
@@ -164,6 +164,8 @@ struct flagcxRmaProxyState; // forward declaration; defined in flagcx_hetero.h
 
 #define FLAGCX_MAGIC 0x0280028002800280 // Nickel atomic number is 28.
 
+struct flagcxOneSideHandleInfo;
+
 struct flagcxHeteroComm {
   uint64_t startMagic;
   struct flagcxMemoryStack memPermanent, memScoped;
@@ -374,6 +376,15 @@ struct flagcxHeteroComm {
   void *netAdaptorPtr;
   // Async RMA proxy state (one-sided Put/Get offload thread).
   struct flagcxRmaProxyState *rmaProxy;
+
+  // One-sided signal / staging handle
+  struct flagcxOneSideHandleInfo *signalHandle;
+  struct flagcxOneSideHandleInfo *stagingHandle;
+
+  // Per-comm dynamic array of one-sided data handles
+  struct flagcxOneSideHandleInfo **oneSideHandles;
+  int oneSideHandleCount;
+  int oneSideHandleCapacity;
 };
 
 typedef struct flagcxHeteroComm *flagcxHeteroComm_t;

--- a/flagcx/core/include/comm.h
+++ b/flagcx/core/include/comm.h
@@ -236,7 +236,7 @@ struct flagcxHeteroComm {
   struct P2pSchedulePair {
     int sendRank;
     int recvRank;
-  } * p2pSchedule;
+  } *p2pSchedule;
 
   // Should this comm allocate LL buffers for network P2P connections?
   bool allocP2pNetLLBuffers;

--- a/flagcx/core/include/comm.h
+++ b/flagcx/core/include/comm.h
@@ -236,7 +236,7 @@ struct flagcxHeteroComm {
   struct P2pSchedulePair {
     int sendRank;
     int recvRank;
-  } *p2pSchedule;
+  } * p2pSchedule;
 
   // Should this comm allocate LL buffers for network P2P connections?
   bool allocP2pNetLLBuffers;

--- a/flagcx/core/include/global_comm.h
+++ b/flagcx/core/include/global_comm.h
@@ -87,7 +87,7 @@ struct flagcxComm {
   struct C2cSchedulePair {
     int sendCluster;
     int recvCluster;
-  } *c2cSchedule; // C2C schedule for pairing send/recv operations
+  } * c2cSchedule; // C2C schedule for pairing send/recv operations
 
   // IPC peer pointer table — deferred cleanup
   struct flagcxIpcTableEntry ipcTable[FLAGCX_MAX_IPC_ENTRIES];

--- a/flagcx/core/include/global_comm.h
+++ b/flagcx/core/include/global_comm.h
@@ -87,7 +87,7 @@ struct flagcxComm {
   struct C2cSchedulePair {
     int sendCluster;
     int recvCluster;
-  } * c2cSchedule; // C2C schedule for pairing send/recv operations
+  } *c2cSchedule; // C2C schedule for pairing send/recv operations
 
   // IPC peer pointer table — deferred cleanup
   struct flagcxIpcTableEntry ipcTable[FLAGCX_MAX_IPC_ENTRIES];

--- a/flagcx/core/include/onesided.h
+++ b/flagcx/core/include/onesided.h
@@ -11,8 +11,6 @@
 
 #include <stdint.h>
 
-#define FLAGCX_MAX_ONE_SIDE_HANDLES 128
-
 struct flagcxOneSideHandleInfo {
   uintptr_t *baseVas;
   uint32_t *rkeys;
@@ -24,17 +22,5 @@ struct flagcxOneSideHandleInfo {
   void **fullRecvComms; // [nRanks] per-peer recvComm (NULL if not owner)
   int nRanks;           // number of ranks (for cleanup iteration)
 };
-
-// Handle table for per-window MR addressing (aligned with NCCL GIN per-window
-// MR)
-extern struct flagcxOneSideHandleInfo
-    *globalOneSideHandleTable[FLAGCX_MAX_ONE_SIDE_HANDLES];
-extern int globalOneSideHandleCount;
-
-// Global variable for one-sided signal handles (separate MR, NCCL-style)
-extern struct flagcxOneSideHandleInfo *globalOneSideSignalHandles;
-
-// Global variable for one-sided staging handles (for PutValue inline)
-extern struct flagcxOneSideHandleInfo *globalOneSideStagingHandles;
 
 #endif // FLAGCX_ONESIDED_H_

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -1276,8 +1276,7 @@ void *flagcxProxyKernelService(void *args) {
       return flagcxInvalidArgument;
 
     // Check full-mesh connection exists for this peer (including self-loopback)
-    if (meshH->fullSendComms == NULL ||
-        meshH->fullSendComms[peerRank] == NULL)
+    if (meshH->fullSendComms == NULL || meshH->fullSendComms[peerRank] == NULL)
       return flagcxNotSupported;
 
     return flagcxSuccess;
@@ -1405,7 +1404,8 @@ void *flagcxProxyKernelService(void *args) {
             break;
           if (comm->signalHandle == NULL) {
             WARN("flagcxDevicePrimSignal: signal handles not initialized "
-                 "for this comm — call flagcxOneSideSignalRegister() before use");
+                 "for this comm — call flagcxOneSideSignalRegister() before "
+                 "use");
             res = flagcxInternalError;
             break;
           }

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -1268,16 +1268,16 @@ void *flagcxProxyKernelService(void *args) {
 
   auto validateOneSidedPeer = [](struct flagcxHeteroComm *comm,
                                  int peerRank) -> flagcxResult_t {
-    if (globalOneSideHandleCount == 0 || globalOneSideHandleTable[0] == NULL)
+    struct flagcxOneSideHandleInfo *meshH =
+        (comm->oneSideHandleCount > 0) ? comm->oneSideHandles[0] : NULL;
+    if (meshH == NULL)
       return flagcxNotSupported;
     if (peerRank < 0 || peerRank >= comm->nRanks)
       return flagcxInvalidArgument;
 
     // Check full-mesh connection exists for this peer (including self-loopback)
-    struct flagcxOneSideHandleInfo *handles =
-        (struct flagcxOneSideHandleInfo *)globalOneSideHandleTable[0];
-    if (handles->fullSendComms == NULL ||
-        handles->fullSendComms[peerRank] == NULL)
+    if (meshH->fullSendComms == NULL ||
+        meshH->fullSendComms[peerRank] == NULL)
       return flagcxNotSupported;
 
     return flagcxSuccess;
@@ -1403,9 +1403,9 @@ void *flagcxProxyKernelService(void *args) {
           res = validateOneSidedPeer(comm, peerRank);
           if (res != flagcxSuccess)
             break;
-          if (globalOneSideSignalHandles == NULL) {
-            WARN("flagcxDevicePrimSignal: globalOneSideSignalHandles not "
-                 "initialized — call flagcxOneSideSignalRegister() before use");
+          if (comm->signalHandle == NULL) {
+            WARN("flagcxDevicePrimSignal: signal handles not initialized "
+                 "for this comm — call flagcxOneSideSignalRegister() before use");
             res = flagcxInternalError;
             break;
           }
@@ -1469,9 +1469,9 @@ void *flagcxProxyKernelService(void *args) {
         int signalIdx = (int)ptr->getSignalIdx();
         uint64_t signalValue = ptr->getSignalValue();
         size_t signalOff = (size_t)signalIdx * sizeof(uint64_t);
-        if (globalOneSideSignalHandles == NULL) {
-          WARN("flagcxDevicePrimPutSignal: globalOneSideSignalHandles not "
-               "initialized — call flagcxOneSideSignalRegister() before use");
+        if (comm->signalHandle == NULL) {
+          WARN("flagcxDevicePrimPutSignal: signal handles not initialized "
+               "for this comm — call flagcxOneSideSignalRegister() before use");
           res = flagcxInternalError;
           break;
         }

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -68,38 +68,26 @@ flagcxResult_t wrapper_deviceMemcpy(void *dst, void *src, size_t size,
   return deviceAdaptor->deviceMemcpy(dst, src, size, type, stream, NULL);
 }
 
-static struct flagcxDeviceHandle globalDeviceHandle{
-    // Basic functions
-    deviceAdaptor->deviceSynchronize,
-    wrapper_deviceMemcpy,
-    deviceAdaptor->deviceMemset,
-    deviceAdaptor->deviceMalloc,
-    deviceAdaptor->deviceFree,
-    deviceAdaptor->setDevice,
-    deviceAdaptor->getDevice,
-    deviceAdaptor->getDeviceCount,
-    deviceAdaptor->getVendor,
-    deviceAdaptor->hostGetDevicePointer,
-    // Stream functions
-    deviceAdaptor->streamCreate,
-    deviceAdaptor->streamDestroy,
-    deviceAdaptor->streamCopy,
-    deviceAdaptor->streamFree,
-    deviceAdaptor->streamSynchronize,
-    deviceAdaptor->streamQuery,
-    deviceAdaptor->streamWaitEvent,
-    // Event functions
-    deviceAdaptor->eventCreate,
-    deviceAdaptor->eventDestroy,
-    deviceAdaptor->eventRecord,
-    deviceAdaptor->eventSynchronize,
-    deviceAdaptor->eventQuery,
-    // IpcMemHandle functions
-    deviceAdaptor->ipcMemHandleCreate,
-    deviceAdaptor->ipcMemHandleGet,
-    deviceAdaptor->ipcMemHandleOpen,
-    deviceAdaptor->ipcMemHandleClose,
-    deviceAdaptor->ipcMemHandleFree,
+static struct flagcxDeviceHandle globalDeviceHandle {
+  // Basic functions
+  deviceAdaptor->deviceSynchronize, wrapper_deviceMemcpy,
+      deviceAdaptor->deviceMemset, deviceAdaptor->deviceMalloc,
+      deviceAdaptor->deviceFree, deviceAdaptor->setDevice,
+      deviceAdaptor->getDevice, deviceAdaptor->getDeviceCount,
+      deviceAdaptor->getVendor, deviceAdaptor->hostGetDevicePointer,
+      // Stream functions
+      deviceAdaptor->streamCreate, deviceAdaptor->streamDestroy,
+      deviceAdaptor->streamCopy, deviceAdaptor->streamFree,
+      deviceAdaptor->streamSynchronize, deviceAdaptor->streamQuery,
+      deviceAdaptor->streamWaitEvent,
+      // Event functions
+      deviceAdaptor->eventCreate, deviceAdaptor->eventDestroy,
+      deviceAdaptor->eventRecord, deviceAdaptor->eventSynchronize,
+      deviceAdaptor->eventQuery,
+      // IpcMemHandle functions
+      deviceAdaptor->ipcMemHandleCreate, deviceAdaptor->ipcMemHandleGet,
+      deviceAdaptor->ipcMemHandleOpen, deviceAdaptor->ipcMemHandleClose,
+      deviceAdaptor->ipcMemHandleFree,
 };
 
 void flagcxRebuildGlobalDeviceHandle() {

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -68,26 +68,38 @@ flagcxResult_t wrapper_deviceMemcpy(void *dst, void *src, size_t size,
   return deviceAdaptor->deviceMemcpy(dst, src, size, type, stream, NULL);
 }
 
-static struct flagcxDeviceHandle globalDeviceHandle {
-  // Basic functions
-  deviceAdaptor->deviceSynchronize, wrapper_deviceMemcpy,
-      deviceAdaptor->deviceMemset, deviceAdaptor->deviceMalloc,
-      deviceAdaptor->deviceFree, deviceAdaptor->setDevice,
-      deviceAdaptor->getDevice, deviceAdaptor->getDeviceCount,
-      deviceAdaptor->getVendor, deviceAdaptor->hostGetDevicePointer,
-      // Stream functions
-      deviceAdaptor->streamCreate, deviceAdaptor->streamDestroy,
-      deviceAdaptor->streamCopy, deviceAdaptor->streamFree,
-      deviceAdaptor->streamSynchronize, deviceAdaptor->streamQuery,
-      deviceAdaptor->streamWaitEvent,
-      // Event functions
-      deviceAdaptor->eventCreate, deviceAdaptor->eventDestroy,
-      deviceAdaptor->eventRecord, deviceAdaptor->eventSynchronize,
-      deviceAdaptor->eventQuery,
-      // IpcMemHandle functions
-      deviceAdaptor->ipcMemHandleCreate, deviceAdaptor->ipcMemHandleGet,
-      deviceAdaptor->ipcMemHandleOpen, deviceAdaptor->ipcMemHandleClose,
-      deviceAdaptor->ipcMemHandleFree,
+static struct flagcxDeviceHandle globalDeviceHandle{
+    // Basic functions
+    deviceAdaptor->deviceSynchronize,
+    wrapper_deviceMemcpy,
+    deviceAdaptor->deviceMemset,
+    deviceAdaptor->deviceMalloc,
+    deviceAdaptor->deviceFree,
+    deviceAdaptor->setDevice,
+    deviceAdaptor->getDevice,
+    deviceAdaptor->getDeviceCount,
+    deviceAdaptor->getVendor,
+    deviceAdaptor->hostGetDevicePointer,
+    // Stream functions
+    deviceAdaptor->streamCreate,
+    deviceAdaptor->streamDestroy,
+    deviceAdaptor->streamCopy,
+    deviceAdaptor->streamFree,
+    deviceAdaptor->streamSynchronize,
+    deviceAdaptor->streamQuery,
+    deviceAdaptor->streamWaitEvent,
+    // Event functions
+    deviceAdaptor->eventCreate,
+    deviceAdaptor->eventDestroy,
+    deviceAdaptor->eventRecord,
+    deviceAdaptor->eventSynchronize,
+    deviceAdaptor->eventQuery,
+    // IpcMemHandle functions
+    deviceAdaptor->ipcMemHandleCreate,
+    deviceAdaptor->ipcMemHandleGet,
+    deviceAdaptor->ipcMemHandleOpen,
+    deviceAdaptor->ipcMemHandleClose,
+    deviceAdaptor->ipcMemHandleFree,
 };
 
 void flagcxRebuildGlobalDeviceHandle() {
@@ -398,7 +410,8 @@ flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
 
   // First handle for this heteroComm: build a new full-mesh IB connection set
   if (isFirstHandle) {
-    FLAGCXCHECKGOTO(flagcxOneSideBuildFullMesh(heteroComm, info), res, fail_info);
+    FLAGCXCHECKGOTO(flagcxOneSideBuildFullMesh(heteroComm, info), res,
+                    fail_info);
   }
 
   // Use self recvComm for MR registration (PD match)
@@ -560,7 +573,8 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
     if (existing->baseVas != NULL &&
         existing->baseVas[comm->rank] != (uintptr_t)buff) {
       WARN("flagcxOneSideSignalRegister: comm %p already registered with a "
-           "different buffer", (void *)comm);
+           "different buffer",
+           (void *)comm);
     }
     return flagcxSuccess;
   }
@@ -593,8 +607,9 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
     firstDataHandle = heteroComm->oneSideHandles[0];
   }
   if (firstDataHandle == NULL) {
-    INFO(FLAGCX_REG, "flagcxOneSideSignalRegister: no full-mesh connections for "
-                     "this heteroComm, register a data buffer first");
+    INFO(FLAGCX_REG,
+         "flagcxOneSideSignalRegister: no full-mesh connections for "
+         "this heteroComm, register a data buffer first");
     return flagcxNotSupported;
   }
 
@@ -604,7 +619,8 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
   void *regComm = NULL;
   struct flagcxOneSideHandleInfo *info = NULL;
 
-  // Use self recvComm from this comm's first data handle for MR registration (PD match)
+  // Use self recvComm from this comm's first data handle for MR registration
+  // (PD match)
   void *selfRecvComm = firstDataHandle->fullRecvComms[state->rank];
   regComm = selfRecvComm;
   if (heteroComm->netAdaptor->name &&
@@ -673,7 +689,8 @@ fail_mr:
   return res;
 }
 
-flagcxResult_t flagcxOneSideSignalDeregister(struct flagcxHeteroComm *heteroComm) {
+flagcxResult_t
+flagcxOneSideSignalDeregister(struct flagcxHeteroComm *heteroComm) {
   if (heteroComm == NULL)
     return flagcxInternalError;
   struct flagcxOneSideHandleInfo *info = heteroComm->signalHandle;
@@ -708,13 +725,13 @@ flagcxResult_t flagcxOneSideStagingRegister(const flagcxComm_t comm, void *buff,
   }
 
   // Per-heteroComm dedup
-  struct flagcxOneSideHandleInfo *existingStg =
-      comm->heteroComm->stagingHandle;
+  struct flagcxOneSideHandleInfo *existingStg = comm->heteroComm->stagingHandle;
   if (existingStg != NULL) {
     if (existingStg->baseVas != NULL &&
         existingStg->baseVas[comm->rank] != (uintptr_t)buff) {
       WARN("flagcxOneSideStagingRegister: comm %p already registered with a "
-           "different buffer", (void *)comm);
+           "different buffer",
+           (void *)comm);
     }
     return flagcxSuccess;
   }
@@ -742,8 +759,9 @@ flagcxResult_t flagcxOneSideStagingRegister(const flagcxComm_t comm, void *buff,
     firstDataHandleStg = heteroComm->oneSideHandles[0];
   }
   if (firstDataHandleStg == NULL) {
-    INFO(FLAGCX_REG, "flagcxOneSideStagingRegister: no full-mesh connections for "
-                     "this heteroComm, register a data buffer first");
+    INFO(FLAGCX_REG,
+         "flagcxOneSideStagingRegister: no full-mesh connections for "
+         "this heteroComm, register a data buffer first");
     return flagcxNotSupported;
   }
 
@@ -753,7 +771,8 @@ flagcxResult_t flagcxOneSideStagingRegister(const flagcxComm_t comm, void *buff,
   void *regComm = NULL;
   struct flagcxOneSideHandleInfo *info = NULL;
 
-  // Use self recvComm from this comm's first data handle for MR registration (PD match)
+  // Use self recvComm from this comm's first data handle for MR registration
+  // (PD match)
   void *selfRecvComm = firstDataHandleStg->fullRecvComms[state->rank];
   regComm = selfRecvComm;
   if (heteroComm->netAdaptor->name &&

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -27,11 +27,6 @@
 #include <unordered_map>
 
 flagcxRegPool globalRegPool;
-struct flagcxOneSideHandleInfo
-    *globalOneSideHandleTable[FLAGCX_MAX_ONE_SIDE_HANDLES] = {};
-int globalOneSideHandleCount = 0;
-struct flagcxOneSideHandleInfo *globalOneSideSignalHandles = NULL;
-struct flagcxOneSideHandleInfo *globalOneSideStagingHandles = NULL;
 
 size_t getFlagcxDataTypeSize(flagcxDataType_t dtype) {
   switch (dtype) {
@@ -239,9 +234,8 @@ flagcxResult_t flagcxMemFree(void *ptr) {
 // Called once on the first flagcxOneSideRegister invocation; stored in
 // handle[0]. Pattern aligned with NCCL GIN gin.cc:146-158.
 static flagcxResult_t
-flagcxOneSideBuildFullMesh(const flagcxComm_t comm,
+flagcxOneSideBuildFullMesh(struct flagcxHeteroComm *heteroComm,
                            struct flagcxOneSideHandleInfo *info) {
-  struct flagcxHeteroComm *heteroComm = comm->heteroComm;
   struct bootstrapState *state = heteroComm->bootstrap;
   int nranks = state->nranks;
   int rank = state->rank;
@@ -345,25 +339,20 @@ flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
     return flagcxSuccess;
   }
 
-  // Check for duplicate registration of the same buffer
-  for (int i = 0; i < globalOneSideHandleCount; i++) {
-    if (globalOneSideHandleTable[i] != NULL &&
-        globalOneSideHandleTable[i]->baseVas != NULL &&
-        globalOneSideHandleTable[i]->baseVas[comm->rank] == (uintptr_t)buff) {
+  struct flagcxHeteroComm *heteroComm = comm->heteroComm;
+
+  // Check for duplicate registration of the same buffer within this comm
+  for (int i = 0; i < heteroComm->oneSideHandleCount; i++) {
+    struct flagcxOneSideHandleInfo *h = heteroComm->oneSideHandles[i];
+    if (h != NULL && h->baseVas != NULL &&
+        h->baseVas[comm->rank] == (uintptr_t)buff) {
       INFO(FLAGCX_REG,
-           "flagcxOneSideRegister: buffer %p already registered at slot %d",
+           "flagcxOneSideRegister: buffer %p already registered at index %d",
            buff, i);
       return flagcxSuccess;
     }
   }
 
-  if (globalOneSideHandleCount >= FLAGCX_MAX_ONE_SIDE_HANDLES) {
-    WARN("flagcxOneSideRegister: handle table full (%d/%d)",
-         globalOneSideHandleCount, FLAGCX_MAX_ONE_SIDE_HANDLES);
-    return flagcxNotSupported;
-  }
-
-  struct flagcxHeteroComm *heteroComm = comm->heteroComm;
   if (heteroComm == NULL || heteroComm->netAdaptor == NULL ||
       heteroComm->netAdaptor->iput == NULL ||
       heteroComm->netAdaptor->regMr == NULL) {
@@ -382,21 +371,42 @@ flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
   struct ibv_mr *mr = NULL;
   void *regComm = NULL;
   struct flagcxOneSideHandleInfo *info = NULL;
-  int slot = globalOneSideHandleCount;
-  bool isFirstHandle = (slot == 0);
+
+  // Grow dynamic array if needed (doubling strategy, initial capacity 4)
+  if (heteroComm->oneSideHandleCount >= heteroComm->oneSideHandleCapacity) {
+    int newCap = heteroComm->oneSideHandleCapacity == 0
+                     ? 4
+                     : heteroComm->oneSideHandleCapacity * 2;
+    struct flagcxOneSideHandleInfo **newArr =
+        (struct flagcxOneSideHandleInfo **)realloc(
+            heteroComm->oneSideHandles,
+            newCap * sizeof(struct flagcxOneSideHandleInfo *));
+    if (newArr == NULL) {
+      WARN("flagcxOneSideRegister: realloc failed");
+      return flagcxSystemError;
+    }
+    // Zero-init new slots
+    for (int i = heteroComm->oneSideHandleCapacity; i < newCap; i++)
+      newArr[i] = NULL;
+    heteroComm->oneSideHandles = newArr;
+    heteroComm->oneSideHandleCapacity = newCap;
+  }
+
+  bool isFirstHandle = (heteroComm->oneSideHandleCount == 0);
 
   FLAGCXCHECKGOTO(flagcxCalloc(&info, 1), res, fail);
 
-  // First handle: build full-mesh IB connections (including self-loopback)
+  // First handle for this heteroComm: build a new full-mesh IB connection set
   if (isFirstHandle) {
-    FLAGCXCHECKGOTO(flagcxOneSideBuildFullMesh(comm, info), res, fail_info);
+    FLAGCXCHECKGOTO(flagcxOneSideBuildFullMesh(heteroComm, info), res, fail_info);
   }
 
   // Use self recvComm for MR registration (PD match)
   {
     void *selfRecvComm =
-        isFirstHandle ? info->fullRecvComms[state->rank]
-                      : globalOneSideHandleTable[0]->fullRecvComms[state->rank];
+        isFirstHandle
+            ? info->fullRecvComms[state->rank]
+            : heteroComm->oneSideHandles[0]->fullRecvComms[state->rank];
     info->localRecvComm = selfRecvComm;
     regComm = selfRecvComm;
     if (heteroComm->netAdaptor->name &&
@@ -446,11 +456,12 @@ flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
         bootstrapAllGather(state, (void *)info->lkeys, sizeof(uint32_t)), res,
         fail_mr);
 
-    globalOneSideHandleTable[slot] = info;
-    globalOneSideHandleCount = slot + 1;
+    int slot = heteroComm->oneSideHandleCount;
+    heteroComm->oneSideHandles[slot] = info;
+    heteroComm->oneSideHandleCount = slot + 1;
 
     INFO(FLAGCX_REG,
-         "One-sided register slot %d allgather results (rank %d, nranks %d):",
+         "One-sided register index %d allgather results (rank %d, nranks %d):",
          slot, state->rank, nranks);
     for (int i = 0; i < nranks; i++) {
       INFO(FLAGCX_REG, "  Rank %d: base_va=0x%lx, rkey=0x%x, lkey=0x%x", i,
@@ -486,18 +497,17 @@ fail:
   return res;
 }
 
-flagcxResult_t flagcxOneSideDeregister(const flagcxComm_t comm) {
-  if (comm == NULL)
+flagcxResult_t flagcxOneSideDeregister(struct flagcxHeteroComm *heteroComm) {
+  if (heteroComm == NULL)
     return flagcxInternalError;
-  struct flagcxHeteroComm *heteroComm = comm->heteroComm;
 
-  // Deregister all handles in reverse order
-  for (int slot = globalOneSideHandleCount - 1; slot >= 0; slot--) {
-    struct flagcxOneSideHandleInfo *info = globalOneSideHandleTable[slot];
+  // Deregister all data handles in reverse order
+  for (int i = heteroComm->oneSideHandleCount - 1; i >= 0; i--) {
+    struct flagcxOneSideHandleInfo *info = heteroComm->oneSideHandles[i];
     if (info == NULL)
       continue;
 
-    if (heteroComm != NULL && heteroComm->netAdaptor != NULL) {
+    if (heteroComm->netAdaptor != NULL) {
       // Deregister MR
       if (info->localMrHandle != NULL && info->localRecvComm != NULL) {
         void *regComm = info->localRecvComm;
@@ -510,8 +520,8 @@ flagcxResult_t flagcxOneSideDeregister(const flagcxComm_t comm) {
         heteroComm->netAdaptor->deregMr(regComm, info->localMrHandle);
       }
 
-      // Close full-mesh connections (only stored in slot 0)
-      if (slot == 0 && info->fullSendComms != NULL) {
+      // Close full-mesh connections (only in the first handle)
+      if (info->fullSendComms != NULL) {
         for (int i = 0; i < info->nRanks; i++) {
           if (info->fullSendComms[i])
             heteroComm->netAdaptor->closeSend(info->fullSendComms[i]);
@@ -527,9 +537,13 @@ flagcxResult_t flagcxOneSideDeregister(const flagcxComm_t comm) {
     free(info->rkeys);
     free(info->lkeys);
     free(info);
-    globalOneSideHandleTable[slot] = NULL;
+    heteroComm->oneSideHandles[i] = NULL;
   }
-  globalOneSideHandleCount = 0;
+
+  free(heteroComm->oneSideHandles);
+  heteroComm->oneSideHandles = NULL;
+  heteroComm->oneSideHandleCount = 0;
+  heteroComm->oneSideHandleCapacity = 0;
   return flagcxSuccess;
 }
 
@@ -539,11 +553,14 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
     return flagcxSuccess;
   }
 
-  if (globalOneSideSignalHandles != NULL) {
-    if (globalOneSideSignalHandles->baseVas != NULL &&
-        globalOneSideSignalHandles->baseVas[comm->rank] != (uintptr_t)buff) {
-      WARN("flagcxOneSideSignalRegister: already registered with a different "
-           "buffer");
+  // Per-heteroComm dedup: skip if already registered
+  struct flagcxHeteroComm *heteroComm = comm->heteroComm;
+  struct flagcxOneSideHandleInfo *existing = heteroComm->signalHandle;
+  if (existing != NULL) {
+    if (existing->baseVas != NULL &&
+        existing->baseVas[comm->rank] != (uintptr_t)buff) {
+      WARN("flagcxOneSideSignalRegister: comm %p already registered with a "
+           "different buffer", (void *)comm);
     }
     return flagcxSuccess;
   }
@@ -555,7 +572,6 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
     return flagcxInvalidArgument;
   }
 
-  struct flagcxHeteroComm *heteroComm = comm->heteroComm;
   if (heteroComm == NULL || heteroComm->netAdaptor == NULL ||
       heteroComm->netAdaptor->iputSignal == NULL ||
       heteroComm->netAdaptor->regMr == NULL) {
@@ -568,12 +584,17 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
     return flagcxNotSupported;
   }
 
-  // Signal registration reuses full-mesh connections from data handle table.
-  // Requires at least one data handle to be registered first.
-  if (globalOneSideHandleCount == 0 ||
-      globalOneSideHandleTable[0]->fullRecvComms == NULL) {
-    INFO(FLAGCX_REG, "flagcxOneSideSignalRegister: no full-mesh connections, "
-                     "register a data buffer first");
+  // Signal registration reuses full-mesh connections from this heteroComm's
+  // first data handle.  Requires at least one data handle first.
+  struct flagcxOneSideHandleInfo *firstDataHandle = NULL;
+  if (heteroComm->oneSideHandleCount > 0 &&
+      heteroComm->oneSideHandles[0] != NULL &&
+      heteroComm->oneSideHandles[0]->fullRecvComms != NULL) {
+    firstDataHandle = heteroComm->oneSideHandles[0];
+  }
+  if (firstDataHandle == NULL) {
+    INFO(FLAGCX_REG, "flagcxOneSideSignalRegister: no full-mesh connections for "
+                     "this heteroComm, register a data buffer first");
     return flagcxNotSupported;
   }
 
@@ -583,8 +604,8 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
   void *regComm = NULL;
   struct flagcxOneSideHandleInfo *info = NULL;
 
-  // Use self recvComm from data handle[0] for MR registration (PD match)
-  void *selfRecvComm = globalOneSideHandleTable[0]->fullRecvComms[state->rank];
+  // Use self recvComm from this comm's first data handle for MR registration (PD match)
+  void *selfRecvComm = firstDataHandle->fullRecvComms[state->rank];
   regComm = selfRecvComm;
   if (heteroComm->netAdaptor->name &&
       strcmp(heteroComm->netAdaptor->name, "IB") == 0) {
@@ -629,7 +650,7 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
     FLAGCXCHECKGOTO(
         bootstrapAllGather(state, (void *)info->lkeys, sizeof(uint32_t)), res,
         fail_mr);
-    globalOneSideSignalHandles = info;
+    heteroComm->signalHandle = info;
     INFO(FLAGCX_REG,
          "Signal register allgather results (rank %d, nranks %d):", state->rank,
          nranks);
@@ -652,16 +673,14 @@ fail_mr:
   return res;
 }
 
-flagcxResult_t flagcxOneSideSignalDeregister(const flagcxComm_t comm) {
-  struct flagcxOneSideHandleInfo *info = globalOneSideSignalHandles;
+flagcxResult_t flagcxOneSideSignalDeregister(struct flagcxHeteroComm *heteroComm) {
+  if (heteroComm == NULL)
+    return flagcxInternalError;
+  struct flagcxOneSideHandleInfo *info = heteroComm->signalHandle;
   if (info == NULL)
     return flagcxSuccess;
-  if (comm == NULL)
-    return flagcxInternalError;
 
-  struct flagcxHeteroComm *heteroComm = comm->heteroComm;
-  if (heteroComm != NULL && heteroComm->netAdaptor != NULL) {
-    // Deregister MR (connections are shared with data handle table, not owned)
+  if (heteroComm->netAdaptor != NULL) {
     if (info->localMrHandle != NULL && info->localRecvComm != NULL) {
       void *regComm = info->localRecvComm;
       if (heteroComm->netAdaptor->name &&
@@ -672,14 +691,13 @@ flagcxResult_t flagcxOneSideSignalDeregister(const flagcxComm_t comm) {
       }
       heteroComm->netAdaptor->deregMr(regComm, info->localMrHandle);
     }
-    // No closeSend/closeRecv — connections owned by data handle table[0]
   }
 
   free(info->baseVas);
   free(info->rkeys);
   free(info->lkeys);
   free(info);
-  globalOneSideSignalHandles = NULL;
+  heteroComm->signalHandle = NULL;
   return flagcxSuccess;
 }
 
@@ -689,11 +707,14 @@ flagcxResult_t flagcxOneSideStagingRegister(const flagcxComm_t comm, void *buff,
     return flagcxSuccess;
   }
 
-  if (globalOneSideStagingHandles != NULL) {
-    if (globalOneSideStagingHandles->baseVas != NULL &&
-        globalOneSideStagingHandles->baseVas[comm->rank] != (uintptr_t)buff) {
-      WARN("flagcxOneSideStagingRegister: already registered with a different "
-           "buffer");
+  // Per-heteroComm dedup
+  struct flagcxOneSideHandleInfo *existingStg =
+      comm->heteroComm->stagingHandle;
+  if (existingStg != NULL) {
+    if (existingStg->baseVas != NULL &&
+        existingStg->baseVas[comm->rank] != (uintptr_t)buff) {
+      WARN("flagcxOneSideStagingRegister: comm %p already registered with a "
+           "different buffer", (void *)comm);
     }
     return flagcxSuccess;
   }
@@ -712,11 +733,17 @@ flagcxResult_t flagcxOneSideStagingRegister(const flagcxComm_t comm, void *buff,
     return flagcxNotSupported;
   }
 
-  // Staging registration reuses full-mesh connections from data handle table.
-  if (globalOneSideHandleCount == 0 ||
-      globalOneSideHandleTable[0]->fullRecvComms == NULL) {
-    INFO(FLAGCX_REG, "flagcxOneSideStagingRegister: no full-mesh connections, "
-                     "register a data buffer first");
+  // Staging registration reuses full-mesh connections from this heteroComm's
+  // first data handle.  Requires at least one data handle first.
+  struct flagcxOneSideHandleInfo *firstDataHandleStg = NULL;
+  if (heteroComm->oneSideHandleCount > 0 &&
+      heteroComm->oneSideHandles[0] != NULL &&
+      heteroComm->oneSideHandles[0]->fullRecvComms != NULL) {
+    firstDataHandleStg = heteroComm->oneSideHandles[0];
+  }
+  if (firstDataHandleStg == NULL) {
+    INFO(FLAGCX_REG, "flagcxOneSideStagingRegister: no full-mesh connections for "
+                     "this heteroComm, register a data buffer first");
     return flagcxNotSupported;
   }
 
@@ -726,8 +753,8 @@ flagcxResult_t flagcxOneSideStagingRegister(const flagcxComm_t comm, void *buff,
   void *regComm = NULL;
   struct flagcxOneSideHandleInfo *info = NULL;
 
-  // Use self recvComm from data handle[0] for MR registration (PD match)
-  void *selfRecvComm = globalOneSideHandleTable[0]->fullRecvComms[state->rank];
+  // Use self recvComm from this comm's first data handle for MR registration (PD match)
+  void *selfRecvComm = firstDataHandleStg->fullRecvComms[state->rank];
   regComm = selfRecvComm;
   if (heteroComm->netAdaptor->name &&
       strcmp(heteroComm->netAdaptor->name, "IB") == 0) {
@@ -773,7 +800,7 @@ flagcxResult_t flagcxOneSideStagingRegister(const flagcxComm_t comm, void *buff,
     FLAGCXCHECKGOTO(
         bootstrapAllGather(state, (void *)info->lkeys, sizeof(uint32_t)), res,
         fail_mr);
-    globalOneSideStagingHandles = info;
+    heteroComm->stagingHandle = info;
     INFO(FLAGCX_REG, "Staging register allgather results (rank %d, nranks %d):",
          state->rank, nranks);
     for (int i = 0; i < nranks; i++) {
@@ -796,14 +823,14 @@ fail_mr:
 }
 
 flagcxResult_t flagcxOneSideStagingDeregister(const flagcxComm_t comm) {
-  struct flagcxOneSideHandleInfo *info = globalOneSideStagingHandles;
+  if (comm == NULL || comm->heteroComm == NULL)
+    return flagcxInternalError;
+  struct flagcxHeteroComm *heteroComm = comm->heteroComm;
+  struct flagcxOneSideHandleInfo *info = heteroComm->stagingHandle;
   if (info == NULL)
     return flagcxSuccess;
-  if (comm == NULL)
-    return flagcxInternalError;
 
-  struct flagcxHeteroComm *heteroComm = comm->heteroComm;
-  if (heteroComm != NULL && heteroComm->netAdaptor != NULL) {
+  if (heteroComm->netAdaptor != NULL) {
     if (info->localMrHandle != NULL && info->localRecvComm != NULL) {
       void *regComm = info->localRecvComm;
       if (heteroComm->netAdaptor->name &&
@@ -820,7 +847,7 @@ flagcxResult_t flagcxOneSideStagingDeregister(const flagcxComm_t comm) {
   free(info->rkeys);
   free(info->lkeys);
   free(info);
-  globalOneSideStagingHandles = NULL;
+  heteroComm->stagingHandle = NULL;
   return flagcxSuccess;
 }
 
@@ -1599,6 +1626,11 @@ flagcxResult_t flagcxCommDestroy(flagcxComm_t comm) {
     // flagcxCommRelayDestroy via the bootstrap barrier before any teardown.
     FLAGCXCHECK(flagcxCommRelayDestroy(comm));
     // Destroy hetero comm (stops/joins proxy threads, frees proxyState)
+    flagcxOneSideStagingDeregister(comm);
+    flagcxOneSideSignalDeregister(comm->heteroComm);
+    flagcxOneSideDeregister(comm->heteroComm);
+
+    // Destroy hetero comm
     FLAGCXCHECK(flagcxHeteroCommDestroy(comm->heteroComm));
     // Destroy host comm
     if (useHostComm()) {

--- a/flagcx/include/flagcx.h
+++ b/flagcx/include/flagcx.h
@@ -449,6 +449,28 @@ flagcxResult_t flagcxRecv(void *recvbuff, size_t count,
  * communicators backed by an RDMA-capable net adaptor.
  */
 
+/* Register a data buffer for one-sided RDMA operations.  Collective: ALL ranks
+ * in the communicator must call with their local buffer.  Internally performs
+ * an AllGather of MR metadata so every rank knows every other rank's rkey and
+ * base VA. */
+flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
+                                     size_t size);
+
+/* Register a signal buffer for one-sided RDMA operations.
+ * ptrType: FLAGCX_PTR_CUDA for device memory, FLAGCX_PTR_HOST for host-pinned
+ * memory.  Collective: ALL ranks in the communicator must call. */
+flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
+                                           size_t size, int ptrType);
+
+/* Register a host-pinned staging buffer for one-sided PutValue operations.
+ * Must be called after flagcxOneSideSignalRegister.  Collective: ALL ranks
+ * in the communicator must call. */
+flagcxResult_t flagcxOneSideStagingRegister(const flagcxComm_t comm, void *buff,
+                                            size_t size);
+
+/* Release staging buffer MR resources. */
+flagcxResult_t flagcxOneSideStagingDeregister(const flagcxComm_t comm);
+
 /* RDMA READ: pull size bytes from remote peer's buffer at srcOffset into the
  * local buffer at dstOffset. srcMrIdx / dstMrIdx index the per-window MR
  * handle table populated by flagcxOneSideRegister. */

--- a/flagcx/include/flagcx_kernel.h
+++ b/flagcx/include/flagcx_kernel.h
@@ -4,6 +4,8 @@
 #include "adaptor.h"
 #include "flagcx.h"
 
+struct flagcxHeteroComm;
+
 #define FLAGCX_FIFO_CAPACITY 128
 #define flagcxTriggerMask(w) ((w == 64) ? ~0ull : ((1ull << w) - 1))
 
@@ -436,7 +438,7 @@ flagcxResult_t flagcxCommDrainDeferredFrees(flagcxComm_t comm);
 flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
                                      size_t size);
 // Release data buffer resources (MR, network connections, handle arrays).
-flagcxResult_t flagcxOneSideDeregister(const flagcxComm_t comm);
+flagcxResult_t flagcxOneSideDeregister(struct flagcxHeteroComm *heteroComm);
 
 // One-sided signal buffer registration.
 // Registers a per-rank signal buffer used by one-sided operations.
@@ -456,7 +458,7 @@ flagcxResult_t flagcxOneSideDeregister(const flagcxComm_t comm);
 flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
                                            size_t size, int ptrType);
 // Release signal buffer resources (MR, network connections, handle arrays).
-flagcxResult_t flagcxOneSideSignalDeregister(const flagcxComm_t comm);
+flagcxResult_t flagcxOneSideSignalDeregister(struct flagcxHeteroComm *heteroComm);
 
 // One-sided staging buffer registration (host-pinned memory for PutValue).
 // Must be called after flagcxOneSideSignalRegister (requires full-mesh

--- a/flagcx/include/flagcx_kernel.h
+++ b/flagcx/include/flagcx_kernel.h
@@ -259,12 +259,11 @@ struct flagcxDevCommRequirements {
 
 #define FLAGCX_DEV_COMM_REQUIREMENTS_INITIALIZER                               \
   {                                                                            \
-      false,       /* intraMulticast */                                        \
-      0,     0, 0, /* barrierCount, intraBarrierCount, interBarrierCount */    \
-      0,     0,    /* intraLLA2ABlockCount, intraLLA2ASlotCount */             \
-      false, 4, 0,                                                             \
-      0 /* interForceEnable, interContextCount,                                \
-           interSignalCount, interCounterCount */                              \
+    false,       /* intraMulticast */                                          \
+        0, 0, 0, /* barrierCount, intraBarrierCount, interBarrierCount */      \
+        0, 0,    /* intraLLA2ABlockCount, intraLLA2ASlotCount */               \
+        false, 4, 0, 0 /* interForceEnable, interContextCount,                 \
+                          interSignalCount, interCounterCount */               \
   }
 
 // Network type enumeration (maps to ncclGinType_t on NVIDIA backend).

--- a/flagcx/include/flagcx_kernel.h
+++ b/flagcx/include/flagcx_kernel.h
@@ -433,40 +433,13 @@ flagcxResult_t flagcxCommRelayDestroy(flagcxComm_t comm);
 void flagcxCommDeferFree(flagcxComm_t comm, void *ptr, int memType);
 flagcxResult_t flagcxCommDrainDeferredFrees(flagcxComm_t comm);
 
-// One-sided data buffer registration.
-// Must be called after flagcxCommInitRank and before one-sided operations.
-flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
-                                     size_t size);
 // Release data buffer resources (MR, network connections, handle arrays).
 flagcxResult_t flagcxOneSideDeregister(struct flagcxHeteroComm *heteroComm);
 
-// One-sided signal buffer registration.
-// Registers a per-rank signal buffer used by one-sided operations.
-//   - buff: pointer to the signal buffer. The pointer type is selected by
-//     ptrType and may be either device memory or host-pinned memory.
-//   - size: size in bytes of the signal buffer.
-//   - ptrType: indicates the type of pointer passed in buff and controls the
-//     MR registration flags / ordering semantics:
-//       * FLAGCX_PTR_CUDA : buff is a CUDA device pointer. The MR is
-//         registered with FORCE_SO to guarantee that remote visibility of
-//         signal updates is ordered after prior GPU writes to the buffer.
-//       * FLAGCX_PTR_HOST : buff is host-pinned memory (e.g., cudaHostAlloc
-//         or other pinned allocation). The MR is registered without FORCE_SO;
-//         the caller is responsible for using appropriate host/device
-//         synchronization to ensure ordering and visibility of signal writes.
-// Must be called after flagcxCommInitRank and before one-sided operations.
-flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
-                                           size_t size, int ptrType);
 // Release signal buffer resources (MR, network connections, handle arrays).
+// flagcxOneSideSignalRegister / flagcxOneSideStagingRegister /
+// flagcxOneSideStagingDeregister are declared in flagcx.h (extern "C").
 flagcxResult_t flagcxOneSideSignalDeregister(struct flagcxHeteroComm *heteroComm);
-
-// One-sided staging buffer registration (host-pinned memory for PutValue).
-// Must be called after flagcxOneSideSignalRegister (requires full-mesh
-// connections).
-flagcxResult_t flagcxOneSideStagingRegister(const flagcxComm_t comm, void *buff,
-                                            size_t size);
-// Release staging buffer MR resources.
-flagcxResult_t flagcxOneSideStagingDeregister(const flagcxComm_t comm);
 
 // One-sided barrier MR registration (host-pinned memory for inter-node
 // barrier). Collective: ALL ranks must call. Leaders pass recvComm+buff,

--- a/flagcx/include/flagcx_kernel.h
+++ b/flagcx/include/flagcx_kernel.h
@@ -259,11 +259,12 @@ struct flagcxDevCommRequirements {
 
 #define FLAGCX_DEV_COMM_REQUIREMENTS_INITIALIZER                               \
   {                                                                            \
-    false,       /* intraMulticast */                                          \
-        0, 0, 0, /* barrierCount, intraBarrierCount, interBarrierCount */      \
-        0, 0,    /* intraLLA2ABlockCount, intraLLA2ASlotCount */               \
-        false, 4, 0, 0 /* interForceEnable, interContextCount,                 \
-                          interSignalCount, interCounterCount */               \
+      false,       /* intraMulticast */                                        \
+      0,     0, 0, /* barrierCount, intraBarrierCount, interBarrierCount */    \
+      0,     0,    /* intraLLA2ABlockCount, intraLLA2ASlotCount */             \
+      false, 4, 0,                                                             \
+      0 /* interForceEnable, interContextCount,                                \
+           interSignalCount, interCounterCount */                              \
   }
 
 // Network type enumeration (maps to ncclGinType_t on NVIDIA backend).
@@ -439,7 +440,8 @@ flagcxResult_t flagcxOneSideDeregister(struct flagcxHeteroComm *heteroComm);
 // Release signal buffer resources (MR, network connections, handle arrays).
 // flagcxOneSideSignalRegister / flagcxOneSideStagingRegister /
 // flagcxOneSideStagingDeregister are declared in flagcx.h (extern "C").
-flagcxResult_t flagcxOneSideSignalDeregister(struct flagcxHeteroComm *heteroComm);
+flagcxResult_t
+flagcxOneSideSignalDeregister(struct flagcxHeteroComm *heteroComm);
 
 // One-sided barrier MR registration (host-pinned memory for inter-node
 // barrier). Collective: ALL ranks must call. Leaders pass recvComm+buff,

--- a/plugin/interservice/flagcx_wrapper.py
+++ b/plugin/interservice/flagcx_wrapper.py
@@ -304,6 +304,14 @@ class FLAGCXLibrary:
             ctypes.c_size_t, ctypes.c_uint64,
             flagcxStream_t
         ]),
+
+        Function("flagcxReadCounter", flagcxResult_t, [
+            flagcxComm_t, ctypes.POINTER(ctypes.c_uint64)
+        ]),
+
+        Function("flagcxWaitCounter", flagcxResult_t, [
+            flagcxComm_t, ctypes.c_uint64
+        ]),
     ]
 
     # class attribute to store the mapping from the path to the library
@@ -518,6 +526,16 @@ class FLAGCXLibrary:
         self.FLAGCX_CHECK(self._funcs["flagcxWaitSignal"](
             comm, peer, ctypes.c_size_t(signalOffset),
             ctypes.c_uint64(expected), stream))
+
+    def flagcxReadCounter(self, comm: flagcxComm_t) -> int:
+        count = ctypes.c_uint64(0)
+        self.FLAGCX_CHECK(self._funcs["flagcxReadCounter"](
+            comm, ctypes.byref(count)))
+        return count.value
+
+    def flagcxWaitCounter(self, comm: flagcxComm_t, target: int) -> None:
+        self.FLAGCX_CHECK(self._funcs["flagcxWaitCounter"](
+            comm, ctypes.c_uint64(target)))
 
     def adaptor_stream_create(self):
         new_stream = flagcxStream_t()

--- a/plugin/interservice/flagcx_wrapper.py
+++ b/plugin/interservice/flagcx_wrapper.py
@@ -261,6 +261,49 @@ class FLAGCXLibrary:
         # it is better not to call it at all.
         # flagcxResult_t flagcxCommDestroy(flagcxComm_t comm);
         Function("flagcxCommDestroy", flagcxResult_t, [flagcxComm_t]),
+        
+        Function("flagcxCommRegister", flagcxResult_t, [
+            flagcxComm_t, ctypes.c_void_p, ctypes.c_size_t,
+            ctypes.POINTER(ctypes.c_void_p)
+        ]),
+        
+        Function("flagcxOneSideRegister", flagcxResult_t, [
+            flagcxComm_t, ctypes.c_void_p, ctypes.c_size_t
+        ]),
+
+        Function("flagcxOneSideSignalRegister", flagcxResult_t, [
+            flagcxComm_t, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int
+        ]),
+
+        Function("flagcxOneSideStagingRegister", flagcxResult_t, [
+            flagcxComm_t, ctypes.c_void_p, ctypes.c_size_t
+        ]),
+
+        Function("flagcxOneSideStagingDeregister", flagcxResult_t, [flagcxComm_t]),
+
+        Function("flagcxGet", flagcxResult_t, [
+            flagcxComm_t, ctypes.c_int,
+            ctypes.c_size_t, ctypes.c_size_t, ctypes.c_size_t,
+            ctypes.c_int, ctypes.c_int
+        ]),
+
+        Function("flagcxPutSignal", flagcxResult_t, [
+            flagcxComm_t, ctypes.c_int,
+            ctypes.c_size_t, ctypes.c_size_t, ctypes.c_size_t,
+            ctypes.c_size_t, ctypes.c_int, ctypes.c_int,
+            ctypes.c_uint64
+        ]),
+
+        Function("flagcxSignal", flagcxResult_t, [
+            flagcxComm_t, ctypes.c_int,
+            ctypes.c_size_t, ctypes.c_uint64
+        ]),
+
+        Function("flagcxWaitSignal", flagcxResult_t, [
+            flagcxComm_t, ctypes.c_int,
+            ctypes.c_size_t, ctypes.c_uint64,
+            flagcxStream_t
+        ]),
     ]
 
     # class attribute to store the mapping from the path to the library
@@ -421,6 +464,60 @@ class FLAGCXLibrary:
 
     def flagcxCommDestroy(self, comm: flagcxComm_t) -> None:
         self.FLAGCX_CHECK(self._funcs["flagcxCommDestroy"](comm))
+
+    def flagcxCommRegister(self, comm: flagcxComm_t, buff: int, size: int) -> ctypes.c_void_p:
+        handle = ctypes.c_void_p()
+        self.FLAGCX_CHECK(self._funcs["flagcxCommRegister"](
+            comm, ctypes.c_void_p(buff), ctypes.c_size_t(size),
+            ctypes.byref(handle)))
+        return handle
+
+    def flagcxOneSideRegister(self, comm: flagcxComm_t,
+                              buff: int, size: int) -> None:
+        self.FLAGCX_CHECK(self._funcs["flagcxOneSideRegister"](
+            comm, ctypes.c_void_p(buff), ctypes.c_size_t(size)))
+
+    def flagcxOneSideSignalRegister(self, comm: flagcxComm_t,
+                                    buff: int, size: int,
+                                    ptrType: int = 1) -> None:
+        self.FLAGCX_CHECK(self._funcs["flagcxOneSideSignalRegister"](
+            comm, ctypes.c_void_p(buff), ctypes.c_size_t(size),
+            ctypes.c_int(ptrType)))
+
+    def flagcxOneSideStagingRegister(self, comm: flagcxComm_t,
+                                     buff: int, size: int) -> None:
+        self.FLAGCX_CHECK(self._funcs["flagcxOneSideStagingRegister"](
+            comm, ctypes.c_void_p(buff), ctypes.c_size_t(size)))
+
+    def flagcxGet(self, comm: flagcxComm_t, peer: int,
+                  srcOffset: int, dstOffset: int, size: int,
+                  srcMrIdx: int, dstMrIdx: int) -> None:
+        self.FLAGCX_CHECK(self._funcs["flagcxGet"](
+            comm, peer, ctypes.c_size_t(srcOffset), ctypes.c_size_t(dstOffset),
+            ctypes.c_size_t(size), srcMrIdx, dstMrIdx))
+
+    def flagcxPutSignal(self, comm: flagcxComm_t, peer: int,
+                        srcOffset: int, dstOffset: int, size: int,
+                        signalOffset: int, srcMrIdx: int, dstMrIdx: int,
+                        signalValue: int) -> None:
+        self.FLAGCX_CHECK(self._funcs["flagcxPutSignal"](
+            comm, peer,
+            ctypes.c_size_t(srcOffset), ctypes.c_size_t(dstOffset),
+            ctypes.c_size_t(size), ctypes.c_size_t(signalOffset),
+            srcMrIdx, dstMrIdx, ctypes.c_uint64(signalValue)))
+
+    def flagcxSignal(self, comm: flagcxComm_t, peer: int,
+                     signalOffset: int, signalValue: int) -> None:
+        self.FLAGCX_CHECK(self._funcs["flagcxSignal"](
+            comm, peer, ctypes.c_size_t(signalOffset),
+            ctypes.c_uint64(signalValue)))
+
+    def flagcxWaitSignal(self, comm: flagcxComm_t, peer: int,
+                         signalOffset: int, expected: int,
+                         stream: flagcxStream_t) -> None:
+        self.FLAGCX_CHECK(self._funcs["flagcxWaitSignal"](
+            comm, peer, ctypes.c_size_t(signalOffset),
+            ctypes.c_uint64(expected), stream))
 
     def adaptor_stream_create(self):
         new_stream = flagcxStream_t()

--- a/test/perf/host_api/test_get.cpp
+++ b/test/perf/host_api/test_get.cpp
@@ -338,8 +338,8 @@ int main(int argc, char *argv[]) {
   res = flagcxCommDeregister(comm, dataHandle);
   fatal(res, "flagcxCommDeregister failed", proc);
 
-  flagcxOneSideDeregister(comm->heteroComm);
   flagcxOneSideSignalDeregister(comm->heteroComm);
+  flagcxOneSideDeregister(comm->heteroComm);
   flagcxMemFree(dataWindow);
   flagcxMemFree(signalWindow);
   free(hostStaging);

--- a/test/perf/host_api/test_get.cpp
+++ b/test/perf/host_api/test_get.cpp
@@ -338,8 +338,8 @@ int main(int argc, char *argv[]) {
   res = flagcxCommDeregister(comm, dataHandle);
   fatal(res, "flagcxCommDeregister failed", proc);
 
-  flagcxOneSideDeregister(comm);
-  flagcxOneSideSignalDeregister(comm);
+  flagcxOneSideDeregister(comm->heteroComm);
+  flagcxOneSideSignalDeregister(comm->heteroComm);
   flagcxMemFree(dataWindow);
   flagcxMemFree(signalWindow);
   free(hostStaging);

--- a/test/perf/host_api/test_one_side_register.cpp
+++ b/test/perf/host_api/test_one_side_register.cpp
@@ -1,0 +1,328 @@
+#include "flagcx.h"
+#include "flagcx_kernel.h"
+#include "flagcx_net.h"
+#include "comm.h"
+#include "tools.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <sched.h>
+#include <unistd.h>
+
+namespace {
+
+void fatal(flagcxResult_t res, const char *msg, int rank) {
+  if (res != flagcxSuccess) {
+    fprintf(stderr, "[rank %d] FATAL: %s (err=%d)\n", rank, msg, int(res));
+    MPI_Abort(MPI_COMM_WORLD, res);
+  }
+}
+
+void warmupConnect(flagcxComm_t comm, flagcxDeviceHandle_t devHandle,
+                  int proc, int totalProcs) {
+  flagcxStream_t stream;
+  devHandle->streamCreate(&stream);
+  void *dummyBuff = nullptr;
+  devHandle->deviceMalloc(&dummyBuff, 1, flagcxMemDevice, NULL);
+
+  flagcxGroupStart(comm);
+  flagcxSend(dummyBuff, 1, flagcxChar, (proc + 1) % totalProcs, comm, stream);
+  flagcxRecv(dummyBuff, 1, flagcxChar, (proc - 1 + totalProcs) % totalProcs,
+             comm, stream);
+  flagcxGroupEnd(comm);
+
+  devHandle->streamSynchronize(stream);
+  devHandle->deviceFree(dummyBuff, flagcxMemDevice, NULL);
+  devHandle->streamDestroy(stream);
+}
+
+bool doPutRound(flagcxComm_t comm, flagcxDeviceHandle_t devHandle,
+                void *dataWindow, void *signalWindow,
+                void *hostStaging, size_t size,
+                size_t signalOffset, size_t dataOffset,
+                uint64_t signalValue,
+                int proc, int senderRank, int receiverRank,
+                flagcxStream_t waitStream) {
+  flagcxResult_t res;
+  if (proc == senderRank) {
+    uint8_t fillVal = (uint8_t)(signalValue & 0xff);
+    std::memset(hostStaging, fillVal, size);
+    devHandle->deviceMemcpy((char *)dataWindow + dataOffset, hostStaging, size,
+                            flagcxMemcpyHostToDevice, NULL);
+    res = flagcxPutSignal(comm, receiverRank, dataOffset, dataOffset, size,
+                          signalOffset, 0, 0, signalValue);
+    if (res != flagcxSuccess) {
+      fprintf(stderr, "[rank %d] flagcxPutSignal failed (err=%d)\n", proc,
+              int(res));
+      return false;
+    }
+  } else {
+    res =
+        flagcxWaitSignal(comm, senderRank, signalOffset, signalValue, waitStream);
+    if (res != flagcxSuccess) {
+      fprintf(stderr, "[rank %d] flagcxWaitSignal failed (err=%d)\n", proc,
+              int(res));
+      return false;
+    }
+    devHandle->streamSynchronize(waitStream);
+  }
+  return true;
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  parser args(argc, argv);
+  size_t minBytes = args.getMinBytes();
+  size_t maxBytes = args.getMaxBytes();
+  int stepFactor   = args.getStepFactor();
+  int numWarmup    = args.getWarmupIters();
+  int numIters     = args.getTestIters();
+  int localRegister = args.getLocalRegister();
+
+  if (localRegister < 1) {
+    fprintf(stderr,
+            "test_multi_comm_put requires -R 1 or -R 2 for GDR allocation.\n");
+    return 1;
+  }
+
+  int worldRank = 0, worldSize = 1, totalProcs = 1, proc = 0, color = 0;
+  uint64_t splitMask = args.getSplitMask();
+  MPI_Comm splitComm;
+
+  flagcxHandlerGroup_t handler;
+  flagcxHandleInit(&handler);
+  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+
+  initMpiEnv(argc, argv, worldRank, worldSize, proc, totalProcs, color,
+             splitComm, splitMask);
+
+  if (totalProcs != 2) {
+    if (proc == 0)
+      printf("test_multi_comm_put requires exactly 2 MPI processes.\n");
+    flagcxHandleFree(handler);
+    MPI_Finalize();
+    return 0;
+  }
+
+  int nGpu;
+  devHandle->getDeviceCount(&nGpu);
+  devHandle->setDevice(worldRank % nGpu);
+
+  const int senderRank   = 0;
+  const int receiverRank = 1;
+
+  flagcxUniqueId_t uid1 = NULL;
+  flagcxCalloc(&uid1, 1);
+  if (proc == 0) flagcxGetUniqueId(&uid1);
+  MPI_Bcast((void *)uid1, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  flagcxComm_t comm1 = NULL;
+  fatal(flagcxCommInitRank(&comm1, totalProcs, uid1, proc),
+        "flagcxCommInitRank (comm1) failed", proc);
+
+  flagcxUniqueId_t uid2 = NULL;
+  flagcxCalloc(&uid2, 1);
+  if (proc == 0) flagcxGetUniqueId(&uid2);
+  MPI_Bcast((void *)uid2, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  flagcxComm_t comm2 = NULL;
+  fatal(flagcxCommInitRank(&comm2, totalProcs, uid2, proc),
+        "flagcxCommInitRank (comm2) failed", proc);
+
+  free(uid1);
+  free(uid2);
+
+  if (proc == 0)
+    printf("[test] comm1=%p  comm2=%p\n", (void *)comm1, (void *)comm2);
+
+  size_t signalBytes      = sizeof(uint64_t);
+  size_t totalIters       = (size_t)(numWarmup + numIters);
+  size_t dataBytes        = maxBytes * std::max(numWarmup, numIters);
+  size_t signalTotalBytes = signalBytes * totalIters;
+
+  void *dataWin1 = nullptr, *sigWin1 = nullptr;
+  fatal(flagcxMemAlloc(&dataWin1, dataBytes), "MemAlloc dataWin1", proc);
+  fatal(flagcxMemAlloc(&sigWin1, signalTotalBytes), "MemAlloc sigWin1", proc);
+  devHandle->deviceMemset(dataWin1, 0, dataBytes, flagcxMemDevice, NULL);
+  devHandle->deviceMemset(sigWin1,  0, signalTotalBytes, flagcxMemDevice, NULL);
+
+  void *dataWin2 = nullptr, *sigWin2 = nullptr;
+  fatal(flagcxMemAlloc(&dataWin2, dataBytes), "MemAlloc dataWin2", proc);
+  fatal(flagcxMemAlloc(&sigWin2, signalTotalBytes), "MemAlloc sigWin2", proc);
+  devHandle->deviceMemset(dataWin2, 0, dataBytes, flagcxMemDevice, NULL);
+  devHandle->deviceMemset(sigWin2,  0, signalTotalBytes, flagcxMemDevice, NULL);
+
+  void *handle1 = nullptr, *handle2 = nullptr;
+  fatal(flagcxCommRegister(comm1, dataWin1, dataBytes, &handle1),
+        "CommRegister (comm1)", proc);
+  fatal(flagcxCommRegister(comm2, dataWin2, dataBytes, &handle2),
+        "CommRegister (comm2)", proc);
+
+  flagcxResult_t r1 = flagcxOneSideRegister(comm1, dataWin1, dataBytes);
+  if (r1 == flagcxNotSupported) {
+    if (proc == 0)
+      printf("[SKIP] flagcxOneSideRegister returned NotSupported; "
+             "set FLAGCX_USE_HETERO_COMM=1 and ensure IB net adaptor.\n");
+    goto cleanup_no_onesided;
+  }
+  fatal(r1, "OneSideRegister (comm1)", proc);
+
+  {
+    flagcxResult_t r2 = flagcxOneSideRegister(comm2, dataWin2, dataBytes);
+    if (r2 == flagcxNotSupported) {
+      if (proc == 0)
+        printf("[SKIP] comm2 OneSideRegister NotSupported.\n");
+      flagcxOneSideDeregister(comm1->heteroComm);
+      goto cleanup_no_onesided;
+    }
+    fatal(r2, "OneSideRegister (comm2)", proc);
+  }
+
+  fatal(flagcxOneSideSignalRegister(comm1, sigWin1, signalTotalBytes,
+                                    FLAGCX_PTR_CUDA),
+            "SignalRegister (comm1)", proc);
+  fatal(flagcxOneSideSignalRegister(comm2, sigWin2, signalTotalBytes,
+                                    FLAGCX_PTR_CUDA),
+        "SignalRegister (comm2)", proc);
+
+  if (proc == 0)
+    printf("[test] OneSideRegister for comm1 and comm2 succeeded.\n");
+
+  warmupConnect(comm1, devHandle, proc, totalProcs);
+  MPI_Barrier(MPI_COMM_WORLD);
+  warmupConnect(comm2, devHandle, proc, totalProcs);
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  {
+    flagcxStream_t waitStream = nullptr;
+    if (proc == receiverRank)
+      devHandle->streamCreate(&waitStream);
+
+    void *hostStaging = nullptr;
+    fatal((flagcxResult_t)(posix_memalign(&hostStaging, 64, maxBytes) == 0
+                               ? flagcxSuccess
+                               : flagcxInternalError),
+          "posix_memalign", proc);
+
+    if (proc == 0) printf("\n[Phase 1] put via comm1\n");
+    for (size_t size = minBytes; size <= maxBytes; size *= stepFactor) {
+      devHandle->deviceMemset(sigWin1, 0, signalTotalBytes, flagcxMemDevice, NULL);
+      MPI_Barrier(MPI_COMM_WORLD);
+
+      for (int i = 0; i < numWarmup + numIters; i++) {
+        size_t signalOffset = (size_t)i * signalBytes;
+        size_t dataOffset   = (size_t)(i % std::max(numWarmup, numIters)) * size;
+        uint64_t sigVal     = (uint64_t)(i + 1);
+
+        bool ok = doPutRound(comm1, devHandle, dataWin1, sigWin1,
+                             hostStaging, size, signalOffset, dataOffset,
+                             sigVal, proc, senderRank, receiverRank,
+                             waitStream);
+        if (!ok) {
+          fprintf(stderr, "[rank %d] Phase 1 FAILED at iter %d size %zu\n",
+                  proc, i, size);
+          MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+      }
+
+      MPI_Barrier(MPI_COMM_WORLD);
+      if (proc == 0)
+        printf("[Phase 1] size=%zu PASS\n", size);
+    }
+
+    if (proc == 0) printf("\n[Phase 2] put via comm2\n");
+    for (size_t size = minBytes; size <= maxBytes; size *= stepFactor) {
+      devHandle->deviceMemset(sigWin2, 0, signalTotalBytes, flagcxMemDevice, NULL);
+      MPI_Barrier(MPI_COMM_WORLD);
+
+      for (int i = 0; i < numWarmup + numIters; i++) {
+        size_t signalOffset = (size_t)i * signalBytes;
+        size_t dataOffset   = (size_t)(i % std::max(numWarmup, numIters)) * size;
+        uint64_t sigVal     = (uint64_t)(i + 1);
+
+        bool ok = doPutRound(comm2, devHandle, dataWin2, sigWin2,
+                             hostStaging, size, signalOffset, dataOffset,
+                             sigVal, proc, senderRank, receiverRank,
+                             waitStream);
+        if (!ok) {
+          fprintf(stderr, "[rank %d] Phase 2 FAILED at iter %d size %zu\n",
+                  proc, i, size);
+          MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+      }
+
+      MPI_Barrier(MPI_COMM_WORLD);
+      if (proc == 0)
+        printf("[Phase 2] size=%zu PASS\n", size);
+    }
+
+    if (proc == 0) printf("\n[Phase 3] deregister comm1, then put via comm2\n");
+
+    flagcxOneSideDeregister(comm1->heteroComm);
+    flagcxOneSideSignalDeregister(comm1->heteroComm);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (proc == 0) printf("[Phase 3] comm1 deregistered.\n");
+
+    for (size_t size = minBytes; size <= maxBytes; size *= stepFactor) {
+      devHandle->deviceMemset(sigWin2, 0, signalTotalBytes, flagcxMemDevice, NULL);
+      MPI_Barrier(MPI_COMM_WORLD);
+
+      for (int i = 0; i < numWarmup + numIters; i++) {
+        size_t signalOffset = (size_t)i * signalBytes;
+        size_t dataOffset   = (size_t)(i % std::max(numWarmup, numIters)) * size;
+        uint64_t sigVal     = (uint64_t)(i + 1);
+
+        bool ok = doPutRound(comm2, devHandle, dataWin2, sigWin2,
+                             hostStaging, size, signalOffset, dataOffset,
+                             sigVal, proc, senderRank, receiverRank,
+                             waitStream);
+        if (!ok) {
+          fprintf(stderr,
+                  "[rank %d] Phase 3 FAILED at iter %d size %zu "
+                  "(comm1 deregister broke comm2!)\n",
+                  proc, i, size);
+          MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+      }
+
+      MPI_Barrier(MPI_COMM_WORLD);
+      if (proc == 0)
+        printf("[Phase 3] size=%zu PASS (comm2 unaffected by comm1 deregister)\n",
+               size);
+    }
+
+    if (proc == 0)
+      printf("\n[test_multi_comm_put] ALL PHASES PASSED\n");
+
+    free(hostStaging);
+    if (waitStream) devHandle->streamDestroy(waitStream);
+
+    flagcxOneSideDeregister(comm2->heteroComm);
+    flagcxOneSideSignalDeregister(comm2->heteroComm);
+  }
+
+cleanup_no_onesided:
+  MPI_Barrier(MPI_COMM_WORLD);
+  sleep(1);
+
+  flagcxCommDeregister(comm1, handle1);
+  flagcxCommDeregister(comm2, handle2);
+  flagcxMemFree(dataWin1);
+  flagcxMemFree(dataWin2);
+  flagcxMemFree(sigWin1);
+  flagcxMemFree(sigWin2);
+
+  flagcxCommDestroy(comm1);
+  flagcxCommDestroy(comm2);
+  flagcxHandleFree(handler);
+
+  MPI_Finalize();
+  return 0;
+}

--- a/test/perf/host_api/test_one_side_register.cpp
+++ b/test/perf/host_api/test_one_side_register.cpp
@@ -158,12 +158,6 @@ int main(int argc, char *argv[]) {
   devHandle->deviceMemset(dataWin2, 0, dataBytes, flagcxMemDevice, NULL);
   devHandle->deviceMemset(sigWin2,  0, signalTotalBytes, flagcxMemDevice, NULL);
 
-  void *handle1 = nullptr, *handle2 = nullptr;
-  fatal(flagcxCommRegister(comm1, dataWin1, dataBytes, &handle1),
-        "CommRegister (comm1)", proc);
-  fatal(flagcxCommRegister(comm2, dataWin2, dataBytes, &handle2),
-        "CommRegister (comm2)", proc);
-
   flagcxResult_t r1 = flagcxOneSideRegister(comm1, dataWin1, dataBytes);
   if (r1 == flagcxNotSupported) {
     if (proc == 0)
@@ -312,8 +306,6 @@ cleanup_no_onesided:
   MPI_Barrier(MPI_COMM_WORLD);
   sleep(1);
 
-  flagcxCommDeregister(comm1, handle1);
-  flagcxCommDeregister(comm2, handle2);
   flagcxMemFree(dataWin1);
   flagcxMemFree(dataWin2);
   flagcxMemFree(sigWin1);

--- a/test/perf/host_api/test_one_side_register.cpp
+++ b/test/perf/host_api/test_one_side_register.cpp
@@ -1,7 +1,7 @@
+#include "comm.h"
 #include "flagcx.h"
 #include "flagcx_kernel.h"
 #include "flagcx_net.h"
-#include "comm.h"
 #include "tools.h"
 
 #include <algorithm>
@@ -21,8 +21,8 @@ void fatal(flagcxResult_t res, const char *msg, int rank) {
   }
 }
 
-void warmupConnect(flagcxComm_t comm, flagcxDeviceHandle_t devHandle,
-                  int proc, int totalProcs) {
+void warmupConnect(flagcxComm_t comm, flagcxDeviceHandle_t devHandle, int proc,
+                   int totalProcs) {
   flagcxStream_t stream;
   devHandle->streamCreate(&stream);
   void *dummyBuff = nullptr;
@@ -40,12 +40,10 @@ void warmupConnect(flagcxComm_t comm, flagcxDeviceHandle_t devHandle,
 }
 
 bool doPutRound(flagcxComm_t comm, flagcxDeviceHandle_t devHandle,
-                void *dataWindow, void *signalWindow,
-                void *hostStaging, size_t size,
-                size_t signalOffset, size_t dataOffset,
-                uint64_t signalValue,
-                int proc, int senderRank, int receiverRank,
-                flagcxStream_t waitStream) {
+                void *dataWindow, void *signalWindow, void *hostStaging,
+                size_t size, size_t signalOffset, size_t dataOffset,
+                uint64_t signalValue, int proc, int senderRank,
+                int receiverRank, flagcxStream_t waitStream) {
   flagcxResult_t res;
   if (proc == senderRank) {
     uint8_t fillVal = (uint8_t)(signalValue & 0xff);
@@ -60,8 +58,8 @@ bool doPutRound(flagcxComm_t comm, flagcxDeviceHandle_t devHandle,
       return false;
     }
   } else {
-    res =
-        flagcxWaitSignal(comm, senderRank, signalOffset, signalValue, waitStream);
+    res = flagcxWaitSignal(comm, senderRank, signalOffset, signalValue,
+                           waitStream);
     if (res != flagcxSuccess) {
       fprintf(stderr, "[rank %d] flagcxWaitSignal failed (err=%d)\n", proc,
               int(res));
@@ -78,9 +76,9 @@ int main(int argc, char *argv[]) {
   parser args(argc, argv);
   size_t minBytes = args.getMinBytes();
   size_t maxBytes = args.getMaxBytes();
-  int stepFactor   = args.getStepFactor();
-  int numWarmup    = args.getWarmupIters();
-  int numIters     = args.getTestIters();
+  int stepFactor = args.getStepFactor();
+  int numWarmup = args.getWarmupIters();
+  int numIters = args.getTestIters();
   int localRegister = args.getLocalRegister();
 
   if (localRegister < 1) {
@@ -112,12 +110,13 @@ int main(int argc, char *argv[]) {
   devHandle->getDeviceCount(&nGpu);
   devHandle->setDevice(worldRank % nGpu);
 
-  const int senderRank   = 0;
+  const int senderRank = 0;
   const int receiverRank = 1;
 
   flagcxUniqueId_t uid1 = NULL;
   flagcxCalloc(&uid1, 1);
-  if (proc == 0) flagcxGetUniqueId(&uid1);
+  if (proc == 0)
+    flagcxGetUniqueId(&uid1);
   MPI_Bcast((void *)uid1, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
@@ -127,7 +126,8 @@ int main(int argc, char *argv[]) {
 
   flagcxUniqueId_t uid2 = NULL;
   flagcxCalloc(&uid2, 1);
-  if (proc == 0) flagcxGetUniqueId(&uid2);
+  if (proc == 0)
+    flagcxGetUniqueId(&uid2);
   MPI_Bcast((void *)uid2, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
@@ -141,22 +141,22 @@ int main(int argc, char *argv[]) {
   if (proc == 0)
     printf("[test] comm1=%p  comm2=%p\n", (void *)comm1, (void *)comm2);
 
-  size_t signalBytes      = sizeof(uint64_t);
-  size_t totalIters       = (size_t)(numWarmup + numIters);
-  size_t dataBytes        = maxBytes * std::max(numWarmup, numIters);
+  size_t signalBytes = sizeof(uint64_t);
+  size_t totalIters = (size_t)(numWarmup + numIters);
+  size_t dataBytes = maxBytes * std::max(numWarmup, numIters);
   size_t signalTotalBytes = signalBytes * totalIters;
 
   void *dataWin1 = nullptr, *sigWin1 = nullptr;
   fatal(flagcxMemAlloc(&dataWin1, dataBytes), "MemAlloc dataWin1", proc);
   fatal(flagcxMemAlloc(&sigWin1, signalTotalBytes), "MemAlloc sigWin1", proc);
   devHandle->deviceMemset(dataWin1, 0, dataBytes, flagcxMemDevice, NULL);
-  devHandle->deviceMemset(sigWin1,  0, signalTotalBytes, flagcxMemDevice, NULL);
+  devHandle->deviceMemset(sigWin1, 0, signalTotalBytes, flagcxMemDevice, NULL);
 
   void *dataWin2 = nullptr, *sigWin2 = nullptr;
   fatal(flagcxMemAlloc(&dataWin2, dataBytes), "MemAlloc dataWin2", proc);
   fatal(flagcxMemAlloc(&sigWin2, signalTotalBytes), "MemAlloc sigWin2", proc);
   devHandle->deviceMemset(dataWin2, 0, dataBytes, flagcxMemDevice, NULL);
-  devHandle->deviceMemset(sigWin2,  0, signalTotalBytes, flagcxMemDevice, NULL);
+  devHandle->deviceMemset(sigWin2, 0, signalTotalBytes, flagcxMemDevice, NULL);
 
   flagcxResult_t r1 = flagcxOneSideRegister(comm1, dataWin1, dataBytes);
   if (r1 == flagcxNotSupported) {
@@ -180,7 +180,7 @@ int main(int argc, char *argv[]) {
 
   fatal(flagcxOneSideSignalRegister(comm1, sigWin1, signalTotalBytes,
                                     FLAGCX_PTR_CUDA),
-            "SignalRegister (comm1)", proc);
+        "SignalRegister (comm1)", proc);
   fatal(flagcxOneSideSignalRegister(comm2, sigWin2, signalTotalBytes,
                                     FLAGCX_PTR_CUDA),
         "SignalRegister (comm2)", proc);
@@ -204,20 +204,21 @@ int main(int argc, char *argv[]) {
                                : flagcxInternalError),
           "posix_memalign", proc);
 
-    if (proc == 0) printf("\n[Phase 1] put via comm1\n");
+    if (proc == 0)
+      printf("\n[Phase 1] put via comm1\n");
     for (size_t size = minBytes; size <= maxBytes; size *= stepFactor) {
-      devHandle->deviceMemset(sigWin1, 0, signalTotalBytes, flagcxMemDevice, NULL);
+      devHandle->deviceMemset(sigWin1, 0, signalTotalBytes, flagcxMemDevice,
+                              NULL);
       MPI_Barrier(MPI_COMM_WORLD);
 
       for (int i = 0; i < numWarmup + numIters; i++) {
         size_t signalOffset = (size_t)i * signalBytes;
-        size_t dataOffset   = (size_t)(i % std::max(numWarmup, numIters)) * size;
-        uint64_t sigVal     = (uint64_t)(i + 1);
+        size_t dataOffset = (size_t)(i % std::max(numWarmup, numIters)) * size;
+        uint64_t sigVal = (uint64_t)(i + 1);
 
-        bool ok = doPutRound(comm1, devHandle, dataWin1, sigWin1,
-                             hostStaging, size, signalOffset, dataOffset,
-                             sigVal, proc, senderRank, receiverRank,
-                             waitStream);
+        bool ok = doPutRound(comm1, devHandle, dataWin1, sigWin1, hostStaging,
+                             size, signalOffset, dataOffset, sigVal, proc,
+                             senderRank, receiverRank, waitStream);
         if (!ok) {
           fprintf(stderr, "[rank %d] Phase 1 FAILED at iter %d size %zu\n",
                   proc, i, size);
@@ -230,20 +231,21 @@ int main(int argc, char *argv[]) {
         printf("[Phase 1] size=%zu PASS\n", size);
     }
 
-    if (proc == 0) printf("\n[Phase 2] put via comm2\n");
+    if (proc == 0)
+      printf("\n[Phase 2] put via comm2\n");
     for (size_t size = minBytes; size <= maxBytes; size *= stepFactor) {
-      devHandle->deviceMemset(sigWin2, 0, signalTotalBytes, flagcxMemDevice, NULL);
+      devHandle->deviceMemset(sigWin2, 0, signalTotalBytes, flagcxMemDevice,
+                              NULL);
       MPI_Barrier(MPI_COMM_WORLD);
 
       for (int i = 0; i < numWarmup + numIters; i++) {
         size_t signalOffset = (size_t)i * signalBytes;
-        size_t dataOffset   = (size_t)(i % std::max(numWarmup, numIters)) * size;
-        uint64_t sigVal     = (uint64_t)(i + 1);
+        size_t dataOffset = (size_t)(i % std::max(numWarmup, numIters)) * size;
+        uint64_t sigVal = (uint64_t)(i + 1);
 
-        bool ok = doPutRound(comm2, devHandle, dataWin2, sigWin2,
-                             hostStaging, size, signalOffset, dataOffset,
-                             sigVal, proc, senderRank, receiverRank,
-                             waitStream);
+        bool ok = doPutRound(comm2, devHandle, dataWin2, sigWin2, hostStaging,
+                             size, signalOffset, dataOffset, sigVal, proc,
+                             senderRank, receiverRank, waitStream);
         if (!ok) {
           fprintf(stderr, "[rank %d] Phase 2 FAILED at iter %d size %zu\n",
                   proc, i, size);
@@ -256,27 +258,29 @@ int main(int argc, char *argv[]) {
         printf("[Phase 2] size=%zu PASS\n", size);
     }
 
-    if (proc == 0) printf("\n[Phase 3] deregister comm1, then put via comm2\n");
+    if (proc == 0)
+      printf("\n[Phase 3] deregister comm1, then put via comm2\n");
 
     flagcxOneSideDeregister(comm1->heteroComm);
     flagcxOneSideSignalDeregister(comm1->heteroComm);
     MPI_Barrier(MPI_COMM_WORLD);
 
-    if (proc == 0) printf("[Phase 3] comm1 deregistered.\n");
+    if (proc == 0)
+      printf("[Phase 3] comm1 deregistered.\n");
 
     for (size_t size = minBytes; size <= maxBytes; size *= stepFactor) {
-      devHandle->deviceMemset(sigWin2, 0, signalTotalBytes, flagcxMemDevice, NULL);
+      devHandle->deviceMemset(sigWin2, 0, signalTotalBytes, flagcxMemDevice,
+                              NULL);
       MPI_Barrier(MPI_COMM_WORLD);
 
       for (int i = 0; i < numWarmup + numIters; i++) {
         size_t signalOffset = (size_t)i * signalBytes;
-        size_t dataOffset   = (size_t)(i % std::max(numWarmup, numIters)) * size;
-        uint64_t sigVal     = (uint64_t)(i + 1);
+        size_t dataOffset = (size_t)(i % std::max(numWarmup, numIters)) * size;
+        uint64_t sigVal = (uint64_t)(i + 1);
 
-        bool ok = doPutRound(comm2, devHandle, dataWin2, sigWin2,
-                             hostStaging, size, signalOffset, dataOffset,
-                             sigVal, proc, senderRank, receiverRank,
-                             waitStream);
+        bool ok = doPutRound(comm2, devHandle, dataWin2, sigWin2, hostStaging,
+                             size, signalOffset, dataOffset, sigVal, proc,
+                             senderRank, receiverRank, waitStream);
         if (!ok) {
           fprintf(stderr,
                   "[rank %d] Phase 3 FAILED at iter %d size %zu "
@@ -288,15 +292,17 @@ int main(int argc, char *argv[]) {
 
       MPI_Barrier(MPI_COMM_WORLD);
       if (proc == 0)
-        printf("[Phase 3] size=%zu PASS (comm2 unaffected by comm1 deregister)\n",
-               size);
+        printf(
+            "[Phase 3] size=%zu PASS (comm2 unaffected by comm1 deregister)\n",
+            size);
     }
 
     if (proc == 0)
       printf("\n[test_multi_comm_put] ALL PHASES PASSED\n");
 
     free(hostStaging);
-    if (waitStream) devHandle->streamDestroy(waitStream);
+    if (waitStream)
+      devHandle->streamDestroy(waitStream);
 
     flagcxOneSideDeregister(comm2->heteroComm);
     flagcxOneSideSignalDeregister(comm2->heteroComm);

--- a/test/perf/host_api/test_put.cpp
+++ b/test/perf/host_api/test_put.cpp
@@ -289,8 +289,8 @@ int main(int argc, char *argv[]) {
   res = flagcxCommDeregister(comm, dataHandle);
   fatal(res, "flagcxCommDeregister failed", proc);
 
-  flagcxOneSideDeregister(comm);
-  flagcxOneSideSignalDeregister(comm);
+  flagcxOneSideDeregister(comm->heteroComm);
+  flagcxOneSideSignalDeregister(comm->heteroComm);
   flagcxMemFree(dataWindow);
   flagcxMemFree(signalWindow);
   free(hostStaging);

--- a/test/perf/host_api/test_put.cpp
+++ b/test/perf/host_api/test_put.cpp
@@ -289,8 +289,8 @@ int main(int argc, char *argv[]) {
   res = flagcxCommDeregister(comm, dataHandle);
   fatal(res, "flagcxCommDeregister failed", proc);
 
-  flagcxOneSideDeregister(comm->heteroComm);
   flagcxOneSideSignalDeregister(comm->heteroComm);
+  flagcxOneSideDeregister(comm->heteroComm);
   flagcxMemFree(dataWindow);
   flagcxMemFree(signalWindow);
   free(hostStaging);


### PR DESCRIPTION
### PR Category
CRL (Communication Runtime Layer)

### PR Types
Optimizations

### PR Description
* Replace process-global globalOneSideHandleTable[128] with a per-comm dynamic array (heteroComm->oneSideHandles) that grows by doubling (initial capacity 4, no upper limit).
* Remove ownerHeteroComm field from flagcxOneSideHandleInfo — ownership is now implicit via the containing flagcxHeteroComm.
* Change flagcxOneSideDeregister / flagcxOneSideSignalDeregister signatures to take struct flagcxHeteroComm* directly, keeping them as internal APIs not exposed to Python bindings.