### PR TITLE
[UIL] Support allgather with different message size in torch flagcx backend

### DIFF
--- a/flagcx/runner/c2c_algo.cc
+++ b/flagcx/runner/c2c_algo.cc
@@ -27,18 +27,6 @@ inline int getLcmOfInterRankList(
   return result;
 }
 
-size_t getC2cCommPatternHash(size_t count, size_t rootClusterId,
-                             flagcxCommOp_t commOp, flagcxRedOp_t redOp,
-                             flagcxComm_t comm) {
-  std::size_t h1 = std::hash<size_t>()(count);
-  std::size_t h2 = std::hash<size_t>()(rootClusterId);
-  std::size_t h3 = std::hash<size_t>()(commOp);
-  std::size_t h4 = std::hash<size_t>()(redOp);
-  std::size_t h5 = std::hash<size_t>()((size_t)((uintptr_t)comm));
-  std::size_t h = h1 ^ (h2 << 1) ^ (h3 << 2) ^ (h4 << 3) ^ (h5 << 4);
-  return (static_cast<size_t>(h) << 4) + static_cast<size_t>(commOp);
-}
-
 flagcxInterRankBufferInfoManager::flagcxInterRankBufferInfoManager(
     size_t totalCount)
     : totalCount_(totalCount) {}
@@ -1261,21 +1249,29 @@ flagcxResult_t flagcxC2cPlanner::refresh(int isSendRecv) {
             clusterdataoffset += comm_->clusterSizes[z];
           } else if (i != z) {
             if (isUseless == 0) {
-              for (int k = 0; k < myCount / minCount; ++k) {
-                interRankBufferInfoManager_.pushBackBufferInfo(
-                    i, clusterInterRankList_[i][j],
-                    (sendCount_ >= recvCount_) ? myCount * j + minCount * k
-                                               : clusterOffset * sendCount_ +
-                                                     myCount * j + minCount * k,
-                    minCount, z, 0, isScheduled, -1, -1);
+              // Distribute remainder evenly: last myRes ranks each get one
+              // extra element instead of dumping all remainder on the last
+              // rank.
+              size_t rankCount =
+                  myCount + (j >= nClusterInterRanks - myRes ? 1 : 0);
+              size_t rankOffset = 0;
+              if (j < nClusterInterRanks - myRes) {
+                rankOffset = myCount * j;
+              } else {
+                rankOffset = myCount * (nClusterInterRanks - myRes) +
+                             (myCount + 1) * (j - (nClusterInterRanks - myRes));
               }
-              if (j == nClusterInterRanks - 1 && myRes > 0) {
+              size_t rankMinCount =
+                  (searchGranularity == "COARSE") ? rankCount : minCount;
+              for (size_t k = 0;
+                   k < (rankMinCount > 0 ? rankCount / rankMinCount : 0); ++k) {
                 interRankBufferInfoManager_.pushBackBufferInfo(
                     i, clusterInterRankList_[i][j],
                     (sendCount_ >= recvCount_)
-                        ? myCount * (j + 1)
-                        : clusterOffset * sendCount_ + myCount * (j + 1),
-                    myRes, z, 0, isScheduled, -1, -1);
+                        ? rankOffset + rankMinCount * k
+                        : clusterOffset * sendCount_ + rankOffset +
+                              rankMinCount * k,
+                    rankMinCount, z, 0, isScheduled, -1, -1);
               }
             }
           }

--- a/flagcx/runner/hybrid_runner.cc
+++ b/flagcx/runner/hybrid_runner.cc
@@ -6,7 +6,7 @@
 #include "runner.h"
 
 #define FLAGCX_CACHE_CAPACITY 16
-static flagcxLRUCache<size_t, flagcxC2cPlanner>
+static flagcxLRUCache<C2cPatternKey, flagcxC2cPlanner, C2cPatternKeyHash>
     planCache(FLAGCX_CACHE_CAPACITY);
 
 flagcxResult_t hybridRunnerReduce(const void *sendbuff, void *recvbuff,
@@ -15,28 +15,24 @@ flagcxResult_t hybridRunnerReduce(const void *sendbuff, void *recvbuff,
                                   flagcxStream_t stream) {
   // Construct flagcxC2cPlanner and find corresponding strategy
   flagcxC2cPlanner planner;
-  auto hashValue = getC2cCommPatternHash(count, comm->clusterIds[root],
-                                         flagcxCommOpReduce, op, comm);
-  if (!planCache.get(hashValue, planner)) {
+  C2cPatternKey key = {count, (size_t)comm->clusterIds[root],
+                       flagcxCommOpReduce, op, (uintptr_t)comm};
+  if (!planCache.get(key, planner)) {
     INFO(FLAGCX_COLL,
          "No available plan is found, create a new one with "
          "communication pattern "
-         "(count, rootClsuterId, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         count, comm->clusterIds[root], flagcxCommOpReduce, op,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %ld, %d, %d, "
+         "%ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
     planner =
         flagcxC2cPlanner(count, count, root, comm, flagcxCommOpReduce, op);
-    planCache.put(hashValue, planner);
+    planCache.put(key, planner);
   } else {
     INFO(FLAGCX_COLL,
          "Found available plan with communication pattern "
-         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         count, comm->clusterIds[root], flagcxCommOpReduce, op,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %ld, %d, %d, "
+         "%ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
   }
   FLAGCXCHECK(planner.execute(sendbuff, recvbuff, datatype, root, stream));
   return flagcxSuccess;
@@ -48,28 +44,22 @@ flagcxResult_t hybridRunnerGather(const void *sendbuff, void *recvbuff,
                                   flagcxStream_t stream) {
   // Construct flagcxC2cPlanner and find corresponding strategy
   flagcxC2cPlanner planner;
-  auto hashValue = getC2cCommPatternHash(count, root, flagcxCommOpGather,
-                                         flagcxRedNoOp, comm);
-  if (!planCache.get(hashValue, planner)) {
+  C2cPatternKey key = {count, (size_t)root, flagcxCommOpGather, flagcxRedNoOp,
+                       (uintptr_t)comm};
+  if (!planCache.get(key, planner)) {
     INFO(FLAGCX_COLL,
          "No available plan is found, create a new one with "
          "communication pattern "
-         "(count, rootRank, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         count, root, flagcxCommOpGather, flagcxRedNoOp,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootRank, commOp, redOp, comm) = (%ld, %ld, %d, %d, %ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
     planner = flagcxC2cPlanner(count, count * comm->nranks, root, comm,
                                flagcxCommOpGather, flagcxRedNoOp);
-    planCache.put(hashValue, planner);
+    planCache.put(key, planner);
   } else {
     INFO(FLAGCX_COLL,
          "Found available plan with communication pattern "
-         "(count, rootRank, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         count, root, flagcxCommOpGather, flagcxRedNoOp,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootRank, commOp, redOp, comm) = (%ld, %ld, %d, %d, %ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
   }
   FLAGCXCHECK(planner.execute(sendbuff, recvbuff, datatype, root, stream));
   return flagcxSuccess;
@@ -81,28 +71,22 @@ flagcxResult_t hybridRunnerScatter(const void *sendbuff, void *recvbuff,
                                    flagcxStream_t stream) {
   // Construct flagcxC2cPlanner and find corresponding strategy
   flagcxC2cPlanner planner;
-  auto hashValue = getC2cCommPatternHash(count, root, flagcxCommOpScatter,
-                                         flagcxRedNoOp, comm);
-  if (!planCache.get(hashValue, planner)) {
+  C2cPatternKey key = {count, (size_t)root, flagcxCommOpScatter, flagcxRedNoOp,
+                       (uintptr_t)comm};
+  if (!planCache.get(key, planner)) {
     INFO(FLAGCX_COLL,
          "No available plan is found, create a new one with "
          "communication pattern "
-         "(count, rootRank, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         count, root, flagcxCommOpScatter, flagcxRedNoOp,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootRank, commOp, redOp, comm) = (%ld, %ld, %d, %d, %ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
     planner = flagcxC2cPlanner(count * comm->nranks, count, root, comm,
                                flagcxCommOpScatter, flagcxRedNoOp);
-    planCache.put(hashValue, planner);
+    planCache.put(key, planner);
   } else {
     INFO(FLAGCX_COLL,
          "Found available plan with communication pattern "
-         "(count, rootRank, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         count, root, flagcxCommOpScatter, flagcxRedNoOp,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootRank, commOp, redOp, comm) = (%ld, %ld, %d, %d, %ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
   }
   FLAGCXCHECK(planner.execute(sendbuff, recvbuff, datatype, root, stream));
   return flagcxSuccess;
@@ -114,29 +98,24 @@ flagcxResult_t hybridRunnerBroadcast(const void *sendbuff, void *recvbuff,
                                      flagcxStream_t stream) {
   // Construct flagcxC2cPlanner and find corresponding strategy
   flagcxC2cPlanner planner;
-  auto hashValue =
-      getC2cCommPatternHash(count, comm->clusterIds[root],
-                            flagcxCommOpBroadcast, flagcxRedNoOp, comm);
-  if (!planCache.get(hashValue, planner)) {
+  C2cPatternKey key = {count, (size_t)comm->clusterIds[root],
+                       flagcxCommOpBroadcast, flagcxRedNoOp, (uintptr_t)comm};
+  if (!planCache.get(key, planner)) {
     INFO(FLAGCX_COLL,
          "No available plan is found, create a new one with "
          "communication pattern "
-         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         count, comm->clusterIds[root], flagcxCommOpBroadcast, flagcxRedNoOp,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %ld, %d, %d, "
+         "%ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
     planner = flagcxC2cPlanner(count, count, root, comm, flagcxCommOpBroadcast,
                                flagcxRedNoOp);
-    planCache.put(hashValue, planner);
+    planCache.put(key, planner);
   } else {
     INFO(FLAGCX_COLL,
          "Found available plan with communication pattern "
-         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         count, comm->clusterIds[root], flagcxCommOpBroadcast, flagcxRedNoOp,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %ld, %d, %d, "
+         "%ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
   }
   FLAGCXCHECK(planner.execute(sendbuff, recvbuff, datatype, root, stream));
   return flagcxSuccess;
@@ -148,33 +127,24 @@ flagcxResult_t hybridRunnerAllReduce(const void *sendbuff, void *recvbuff,
                                      flagcxStream_t stream) {
   // Construct flagcxC2cPlanner and find corresponding strategy
   flagcxC2cPlanner planner;
-  auto hashValue =
-      getC2cCommPatternHash(count, comm->nclusters, flagcxCommOpAllReduce, op,
-                            comm); // use nclusters as rootClusterId for hash
-  if (!planCache.get(hashValue, planner)) {
+  C2cPatternKey key = {count, (size_t)comm->nclusters, flagcxCommOpAllReduce,
+                       op, (uintptr_t)comm};
+  if (!planCache.get(key, planner)) {
     INFO(FLAGCX_COLL,
          "No available plan is found, create a new one with "
          "communication pattern "
-         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         count, comm->nclusters, flagcxCommOpAllReduce, op,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %ld, %d, %d, "
+         "%ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
     planner =
         flagcxC2cPlanner(count, count, -1, comm, flagcxCommOpAllReduce, op);
-    planCache.put(hashValue, planner);
-    // TODO: add estimator part
-    // flagcxAlgoTimeEstimator estimator(planner, datatype);
-    // float time = 0.0;
-    // FLAGCXCHECK(estimator.getAlgoTime(&time));
+    planCache.put(key, planner);
   } else {
     INFO(FLAGCX_COLL,
          "Found available plan with communication pattern "
-         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         count, comm->nclusters, flagcxCommOpAllReduce, op,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %ld, %d, %d, "
+         "%ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
   }
   FLAGCXCHECK(planner.execute(sendbuff, recvbuff, datatype, -1, stream));
   return flagcxSuccess;
@@ -187,29 +157,24 @@ flagcxResult_t hybridRunnerReduceScatter(const void *sendbuff, void *recvbuff,
                                          flagcxStream_t stream) {
   // Construct flagcxC2cPlanner and find corresponding strategy
   flagcxC2cPlanner planner;
-  auto hashValue = getC2cCommPatternHash(
-      recvcount, comm->nclusters, flagcxCommOpReduceScatter, op,
-      comm); // use nclusters as rootClusterId for hash
-  if (!planCache.get(hashValue, planner)) {
+  C2cPatternKey key = {recvcount, (size_t)comm->nclusters,
+                       flagcxCommOpReduceScatter, op, (uintptr_t)comm};
+  if (!planCache.get(key, planner)) {
     INFO(FLAGCX_COLL,
          "No available plan is found, create a new one with "
          "communication pattern "
-         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         recvcount, comm->nclusters, flagcxCommOpReduceScatter, op,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %ld, %d, %d, "
+         "%ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
     planner = flagcxC2cPlanner(comm->nranks * recvcount, recvcount, -1, comm,
                                flagcxCommOpReduceScatter, op);
-    planCache.put(hashValue, planner);
+    planCache.put(key, planner);
   } else {
     INFO(FLAGCX_COLL,
          "Found available plan with communication pattern "
-         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         recvcount, comm->nclusters, flagcxCommOpReduceScatter, op,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %ld, %d, %d, "
+         "%ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
   }
   FLAGCXCHECK(planner.execute(sendbuff, recvbuff, datatype, -1, stream));
   return flagcxSuccess;
@@ -221,30 +186,24 @@ flagcxResult_t hybridRunnerAllGather(const void *sendbuff, void *recvbuff,
                                      flagcxComm_t comm, flagcxStream_t stream) {
   // Construct flagcxC2cPlanner and find corresponding strategy
   flagcxC2cPlanner planner;
-  auto hashValue = getC2cCommPatternHash(
-      sendcount, comm->nclusters,
-      flagcxCommOpAllGather, // use nclusters as rootClusterId for hash
-      flagcxRedNoOp, comm);
-  if (!planCache.get(hashValue, planner)) {
+  C2cPatternKey key = {sendcount, (size_t)comm->nclusters,
+                       flagcxCommOpAllGather, flagcxRedNoOp, (uintptr_t)comm};
+  if (!planCache.get(key, planner)) {
     INFO(FLAGCX_COLL,
          "No available plan is found, create a new one with "
          "communication pattern "
-         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         sendcount, comm->nclusters, flagcxCommOpAllGather, flagcxRedNoOp,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %ld, %d, %d, "
+         "%ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
     planner = flagcxC2cPlanner(sendcount, sendcount * comm->nranks, -1, comm,
                                flagcxCommOpAllGather, flagcxRedNoOp);
-    planCache.put(hashValue, planner);
+    planCache.put(key, planner);
   } else {
     INFO(FLAGCX_COLL,
          "Found available plan with communication pattern "
-         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         sendcount, comm->nclusters, flagcxCommOpAllGather, flagcxRedNoOp,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %ld, %d, %d, "
+         "%ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
   }
   FLAGCXCHECK(planner.execute(sendbuff, recvbuff, datatype, -1, stream));
   return flagcxSuccess;
@@ -255,29 +214,24 @@ flagcxResult_t hybridRunnerAlltoAll(const void *sendbuff, void *recvbuff,
                                     flagcxComm_t comm, flagcxStream_t stream) {
   // Construct flagcxC2cPlanner and find corresponding strategy
   flagcxC2cPlanner planner;
-  auto hashValue =
-      getC2cCommPatternHash(count, 1, // use 1 as rootClusterId for hash
-                            flagcxCommOpAlltoAll, flagcxRedNoOp, comm);
-  if (!planCache.get(hashValue, planner)) {
+  C2cPatternKey key = {count, 1, flagcxCommOpAlltoAll, flagcxRedNoOp,
+                       (uintptr_t)comm};
+  if (!planCache.get(key, planner)) {
     INFO(FLAGCX_COLL,
          "No available plan is found, create a new one with "
          "communication pattern "
-         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         count, 1, flagcxCommOpAlltoAll, flagcxRedNoOp,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %ld, %d, %d, "
+         "%ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
     planner = flagcxC2cPlanner(count, count, -1, comm, flagcxCommOpAlltoAll,
                                flagcxRedNoOp);
-    planCache.put(hashValue, planner);
+    planCache.put(key, planner);
   } else {
     INFO(FLAGCX_COLL,
          "Found available plan with communication pattern "
-         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         count, 1, flagcxCommOpAlltoAll, flagcxRedNoOp,
-         (size_t)((uintptr_t)comm), hashValue);
+         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %ld, %d, %d, "
+         "%ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
   }
   FLAGCXCHECK(planner.execute(sendbuff, recvbuff, datatype, -1, stream));
   return flagcxSuccess;
@@ -289,29 +243,24 @@ flagcxResult_t hybridRunnerAlltoAllv(const void *sendbuff, size_t *sendcounts,
                                      flagcxDataType_t datatype,
                                      flagcxComm_t comm, flagcxStream_t stream) {
   flagcxC2cPlanner planner;
-  auto hashValue = getC2cCommPatternHash(
-      1, 1, // use 1 both as count and rootClusterId for hash
-      flagcxCommOpAlltoAllv, flagcxRedNoOp, comm);
-  if (!planCache.get(hashValue, planner)) {
+  C2cPatternKey key = {1, 1, flagcxCommOpAlltoAllv, flagcxRedNoOp,
+                       (uintptr_t)comm};
+  if (!planCache.get(key, planner)) {
     INFO(FLAGCX_COLL,
          "No available plan is found, create a new one with "
          "communication pattern "
-         "(count, rootClusterId, commOp, redOp, comm) = (%d, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         1, 1, flagcxCommOpAlltoAllv, flagcxRedNoOp, (size_t)((uintptr_t)comm),
-         hashValue);
+         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %ld, %d, %d, "
+         "%ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
     planner =
         flagcxC2cPlanner(1, 1, -1, comm, flagcxCommOpAlltoAllv, flagcxRedNoOp);
-    planCache.put(hashValue, planner);
+    planCache.put(key, planner);
   } else {
     INFO(FLAGCX_COLL,
          "Found available plan with communication pattern "
-         "(count, rootClusterId, commOp, redOp, comm) = (%d, %d, %d, %d, "
-         "%ld), hashValue = "
-         "%ld",
-         1, 1, flagcxCommOpAlltoAllv, flagcxRedNoOp, (size_t)((uintptr_t)comm),
-         hashValue);
+         "(count, rootClusterId, commOp, redOp, comm) = (%ld, %ld, %d, %d, "
+         "%ld)",
+         key.count, key.rootClusterId, key.commOp, key.redOp, key.comm);
   }
   FLAGCXCHECK(planner.execute(sendbuff, recvbuff, datatype, -1, stream,
                               sendcounts, sdispls, recvcounts, rdispls));

--- a/flagcx/runner/include/c2c_algo.h
+++ b/flagcx/runner/include/c2c_algo.h
@@ -6,6 +6,8 @@
 #include "flagcx_hetero.h"
 #include "group.h"
 #include "param.h"
+#include <cstdint>
+#include <functional>
 #include <iostream>
 #include <list>
 #include <map>
@@ -18,11 +20,33 @@ typedef enum {
   flagcxAlgoInput = 2
 } flagcxAlgorithm_t;
 
-size_t getC2cCommPatternHash(size_t count, size_t rootClusterId,
-                             flagcxCommOp_t commOp, flagcxRedOp_t redOp,
-                             flagcxComm_t comm);
+struct C2cPatternKey {
+  size_t count;
+  size_t rootClusterId;
+  flagcxCommOp_t commOp;
+  flagcxRedOp_t redOp;
+  uintptr_t comm;
 
-template <typename Key, typename Value>
+  bool operator==(const C2cPatternKey &other) const {
+    return count == other.count && rootClusterId == other.rootClusterId &&
+           commOp == other.commOp && redOp == other.redOp && comm == other.comm;
+  }
+};
+
+struct C2cPatternKeyHash {
+  size_t operator()(const C2cPatternKey &k) const {
+    size_t h = 0;
+    h ^= std::hash<size_t>()(k.count) + 0x9e3779b9 + (h << 6) + (h >> 2);
+    h ^=
+        std::hash<size_t>()(k.rootClusterId) + 0x9e3779b9 + (h << 6) + (h >> 2);
+    h ^= std::hash<int>()(k.commOp) + 0x9e3779b9 + (h << 6) + (h >> 2);
+    h ^= std::hash<int>()(k.redOp) + 0x9e3779b9 + (h << 6) + (h >> 2);
+    h ^= std::hash<uintptr_t>()(k.comm) + 0x9e3779b9 + (h << 6) + (h >> 2);
+    return h;
+  }
+};
+
+template <typename Key, typename Value, typename Hash = std::hash<Key>>
 class flagcxLRUCache {
 public:
   flagcxLRUCache(size_t capacity) : capacity_(capacity) {}
@@ -60,7 +84,8 @@ public:
 private:
   size_t capacity_;
   std::list<std::pair<Key, Value>> cacheItems_;
-  std::unordered_map<Key, typename std::list<std::pair<Key, Value>>::iterator>
+  std::unordered_map<Key, typename std::list<std::pair<Key, Value>>::iterator,
+                     Hash>
       cacheMap_;
 };
 

--- a/plugin/torch/example/example.py
+++ b/plugin/torch/example/example.py
@@ -219,9 +219,7 @@ def test_allgather():
             input_diff_size[i] = MY_RANK + i
         output_diff_size_list = [torch.empty(rank + 1).cuda() for rank in range(WORLD_SIZE)]
         print(f"rank {MY_RANK} before all_gather with different sizes with FLAGCX_GROUP1: input_diff_size = {input_diff_size}, output_diff_size_list = {output_diff_size_list}")
-        with dist._coalescing_manager(group=FLAGCX_GROUP1, async_ops=True)  as cm:
-            dist.all_gather(output_diff_size_list, input_diff_size, group=FLAGCX_GROUP1)
-        cm.wait()
+        dist.all_gather(output_diff_size_list, input_diff_size, group=FLAGCX_GROUP1)
         print(f"rank {MY_RANK} after all_gather with different sizes with FLAGCX_GROUP1: input_diff_size = {input_diff_size}, output_diff_size_list = {output_diff_size_list}")
 
 def test_reducescatter():

--- a/plugin/torch/example/example.py
+++ b/plugin/torch/example/example.py
@@ -213,6 +213,17 @@ def test_allgather():
         cm.wait()
         print(f"rank {MY_RANK} after all_gather_coalesced async with FLAGCX_GROUP1: x = {x}, y = {y}, z = {z}, z1 = {z1}")
 
+        # Perform all_gather with different input sizes (using broadcast implementation)
+        input_diff_size = torch.rand(MY_RANK + 1).cuda()
+        for i in range(MY_RANK + 1):
+            input_diff_size[i] = MY_RANK + i
+        output_diff_size_list = [torch.empty(rank + 1).cuda() for rank in range(WORLD_SIZE)]
+        print(f"rank {MY_RANK} before all_gather with different sizes with FLAGCX_GROUP1: input_diff_size = {input_diff_size}, output_diff_size_list = {output_diff_size_list}")
+        with dist._coalescing_manager(group=FLAGCX_GROUP1, async_ops=True)  as cm:
+            dist.all_gather(output_diff_size_list, input_diff_size, group=FLAGCX_GROUP1)
+        cm.wait()
+        print(f"rank {MY_RANK} after all_gather with different sizes with FLAGCX_GROUP1: input_diff_size = {input_diff_size}, output_diff_size_list = {output_diff_size_list}")
+
 def test_reducescatter():
     if torch.cuda.is_available():
         # Create tensors

--- a/plugin/torch/flagcx/src/backend_flagcx.cpp
+++ b/plugin/torch/flagcx/src/backend_flagcx.cpp
@@ -553,15 +553,25 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
   auto device = inputTensor.device();
   auto flagcxDataType = getFlagcxDataType(inputTensor.scalar_type());
   auto stream = getStreamByIndex(0);
-  auto work = c10::make_intrusive<flagcxWork>(OpType::ALLGATHER, stream,
-                                              handler_->devHandle);
   check_device(inputTensor.device(), outputTensorsTmp[0].device());
   initComm(device);
   syncStream(device);
 
   if (!check_same_size(outputTensorsTmp)) {
-    throw std::runtime_error(
-        "flagcx only support same size allgather operation");
+      // Implement allgather with different sizes using broadcast
+      const auto num_reduces = outputTensorsTmp.size();
+      startCoalescing();
+      for (const int64_t i : c10::irange(static_cast<int64_t>(num_reduces))) {
+	  auto& output = outputTensorsTmp[i];
+	  auto& input = (i == rank_) ? inputTensor : output;
+	  // Perform out-of-place broadcast from rank i
+	  C10D_FLAGCX_CHECK(flagcxBroadcast(input.data_ptr(), output.data_ptr(),
+				                  output.numel(), flagcxDataType, i,
+		                                  handler_->comm, stream),
+			                          std::nullopt);
+      }
+      auto work = endCoalescing();
+      return work;
   } else {
     // Flatten a vector of tensors into a single, stacked tensor.
     at::Tensor outputFlattened = newLikeFlat(outputTensorsTmp);
@@ -590,6 +600,8 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
     }
   }
 
+  auto work = c10::make_intrusive<flagcxWork>(OpType::ALLGATHER, stream,
+		                                    handler_->devHandle);
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
   // Create a future to track the allgather operation

--- a/plugin/torch/flagcx/src/backend_flagcx.cpp
+++ b/plugin/torch/flagcx/src/backend_flagcx.cpp
@@ -558,20 +558,20 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
   syncStream(device);
 
   if (!check_same_size(outputTensorsTmp)) {
-      // Implement allgather with different sizes using broadcast
-      const auto num_reduces = outputTensorsTmp.size();
-      startCoalescing();
-      for (const int64_t i : c10::irange(static_cast<int64_t>(num_reduces))) {
-	  auto& output = outputTensorsTmp[i];
-	  auto& input = (i == rank_) ? inputTensor : output;
-	  // Perform out-of-place broadcast from rank i
-	  C10D_FLAGCX_CHECK(flagcxBroadcast(input.data_ptr(), output.data_ptr(),
-				                  output.numel(), flagcxDataType, i,
-		                                  handler_->comm, stream),
-			                          std::nullopt);
-      }
-      auto work = endCoalescing();
-      return work;
+    // Implement allgather with different sizes using broadcast
+    const auto num_reduces = outputTensorsTmp.size();
+    startCoalescing();
+    for (const int64_t i : c10::irange(static_cast<int64_t>(num_reduces))) {
+      auto &output = outputTensorsTmp[i];
+      auto &input = (i == rank_) ? inputTensor : output;
+      // Perform out-of-place broadcast from rank i
+      C10D_FLAGCX_CHECK(flagcxBroadcast(input.data_ptr(), output.data_ptr(),
+                                        output.numel(), flagcxDataType, i,
+                                        handler_->comm, stream),
+                        std::nullopt);
+    }
+    auto work = endCoalescing();
+    return work;
   } else {
     // Flatten a vector of tensors into a single, stacked tensor.
     at::Tensor outputFlattened = newLikeFlat(outputTensorsTmp);
@@ -601,7 +601,7 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
   }
 
   auto work = c10::make_intrusive<flagcxWork>(OpType::ALLGATHER, stream,
-		                                    handler_->devHandle);
+                                              handler_->devHandle);
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
   // Create a future to track the allgather operation

--- a/plugin/torch/flagcx/src/backend_flagcx.cpp
+++ b/plugin/torch/flagcx/src/backend_flagcx.cpp
@@ -560,18 +560,15 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
   if (!check_same_size(outputTensorsTmp)) {
     // Implement allgather with different sizes using broadcast
     const auto num_reduces = outputTensorsTmp.size();
-    startCoalescing();
     for (const int64_t i : c10::irange(static_cast<int64_t>(num_reduces))) {
       auto &output = outputTensorsTmp[i];
       auto &input = (i == rank_) ? inputTensor : output;
       // Perform out-of-place broadcast from rank i
       C10D_FLAGCX_CHECK(flagcxBroadcast(input.data_ptr(), output.data_ptr(),
-                                        output.numel(), flagcxDataType, i,
+                                        input.numel(), flagcxDataType, i,
                                         handler_->comm, stream),
                         std::nullopt);
     }
-    auto work = endCoalescing();
-    return work;
   } else {
     // Flatten a vector of tensors into a single, stacked tensor.
     at::Tensor outputFlattened = newLikeFlat(outputTensorsTmp);


### PR DESCRIPTION
### PR Category
<!-- One of [ UIL (User Interface Layer) | CRL (Communication Runtime Layer) | PAL (Portable Abstraction Layer) | CICD | Others ] -->
UIL
### PR Types
<!-- One of [ New Features | Bug Fixes | Optimizations | Deprecations | Test Case | Docs | Others ] -->
New Feature
### PR Description
<!-- Describe what you’ve done -->
Support allgather with different message size in torch flagcx backend. In case of MoE training with TP enabled, after dispatch communication (post_dispatch) in the forward pass, the dispatched tokens (different number) should be aggregated in TP communication group via allgather with different size message.