### PR TITLE
[CRL] P2P topo manager

### DIFF
--- a/flagcx/core/include/p2p_topo.h
+++ b/flagcx/core/include/p2p_topo.h
@@ -1,0 +1,29 @@
+/*************************************************************************
+ * Copyright (c) 2025 BAAI. All rights reserved.
+ ************************************************************************/
+
+#ifndef FLAGCX_P2P_TOPO_H_
+#define FLAGCX_P2P_TOPO_H_
+
+#include "flagcx_net_adaptor.h"
+#include "topo.h"
+
+struct flagcxP2pTopoManager {
+  struct flagcxTopoServer *topoServer;
+  int nGpus; // number of visible GPUs
+};
+
+// Initialize the P2P topo manager. Enumerates all local GPUs and NICs,
+// builds a node-scoped topology graph, and computes paths for NIC selection.
+// netAdaptor: the network adaptor used for NIC enumeration.
+flagcxResult_t flagcxP2pTopoInit(struct flagcxNetAdaptor *netAdaptor,
+                                 struct flagcxP2pTopoManager **mgr);
+
+// Query: given a local GPU device index, return the best net device index.
+flagcxResult_t flagcxP2pTopoGetNetDev(struct flagcxP2pTopoManager *mgr,
+                                      int gpuDev, int *netDev);
+
+// Free all resources owned by the manager.
+flagcxResult_t flagcxP2pTopoDestroy(struct flagcxP2pTopoManager *mgr);
+
+#endif // FLAGCX_P2P_TOPO_H_

--- a/flagcx/core/include/topo.h
+++ b/flagcx/core/include/topo.h
@@ -289,6 +289,9 @@ flagcxResult_t flagcxTopoPrint(struct flagcxTopoServer *topoServer);
 
 flagcxResult_t flagcxTopoPrintPaths(struct flagcxTopoServer *topoServer);
 
+flagcxResult_t flagcxTopoGetLocalNet(struct flagcxTopoServer *topoServer,
+                                     int rank, int *netDev);
+
 flagcxResult_t
 flagcxGetInterServerTopo(struct flagcxHeteroComm *comm,
                          struct flagcxInterServerTopo **interServerTopo,

--- a/flagcx/core/p2p_topo.cc
+++ b/flagcx/core/p2p_topo.cc
@@ -1,0 +1,115 @@
+/*************************************************************************
+ * Copyright (c) 2025 BAAI. All rights reserved.
+ ************************************************************************/
+
+#include "p2p_topo.h"
+#include "adaptor.h"
+#include "utils.h"
+#include "xml.h"
+
+// Build the XML topology for all local GPUs and NICs without a communicator.
+// Mirrors the logic in flagcxTopoGetXmlTopo (topo.cc) but uses deviceAdaptor
+// for GPU enumeration and the provided netAdaptor for NIC enumeration.
+static flagcxResult_t flagcxP2pTopoBuildXml(struct flagcxNetAdaptor *netAdaptor,
+                                            struct flagcxXml *xml,
+                                            int *nGpusOut) {
+  // Create root node
+  struct flagcxXmlNode *top;
+  FLAGCXCHECK(xmlAddNode(xml, NULL, "system", &top));
+  FLAGCXCHECK(xmlSetAttrInt(top, "version", FLAGCX_TOPO_XML_VERSION));
+
+  // Enumerate local GPUs
+  int nGpus = 0;
+  FLAGCXCHECK(deviceAdaptor->getDeviceCount(&nGpus));
+  INFO(FLAGCX_INIT, "P2P topo: detected %d GPUs", nGpus);
+
+  for (int i = 0; i < nGpus; i++) {
+    char busId[FLAGCX_DEVICE_PCI_BUSID_BUFFER_SIZE];
+    FLAGCXCHECK(deviceAdaptor->getDevicePciBusId(busId, sizeof(busId), i));
+
+    struct flagcxXmlNode *node;
+    FLAGCXCHECK(flagcxTopoFillApu(xml, busId, &node));
+    if (node == NULL) {
+      continue;
+    }
+
+    int devLogicalIdx = 0;
+    FLAGCXCHECK(deviceAdaptor->getDeviceByPciBusId(&devLogicalIdx, busId));
+    FLAGCXCHECK(xmlSetAttrInt(node, "dev", devLogicalIdx));
+    FLAGCXCHECK(xmlSetAttrInt(node, "rank", i));
+  }
+
+  // Enumerate NICs
+  int netDevCount = 0;
+  FLAGCXCHECK(netAdaptor->devices(&netDevCount));
+  INFO(FLAGCX_INIT, "P2P topo: detected %d NICs", netDevCount);
+
+  for (int n = 0; n < netDevCount; n++) {
+    flagcxNetProperties_t props;
+    FLAGCXCHECK(netAdaptor->getProperties(n, (void *)&props));
+
+    struct flagcxXmlNode *netNode;
+    FLAGCXCHECK(flagcxTopoFillNet(xml, props.pciPath, props.name, &netNode));
+    FLAGCXCHECK(xmlSetAttrInt(netNode, "dev", n));
+    FLAGCXCHECK(xmlSetAttrInt(netNode, "speed", props.speed));
+    FLAGCXCHECK(xmlSetAttrFloat(netNode, "latency", props.latency));
+    FLAGCXCHECK(xmlSetAttrInt(netNode, "port", props.port));
+    FLAGCXCHECK(xmlInitAttrUint64(netNode, "guid", props.guid));
+    FLAGCXCHECK(xmlSetAttrInt(netNode, "maxConn", props.maxComms));
+  }
+
+  *nGpusOut = nGpus;
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxP2pTopoInit(struct flagcxNetAdaptor *netAdaptor,
+                                 struct flagcxP2pTopoManager **mgr) {
+  struct flagcxP2pTopoManager *m;
+  FLAGCXCHECK(flagcxCalloc(&m, 1));
+
+  // Build XML topology
+  struct flagcxXml *xml;
+  FLAGCXCHECK(xmlAlloc(&xml, FLAGCX_TOPO_XML_MAX_NODES));
+
+  int nGpus = 0;
+  FLAGCXCHECK(flagcxP2pTopoBuildXml(netAdaptor, xml, &nGpus));
+
+  // Convert XML to server topology
+  uint64_t localHostHash = getHostHash();
+  FLAGCXCHECK(
+      flagcxTopoGetServerTopoFromXml(xml, &m->topoServer, localHostHash));
+
+  free(xml);
+
+  // Compute shortest paths between all nodes
+  FLAGCXCHECK(flagcxTopoComputePaths(m->topoServer, NULL));
+
+  m->nGpus = nGpus;
+  *mgr = m;
+
+  INFO(FLAGCX_INIT, "P2P topo manager initialized: %d GPUs", nGpus);
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxP2pTopoGetNetDev(struct flagcxP2pTopoManager *mgr,
+                                      int gpuDev, int *netDev) {
+  if (mgr == NULL || netDev == NULL) {
+    return flagcxInvalidArgument;
+  }
+  if (gpuDev < 0 || gpuDev >= mgr->nGpus) {
+    WARN("P2P topo: gpuDev %d out of range [0, %d)", gpuDev, mgr->nGpus);
+    return flagcxInvalidArgument;
+  }
+  // gpuDev is used directly as the synthetic rank
+  FLAGCXCHECK(flagcxTopoGetLocalNet(mgr->topoServer, gpuDev, netDev));
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxP2pTopoDestroy(struct flagcxP2pTopoManager *mgr) {
+  if (mgr == NULL) {
+    return flagcxSuccess;
+  }
+  free(mgr->topoServer);
+  free(mgr);
+  return flagcxSuccess;
+}

--- a/flagcx/core/p2p_topo.cc
+++ b/flagcx/core/p2p_topo.cc
@@ -4,6 +4,7 @@
 
 #include "p2p_topo.h"
 #include "adaptor.h"
+#include "flagcx_net.h"
 #include "utils.h"
 #include "xml.h"
 

--- a/test/unittest/Makefile
+++ b/test/unittest/Makefile
@@ -10,7 +10,7 @@
 #   make run          Run everything
 #   make clean        Clean all build artifacts
 
-COMPONENTS := adaptor core kernel service runner p2p
+COMPONENTS := adaptor core kernel service runner p2p topo
 
 .PHONY: all $(COMPONENTS) clean run-unit run-mpi run
 

--- a/test/unittest/topo/Makefile
+++ b/test/unittest/topo/Makefile
@@ -1,0 +1,33 @@
+include ../../make.inc
+
+# [unit] tests: test_*.cpp — single GPU, no MPI required
+UNIT_SRCS   := $(wildcard test_*.cpp)
+UNIT_OBJS   := $(UNIT_SRCS:%.cpp=$(OBJDIR)/%.o)
+UNIT_TARGET := $(BINDIR)/topo_unit_tests
+
+.PHONY: all clean run-unit run
+
+ALL_TARGETS :=
+ifneq ($(UNIT_SRCS),)
+ALL_TARGETS += $(UNIT_TARGET)
+endif
+
+all: $(ALL_TARGETS)
+
+$(UNIT_TARGET): $(UNIT_OBJS)
+	@mkdir -p $(BINDIR)
+	@echo "Linking   $@"
+	@$(CXX) $^ -o $@ $(FLAGCX_LINK) $(GTEST_LINK)
+
+$(OBJDIR)/test_%.o: test_%.cpp
+	@mkdir -p $(OBJDIR)
+	@echo "Compiling $<"
+	@$(CXX) $< -o $@ -c $(CXXFLAGS) $(FLAGCX_INCLUDES) $(GTEST_INCLUDE) $(FIXTURE_INCLUDE)
+
+clean:
+	@rm -rf $(BUILDDIR)
+
+run-unit: $(UNIT_TARGET)
+	@$(UNIT_TARGET)
+
+run: run-unit

--- a/test/unittest/topo/Makefile
+++ b/test/unittest/topo/Makefile
@@ -5,7 +5,7 @@ UNIT_SRCS   := $(wildcard test_*.cpp)
 UNIT_OBJS   := $(UNIT_SRCS:%.cpp=$(OBJDIR)/%.o)
 UNIT_TARGET := $(BINDIR)/topo_unit_tests
 
-.PHONY: all clean run-unit run
+.PHONY: all clean run-unit run-mpi run
 
 ALL_TARGETS :=
 ifneq ($(UNIT_SRCS),)
@@ -29,5 +29,8 @@ clean:
 
 run-unit: $(UNIT_TARGET)
 	@$(UNIT_TARGET)
+
+run-mpi:
+	@echo "No MPI tests for topo component"
 
 run: run-unit

--- a/test/unittest/topo/test_p2p_topo.cpp
+++ b/test/unittest/topo/test_p2p_topo.cpp
@@ -13,7 +13,7 @@
 #include "flagcx.h"
 #include "p2p_topo.h"
 
-extern struct flagcxNetAdaptor flagcxNetIb;
+extern struct flagcxNetAdaptor flagcxNetIbP2p;
 
 class P2pTopoTest : public ::testing::Test {
 protected:
@@ -21,13 +21,13 @@ protected:
     // Initialize device adaptor (sets global deviceAdaptor)
     flagcxHandleInit(&handler);
 
-    netAdaptor = &flagcxNetIb;
+    netAdaptor = &flagcxNetIbP2p;
     ASSERT_EQ(netAdaptor->init(), flagcxSuccess)
-        << "IB net adaptor init failed";
+        << "IB P2P net adaptor init failed";
 
     int ndev = 0;
     ASSERT_EQ(netAdaptor->devices(&ndev), flagcxSuccess);
-    ASSERT_GT(ndev, 0) << "No IB devices found";
+    ASSERT_GT(ndev, 0) << "No IB P2P devices found";
     std::cout << "Net adaptor: " << netAdaptor->name << " (" << ndev
               << " devices)" << std::endl;
   }

--- a/test/unittest/topo/test_p2p_topo.cpp
+++ b/test/unittest/topo/test_p2p_topo.cpp
@@ -1,0 +1,83 @@
+/*************************************************************************
+ * Copyright (c) 2025 BAAI. All rights reserved.
+ *
+ * P2P topology manager unit test — no MPI or communicator required.
+ * Initializes device and net adaptors directly, builds a standalone
+ * topology graph, and verifies NIC selection for each visible GPU.
+ ************************************************************************/
+
+#include <gtest/gtest.h>
+#include <iostream>
+
+#include "adaptor.h"
+#include "flagcx.h"
+#include "p2p_topo.h"
+
+extern struct flagcxNetAdaptor flagcxNetIb;
+
+class P2pTopoTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    // Initialize device adaptor (sets global deviceAdaptor)
+    flagcxHandleInit(&handler);
+
+    netAdaptor = &flagcxNetIb;
+    ASSERT_EQ(netAdaptor->init(), flagcxSuccess)
+        << "IB net adaptor init failed";
+
+    int ndev = 0;
+    ASSERT_EQ(netAdaptor->devices(&ndev), flagcxSuccess);
+    ASSERT_GT(ndev, 0) << "No IB devices found";
+    std::cout << "Net adaptor: " << netAdaptor->name << " (" << ndev
+              << " devices)" << std::endl;
+  }
+
+  void TearDown() override { flagcxHandleFree(handler); }
+
+  flagcxHandlerGroup_t handler = nullptr;
+  struct flagcxNetAdaptor *netAdaptor = nullptr;
+};
+
+TEST_F(P2pTopoTest, InitAndDestroy) {
+  struct flagcxP2pTopoManager *mgr = nullptr;
+  ASSERT_EQ(flagcxP2pTopoInit(netAdaptor, &mgr), flagcxSuccess);
+  ASSERT_NE(mgr, nullptr);
+  EXPECT_GT(mgr->nGpus, 0);
+  std::cout << "P2P topo manager: " << mgr->nGpus << " GPUs" << std::endl;
+  EXPECT_EQ(flagcxP2pTopoDestroy(mgr), flagcxSuccess);
+}
+
+TEST_F(P2pTopoTest, GetNetDevForEachGpu) {
+  struct flagcxP2pTopoManager *mgr = nullptr;
+  ASSERT_EQ(flagcxP2pTopoInit(netAdaptor, &mgr), flagcxSuccess);
+
+  for (int gpu = 0; gpu < mgr->nGpus; gpu++) {
+    int netDev = -1;
+    EXPECT_EQ(flagcxP2pTopoGetNetDev(mgr, gpu, &netDev), flagcxSuccess);
+    EXPECT_GE(netDev, 0);
+    std::cout << "  GPU " << gpu << " -> NIC " << netDev << std::endl;
+  }
+
+  EXPECT_EQ(flagcxP2pTopoDestroy(mgr), flagcxSuccess);
+}
+
+TEST_F(P2pTopoTest, OutOfRangeGpuDev) {
+  struct flagcxP2pTopoManager *mgr = nullptr;
+  ASSERT_EQ(flagcxP2pTopoInit(netAdaptor, &mgr), flagcxSuccess);
+
+  int netDev = -1;
+  EXPECT_NE(flagcxP2pTopoGetNetDev(mgr, -1, &netDev), flagcxSuccess);
+  EXPECT_NE(flagcxP2pTopoGetNetDev(mgr, mgr->nGpus, &netDev), flagcxSuccess);
+
+  EXPECT_EQ(flagcxP2pTopoDestroy(mgr), flagcxSuccess);
+}
+
+TEST_F(P2pTopoTest, NullArgs) {
+  EXPECT_NE(flagcxP2pTopoGetNetDev(nullptr, 0, nullptr), flagcxSuccess);
+  EXPECT_EQ(flagcxP2pTopoDestroy(nullptr), flagcxSuccess);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
### PR Category
<!-- One of [ UIL (User Interface Layer) | CRL (Communication Runtime Layer) | PAL (Portable Abstraction Layer) | CICD | Others ] -->
CRL

### PR Types
<!-- One of [ New Features | Bug Fixes | Optimizations | Deprecations | Test Case | Docs | Others ] -->
New Features
### PR Description
<!-- Describe what you’ve done -->
This PR introduces a thin topo manager wrapper that can be used for nic selection for the FlagCX p2p engine. This topo manager uses FlagCX's underlying topology detection mechanism, while exposing APIs that do not rely on communicator and rank info.
