### PR TITLE
[CRL] Optim rmaProxyProgress and Adds batched one-sided PUT operations to improve RDMA throughput

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -76,6 +76,8 @@ This document provides a comprehensive reference for all environment variables u
 | `FLAGCX_P2P_DISABLE` | 0 | When set to 1, disables P2P transport |
 | `FLAGCX_P2P_SCHEDULE_DISABLE` | 0 | When set to 1, disables P2P scheduling optimization |
 | `FLAGCX_DEVICE_FUNC_PATH` | None | Path to device function library for async kernel loading |
+| `FLAGCX_RMA_QUEUE_SIZE` | 256 | Per-peer circular buffer depth for the RMA proxy thread. Must be a power of two. Increasing this allows more in-flight RDMA descriptors per peer before the producer blocks |
+| `FLAGCX_RMA_BATCH_MAX` | 256 | Maximum number of RDMA PUT descriptors batched into a single `iputBatch` call by the RMA proxy thread. Capped internally at 256. Set to 1 to disable batching and fall back to one-at-a-time `iput` |
 
 ---
 

--- a/flagcx/adaptor/include/flagcx_net_adaptor.h
+++ b/flagcx/adaptor/include/flagcx_net_adaptor.h
@@ -74,6 +74,17 @@ struct flagcxNetAdaptor_v1 {
 
   // Device name lookup
   flagcxResult_t (*getDevFromName)(char *name, int *dev);
+
+  // Optional one-sided batch WRITE. Implementations should post up to
+  // `count` WRs and set `posted` to the number accepted by the QP. A partial
+  // post is allowed when the send queue is temporarily full; requests[0:posted]
+  // must then be valid and requests[posted:] must remain untouched/NULL.
+  flagcxResult_t (*iputBatch)(void *sendComm, int count,
+                              const uint64_t *srcOffs,
+                              const uint64_t *dstOffs, const size_t *sizes,
+                              int srcRank, int dstRank, void **srcHandles,
+                              void **dstHandles, void **requests,
+                              int *posted);
 };
 #define flagcxNetAdaptor flagcxNetAdaptor_v1
 

--- a/flagcx/adaptor/include/flagcx_net_adaptor.h
+++ b/flagcx/adaptor/include/flagcx_net_adaptor.h
@@ -84,7 +84,7 @@ struct flagcxNetAdaptor_v2 {
   flagcxResult_t (*init)();
   flagcxResult_t (*devices)(int *ndev);
   flagcxResult_t (*getProperties)(int dev, void *props);
-  
+
   // Setup functions
   flagcxResult_t (*listen)(int dev, void *handle, void **listenComm);
   flagcxResult_t (*connect)(int dev, void *handle, void **sendComm);

--- a/flagcx/adaptor/include/flagcx_net_adaptor.h
+++ b/flagcx/adaptor/include/flagcx_net_adaptor.h
@@ -6,6 +6,7 @@
 #define FLAGCX_NET_ADAPTOR_H_
 
 #include "flagcx.h"
+#include "string.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -23,6 +24,8 @@ typedef enum {
 //         listen, connect, accept, closeSend, closeRecv, closeListen,
 //         regMr, regMrDmaBuf, deregMr, isend, irecv, iflush, test,
 //         iput, iget, iputSignal, getDevFromName
+//   v2 — adds iputBatch (optional one-sided batch WRITE)
+
 struct flagcxNetAdaptor_v1 {
   // Basic functions
   const char *name;
@@ -71,22 +74,77 @@ struct flagcxNetAdaptor_v1 {
                                void **srcHandles, void **dstHandles,
                                uint64_t signalOff, void **signalHandles,
                                uint64_t signalValue, void **request);
+  // Device name lookup
+  flagcxResult_t (*getDevFromName)(char *name, int *dev);
+};
+
+struct flagcxNetAdaptor_v2 {
+  // Basic functions
+  const char *name;
+  flagcxResult_t (*init)();
+  flagcxResult_t (*devices)(int *ndev);
+  flagcxResult_t (*getProperties)(int dev, void *props);
+  
+  // Setup functions
+  flagcxResult_t (*listen)(int dev, void *handle, void **listenComm);
+  flagcxResult_t (*connect)(int dev, void *handle, void **sendComm);
+  flagcxResult_t (*accept)(void *listenComm, void **recvComm);
+  flagcxResult_t (*closeSend)(void *sendComm);
+  flagcxResult_t (*closeRecv)(void *recvComm);
+  flagcxResult_t (*closeListen)(void *listenComm);
+
+  // Memory region functions
+  flagcxResult_t (*regMr)(void *comm, void *data, size_t size, int type,
+                          int mrFlags, void **mhandle);
+  flagcxResult_t (*regMrDmaBuf)(void *comm, void *data, size_t size, int type,
+                                uint64_t offset, int fd, int mrFlags,
+                                void **mhandle);
+  flagcxResult_t (*deregMr)(void *comm, void *mhandle);
+
+  // Two-sided functions
+  flagcxResult_t (*isend)(void *sendComm, void *data, size_t size, int tag,
+                          void *mhandle, void *phandle, void **request);
+  flagcxResult_t (*irecv)(void *recvComm, int n, void **data, size_t *sizes,
+                          int *tags, void **mhandles, void **phandles,
+                          void **request);
+  flagcxResult_t (*iflush)(void *recvComm, int n, void **data, int *sizes,
+                           void **mhandles, void **request);
+  flagcxResult_t (*test)(void *request, int *done, int *sizes);
+
+  // One-sided (per-window MR: separate src/dst handles for independent buffers)
+  flagcxResult_t (*iput)(void *sendComm, uint64_t srcOff, uint64_t dstOff,
+                         size_t size, int srcRank, int dstRank,
+                         void **srcHandles, void **dstHandles, void **request);
+  // RDMA READ: pull data from remote srcRank into local dstRank buffer
+  flagcxResult_t (*iget)(void *sendComm, uint64_t srcOff, uint64_t dstOff,
+                         size_t size, int srcRank, int dstRank,
+                         void **srcHandles, void **dstHandles, void **request);
+  // Data + signal combined (NCCL GIN-aligned: enables chained WRITE + ATOMIC)
+  // When size == 0, only signal ATOMIC is posted (signal-only mode)
+  flagcxResult_t (*iputSignal)(void *sendComm, uint64_t srcOff, uint64_t dstOff,
+                               size_t size, int srcRank, int dstRank,
+                               void **srcHandles, void **dstHandles,
+                               uint64_t signalOff, void **signalHandles,
+                               uint64_t signalValue, void **request);
 
   // Device name lookup
   flagcxResult_t (*getDevFromName)(char *name, int *dev);
-
-  // Optional one-sided batch WRITE. Implementations should post up to
-  // `count` WRs and set `posted` to the number accepted by the QP. A partial
-  // post is allowed when the send queue is temporarily full; requests[0:posted]
-  // must then be valid and requests[posted:] must remain untouched/NULL.
+  // Optional one-side batch WRITE.
   flagcxResult_t (*iputBatch)(void *sendComm, int count,
-                              const uint64_t *srcOffs,
-                              const uint64_t *dstOffs, const size_t *sizes,
-                              int srcRank, int dstRank, void **srcHandles,
-                              void **dstHandles, void **requests,
-                              int *posted);
+                              const uint64_t *srcOffs, const uint64_t *dstOffs,
+                              const size_t *sizes, int srcRank, int dstRank,
+                              void **srcHandles, void **dstHandles,
+                              void **requests, int *posted);
 };
-#define flagcxNetAdaptor flagcxNetAdaptor_v1
+
+#define flagcxNetAdaptor flagcxNetAdaptor_v2
+
+static inline void
+flagcxNetAdaptorUpgradeV1(const struct flagcxNetAdaptor_v1 *src,
+                          struct flagcxNetAdaptor_v2 *dst) {
+  memset(dst, 0, sizeof(*dst));
+  memcpy(dst, src, sizeof(struct flagcxNetAdaptor_v1));
+}
 
 // Versioned export symbol name
 #define FLAGCX_NET_ADAPTOR_PLUGIN_SYMBOL_V1 flagcxNetAdaptorPlugin_v1

--- a/flagcx/adaptor/include/flagcx_net_adaptor.h
+++ b/flagcx/adaptor/include/flagcx_net_adaptor.h
@@ -78,7 +78,7 @@ struct flagcxNetAdaptor_v1 {
   flagcxResult_t (*getDevFromName)(char *name, int *dev);
 };
 
-struct flagcxNetAdaptor_v2 {
+struct flagcxNetAdaptor_latest {
   // Basic functions
   const char *name;
   flagcxResult_t (*init)();
@@ -137,11 +137,11 @@ struct flagcxNetAdaptor_v2 {
                               void **requests, int *posted);
 };
 
-#define flagcxNetAdaptor flagcxNetAdaptor_v2
+#define flagcxNetAdaptor flagcxNetAdaptor_latest
 
 static inline void
-flagcxNetAdaptorUpgradeV1(const struct flagcxNetAdaptor_v1 *src,
-                          struct flagcxNetAdaptor_v2 *dst) {
+flagcxNetAdaptorUpgrade(const struct flagcxNetAdaptor_v1 *src,
+                        struct flagcxNetAdaptor_latest *dst) {
   memset(dst, 0, sizeof(*dst));
   memcpy(dst, src, sizeof(struct flagcxNetAdaptor_v1));
 }

--- a/flagcx/adaptor/net/ibrc_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_adaptor.cc
@@ -2432,7 +2432,9 @@ flagcxResult_t flagcxIbIput(void *sendComm, uint64_t srcOff, uint64_t dstOff,
   struct flagcxOneSideHandleInfo *dstInfo =
       (struct flagcxOneSideHandleInfo *)dstHandles;
 
-  struct flagcxIbQp *qp = &comm->base.qps[0];
+  int qpIdx = comm->base.qpIndex;
+  comm->base.qpIndex = (qpIdx + 1) % comm->base.nqps;
+  struct flagcxIbQp *qp = &comm->base.qps[qpIdx];
   void *srcPtr = (void *)(srcInfo->baseVas[srcRank] + srcOff);
   void *dstPtr = (void *)(dstInfo->baseVas[dstRank] + dstOff);
   int lkey = srcInfo->lkeys[srcRank];
@@ -2476,6 +2478,120 @@ flagcxResult_t flagcxIbIput(void *sendComm, uint64_t srcOff, uint64_t dstOff,
   return flagcxSuccess;
 }
 
+flagcxResult_t flagcxIbIputBatch(void *sendComm, int count,
+                                 const uint64_t *srcOffs,
+                                 const uint64_t *dstOffs,
+                                 const size_t *sizes, int srcRank,
+                                 int dstRank, void **srcHandles,
+                                 void **dstHandles, void **requests,
+                                 int *posted) {
+  if (posted == NULL || requests == NULL)
+    return flagcxInvalidArgument;
+  *posted = 0;
+  if (count <= 0)
+    return flagcxSuccess;
+  if (count > MAX_REQUESTS)
+    return flagcxInvalidArgument;
+
+  struct flagcxIbSendComm *comm = (struct flagcxIbSendComm *)sendComm;
+  struct flagcxOneSideHandleInfo *srcInfo =
+      (struct flagcxOneSideHandleInfo *)srcHandles;
+  struct flagcxOneSideHandleInfo *dstInfo =
+      (struct flagcxOneSideHandleInfo *)dstHandles;
+  if (comm == NULL || srcInfo == NULL || dstInfo == NULL || srcOffs == NULL ||
+      dstOffs == NULL || sizes == NULL) {
+    return flagcxInvalidArgument;
+  }
+
+  int qpIdx = comm->base.qpIndex;
+  comm->base.qpIndex = (qpIdx + 1) % comm->base.nqps;
+  struct flagcxIbQp *qp = &comm->base.qps[qpIdx];
+  int devIndex = qp->devIndex;
+  int lkey = srcInfo->lkeys[srcRank];
+  int rkey = dstInfo->rkeys[dstRank];
+
+  struct ibv_send_wr wrs[MAX_REQUESTS];
+  struct ibv_sge sges[MAX_REQUESTS];
+  struct flagcxIbRequest *reqs[MAX_REQUESTS];
+  memset(wrs, 0, count * sizeof(struct ibv_send_wr));
+  memset(sges, 0, count * sizeof(struct ibv_sge));
+  memset(reqs, 0, count * sizeof(struct flagcxIbRequest *));
+
+  flagcxResult_t res = flagcxSuccess;
+  struct ibv_send_wr *bad_wr = NULL;
+  int ret = 0;
+  for (int i = 0; i < count; i++) {
+    struct flagcxIbRequest *req = NULL;
+    res = flagcxIbGetRequest(&comm->base, &req);
+    if (res != flagcxSuccess) {
+      goto fail_before_post;
+    }
+    reqs[i] = req;
+    req->type = FLAGCX_NET_IB_REQ_IPUT;
+    req->sock = &comm->base.sock;
+    for (int d = 0; d < comm->base.ndevs; d++) {
+      req->devBases[d] = &comm->devs[d].base;
+    }
+
+    void *srcPtr = (void *)(srcInfo->baseVas[srcRank] + srcOffs[i]);
+    void *dstPtr = (void *)(dstInfo->baseVas[dstRank] + dstOffs[i]);
+
+    wrs[i].opcode = IBV_WR_RDMA_WRITE;
+    wrs[i].send_flags = IBV_SEND_SIGNALED;
+    wrs[i].wr_id = req - comm->base.reqs;
+    wrs[i].next = (i + 1 == count) ? NULL : &wrs[i + 1];
+    wrs[i].wr.rdma.remote_addr = (uint64_t)dstPtr;
+    wrs[i].wr.rdma.rkey = rkey;
+    wrs[i].sg_list = &sges[i];
+    wrs[i].num_sge = 1;
+
+    sges[i].addr = (uintptr_t)srcPtr;
+    sges[i].length = (uint32_t)sizes[i];
+    if ((size_t)sges[i].length != sizes[i]) {
+      WARN("flagcxIbIputBatch: transfer size %zu exceeds ibv_sge 32-bit limit",
+           sizes[i]);
+      res = flagcxInvalidArgument;
+      goto fail_before_post;
+    }
+    sges[i].lkey = lkey;
+
+    flagcxIbAddEvent(req, devIndex, &comm->devs[devIndex].base);
+  }
+
+  ret = qp->qp->context->ops.post_send(qp->qp, wrs, &bad_wr);
+  if (ret != IBV_SUCCESS) {
+    int first_failed = bad_wr ? (int)(bad_wr - wrs) : 0;
+    if (first_failed < 0 || first_failed > count)
+      first_failed = 0;
+    if (ret != ENOMEM) {
+      WARN("ibv_post_send(batch=%d) failed with error %s, posted=%d",
+           count, strerror(ret), first_failed);
+    }
+    for (int i = first_failed; i < count; i++) {
+      if (reqs[i] != NULL) {
+        flagcxIbFreeRequest(reqs[i]);
+        reqs[i] = NULL;
+      }
+    }
+    for (int i = 0; i < first_failed; i++)
+      requests[i] = reqs[i];
+    *posted = first_failed;
+    return first_failed > 0 ? flagcxSuccess : flagcxSystemError;
+  }
+
+  for (int i = 0; i < count; i++)
+    requests[i] = reqs[i];
+  *posted = count;
+  return flagcxSuccess;
+
+fail_before_post:
+  for (int i = 0; i < count; i++) {
+    if (reqs[i] != NULL)
+      flagcxIbFreeRequest(reqs[i]);
+  }
+  return res;
+}
+
 flagcxResult_t flagcxIbIget(void *sendComm, uint64_t srcOff, uint64_t dstOff,
                             size_t size, int srcRank, int dstRank,
                             void **srcHandles, void **dstHandles,
@@ -2486,7 +2602,9 @@ flagcxResult_t flagcxIbIget(void *sendComm, uint64_t srcOff, uint64_t dstOff,
   struct flagcxOneSideHandleInfo *dstInfo =
       (struct flagcxOneSideHandleInfo *)dstHandles;
 
-  struct flagcxIbQp *qp = &comm->base.qps[0];
+  int qpIdx = comm->base.qpIndex;
+  comm->base.qpIndex = (qpIdx + 1) % comm->base.nqps;
+  struct flagcxIbQp *qp = &comm->base.qps[qpIdx];
   // For RDMA READ: remote_addr is the source (remote peer), sge is the local
   // destination
   void *srcPtr = (void *)(srcInfo->baseVas[srcRank] + srcOff);
@@ -2550,7 +2668,9 @@ flagcxResult_t flagcxIbIputSignal(void *sendComm, uint64_t srcOff,
     return flagcxInternalError;
   }
 
-  struct flagcxIbQp *qp = &comm->base.qps[0];
+  int qpIdx = comm->base.qpIndex;
+  comm->base.qpIndex = (qpIdx + 1) % comm->base.nqps;
+  struct flagcxIbQp *qp = &comm->base.qps[qpIdx];
   int devIndex = qp->devIndex;
   struct flagcxIbRequest *req;
   FLAGCXCHECK(flagcxIbGetRequest(&comm->base, &req));
@@ -2641,4 +2761,7 @@ struct flagcxNetAdaptor flagcxNetIb = {
     flagcxIbIput, flagcxIbIget, flagcxIbIputSignal,
 
     // Device name lookup
-    flagcxIbGetDevFromName};
+    flagcxIbGetDevFromName,
+
+    // Optional one-sided batch WRITE
+    flagcxIbIputBatch};

--- a/flagcx/adaptor/net/ibrc_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_adaptor.cc
@@ -2480,9 +2480,8 @@ flagcxResult_t flagcxIbIput(void *sendComm, uint64_t srcOff, uint64_t dstOff,
 
 flagcxResult_t flagcxIbIputBatch(void *sendComm, int count,
                                  const uint64_t *srcOffs,
-                                 const uint64_t *dstOffs,
-                                 const size_t *sizes, int srcRank,
-                                 int dstRank, void **srcHandles,
+                                 const uint64_t *dstOffs, const size_t *sizes,
+                                 int srcRank, int dstRank, void **srcHandles,
                                  void **dstHandles, void **requests,
                                  int *posted) {
   if (posted == NULL || requests == NULL)
@@ -2519,7 +2518,6 @@ flagcxResult_t flagcxIbIputBatch(void *sendComm, int count,
 
   flagcxResult_t res = flagcxSuccess;
   struct ibv_send_wr *bad_wr = NULL;
-  int ret = 0;
   for (int i = 0; i < count; i++) {
     struct flagcxIbRequest *req = NULL;
     res = flagcxIbGetRequest(&comm->base, &req);
@@ -2554,33 +2552,31 @@ flagcxResult_t flagcxIbIputBatch(void *sendComm, int count,
       goto fail_before_post;
     }
     sges[i].lkey = lkey;
-
-    flagcxIbAddEvent(req, devIndex, &comm->devs[devIndex].base);
   }
 
-  ret = qp->qp->context->ops.post_send(qp->qp, wrs, &bad_wr);
-  if (ret != IBV_SUCCESS) {
+  res = flagcxWrapIbvPostSend(qp->qp, wrs, &bad_wr);
+  if (res != flagcxSuccess) {
     int first_failed = bad_wr ? (int)(bad_wr - wrs) : 0;
     if (first_failed < 0 || first_failed > count)
       first_failed = 0;
-    if (ret != ENOMEM) {
-      WARN("ibv_post_send(batch=%d) failed with error %s, posted=%d",
-           count, strerror(ret), first_failed);
-    }
     for (int i = first_failed; i < count; i++) {
       if (reqs[i] != NULL) {
         flagcxIbFreeRequest(reqs[i]);
         reqs[i] = NULL;
       }
     }
-    for (int i = 0; i < first_failed; i++)
+    for (int i = 0; i < first_failed; i++) {
+      flagcxIbAddEvent(reqs[i], devIndex, &comm->devs[devIndex].base);
       requests[i] = reqs[i];
+    }
     *posted = first_failed;
-    return first_failed > 0 ? flagcxSuccess : flagcxSystemError;
+    return res;
   }
 
-  for (int i = 0; i < count; i++)
+  for (int i = 0; i < count; i++) {
+    flagcxIbAddEvent(reqs[i], devIndex, &comm->devs[devIndex].base);
     requests[i] = reqs[i];
+  }
   *posted = count;
   return flagcxSuccess;
 

--- a/flagcx/adaptor/net/ibrc_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_adaptor.cc
@@ -2432,9 +2432,7 @@ flagcxResult_t flagcxIbIput(void *sendComm, uint64_t srcOff, uint64_t dstOff,
   struct flagcxOneSideHandleInfo *dstInfo =
       (struct flagcxOneSideHandleInfo *)dstHandles;
 
-  int qpIdx = comm->base.qpIndex;
-  comm->base.qpIndex = (qpIdx + 1) % comm->base.nqps;
-  struct flagcxIbQp *qp = &comm->base.qps[qpIdx];
+  struct flagcxIbQp *qp = &comm->base.qps[0];
   void *srcPtr = (void *)(srcInfo->baseVas[srcRank] + srcOff);
   void *dstPtr = (void *)(dstInfo->baseVas[dstRank] + dstOff);
   int lkey = srcInfo->lkeys[srcRank];
@@ -2598,9 +2596,7 @@ flagcxResult_t flagcxIbIget(void *sendComm, uint64_t srcOff, uint64_t dstOff,
   struct flagcxOneSideHandleInfo *dstInfo =
       (struct flagcxOneSideHandleInfo *)dstHandles;
 
-  int qpIdx = comm->base.qpIndex;
-  comm->base.qpIndex = (qpIdx + 1) % comm->base.nqps;
-  struct flagcxIbQp *qp = &comm->base.qps[qpIdx];
+  struct flagcxIbQp *qp = &comm->base.qps[0];
   // For RDMA READ: remote_addr is the source (remote peer), sge is the local
   // destination
   void *srcPtr = (void *)(srcInfo->baseVas[srcRank] + srcOff);
@@ -2664,9 +2660,7 @@ flagcxResult_t flagcxIbIputSignal(void *sendComm, uint64_t srcOff,
     return flagcxInternalError;
   }
 
-  int qpIdx = comm->base.qpIndex;
-  comm->base.qpIndex = (qpIdx + 1) % comm->base.nqps;
-  struct flagcxIbQp *qp = &comm->base.qps[qpIdx];
+  struct flagcxIbQp *qp = &comm->base.qps[0];
   int devIndex = qp->devIndex;
   struct flagcxIbRequest *req;
   FLAGCXCHECK(flagcxIbGetRequest(&comm->base, &req));

--- a/flagcx/adaptor/net/net_plugin_load.cc
+++ b/flagcx/adaptor/net/net_plugin_load.cc
@@ -54,7 +54,7 @@ static flagcxResult_t flagcxNetAdaptorPluginLoad() {
     netPluginDlHandle = NULL;
     return flagcxSystemError;
   }
-  flagcxNetAdaptorUpgradeV1(pluginV1, upgradedNetPluginAdaptor);
+  flagcxNetAdaptorUpgrade(pluginV1, upgradedNetPluginAdaptor);
   struct flagcxNetAdaptor *plugin = upgradedNetPluginAdaptor;
 
   // Validate function pointers that all built-in net adaptors implement.

--- a/flagcx/adaptor/net/net_plugin_load.cc
+++ b/flagcx/adaptor/net/net_plugin_load.cc
@@ -3,6 +3,7 @@
  ************************************************************************/
 
 #include "adaptor_plugin_load.h"
+#include "alloc.h"
 #include "core.h"
 #include "flagcx_net_adaptor.h"
 #include "net.h"
@@ -15,6 +16,7 @@
 static void *netPluginDlHandle = NULL;
 static int netPluginRefCount = 0;
 static std::mutex netPluginMutex;
+static struct flagcxNetAdaptor *upgradedNetPluginAdaptor = NULL;
 
 extern struct flagcxNetAdaptor *flagcxNetAdaptors[3];
 
@@ -35,12 +37,9 @@ static flagcxResult_t flagcxNetAdaptorPluginLoad() {
     return flagcxSuccess;
   }
 
-  // Future: When v2 is introduced, try dlsym("flagcxNetAdaptorPlugin_v2")
-  // first, then fall back to "flagcxNetAdaptorPlugin_v1" and wrap in a v1→v2
-  // shim.
-  struct flagcxNetAdaptor *plugin = (struct flagcxNetAdaptor *)dlsym(
+  struct flagcxNetAdaptor_v1 *pluginV1 = (struct flagcxNetAdaptor_v1 *)dlsym(
       netPluginDlHandle, "flagcxNetAdaptorPlugin_v1");
-  if (plugin == NULL) {
+  if (pluginV1 == NULL) {
     WARN("ADAPTOR/Plugin: Failed to find symbol 'flagcxNetAdaptorPlugin_v1' in "
          "'%s': %s",
          envValue, dlerror());
@@ -48,6 +47,15 @@ static flagcxResult_t flagcxNetAdaptorPluginLoad() {
     netPluginDlHandle = NULL;
     return flagcxSuccess;
   }
+
+  if (flagcxCalloc(&upgradedNetPluginAdaptor, 1) != flagcxSuccess) {
+    WARN("ADAPTOR/Plugin: Failed to allocate upgraded net adaptor struct");
+    flagcxAdaptorClosePluginLib(netPluginDlHandle);
+    netPluginDlHandle = NULL;
+    return flagcxSystemError;
+  }
+  flagcxNetAdaptorUpgradeV1(pluginV1, upgradedNetPluginAdaptor);
+  struct flagcxNetAdaptor *plugin = upgradedNetPluginAdaptor;
 
   // Validate function pointers that all built-in net adaptors implement.
   // Fields left NULL in some adaptors (regMrDmaBuf, iput, iget, iputSignal,
@@ -62,6 +70,8 @@ static flagcxResult_t flagcxNetAdaptorPluginLoad() {
     WARN("ADAPTOR/Plugin: Net adaptor plugin '%s' is missing required function "
          "pointers",
          envValue);
+    free(upgradedNetPluginAdaptor);
+    upgradedNetPluginAdaptor = NULL;
     flagcxAdaptorClosePluginLib(netPluginDlHandle);
     netPluginDlHandle = NULL;
     return flagcxSuccess;
@@ -76,6 +86,10 @@ static flagcxResult_t flagcxNetAdaptorPluginLoad() {
 static flagcxResult_t flagcxNetAdaptorPluginUnload() {
   flagcxNetAdaptors[0] = nullptr;
   flagcxNetStates[0] = flagcxNetStateInit;
+  if (upgradedNetPluginAdaptor != NULL) {
+    free(upgradedNetPluginAdaptor);
+    upgradedNetPluginAdaptor = NULL;
+  }
   flagcxAdaptorClosePluginLib(netPluginDlHandle);
   netPluginDlHandle = NULL;
   return flagcxSuccess;

--- a/flagcx/core/flagcx_hetero.cc
+++ b/flagcx/core/flagcx_hetero.cc
@@ -3,6 +3,7 @@
 #include "group.h"
 #include "net.h"
 #include "onesided.h"
+#include "param.h"
 #include "transport.h"
 #include "type.h"
 
@@ -17,199 +18,218 @@
 // Async RMA proxy implementation
 // ---------------------------------------------------------------------------
 
-static flagcxResult_t allocRmaDesc(struct flagcxRmaDesc **out) {
-  struct flagcxRmaDesc *d =
-      (struct flagcxRmaDesc *)calloc(1, sizeof(struct flagcxRmaDesc));
-  if (d == NULL) {
-    WARN("allocRmaDesc: out of memory");
-    return flagcxSystemError;
+#ifndef FLAGCX_RMA_QUEUE_SIZE
+#define FLAGCX_RMA_QUEUE_SIZE 256
+#endif
+
+FLAGCX_PARAM(RmaQueueSize, "RMA_QUEUE_SIZE", FLAGCX_RMA_QUEUE_SIZE);
+
+// ---- Circular buffer helpers ----
+
+static inline bool
+flagcxRmaProxyCircularBufFull(struct flagcxRmaProxyState *proxy, int peer) {
+  uint32_t pi = __atomic_load_n(&proxy->pis[peer], __ATOMIC_RELAXED);
+  uint32_t ci = __atomic_load_n(&proxy->cis[peer], __ATOMIC_ACQUIRE);
+  return (pi - ci) >= proxy->queueSize;
+}
+
+static inline bool
+flagcxRmaProxyCircularBufEmpty(struct flagcxRmaProxyState *proxy, int peer) {
+  uint32_t ci = __atomic_load_n(&proxy->cis[peer], __ATOMIC_RELAXED);
+  uint32_t pi = __atomic_load_n(&proxy->pis[peer], __ATOMIC_ACQUIRE);
+  return ci >= pi;
+}
+
+static flagcxResult_t
+flagcxRmaProxyEnqueueDesc(struct flagcxRmaProxyState *proxy, int peer,
+                          struct flagcxRmaDesc *desc) {
+  pthread_mutex_lock(&proxy->peerProducerMutexes[peer]);
+  while (flagcxRmaProxyCircularBufFull(proxy, peer)) {
+    if (__atomic_load_n(&proxy->rmaError, __ATOMIC_ACQUIRE)) {
+      pthread_mutex_unlock(&proxy->peerProducerMutexes[peer]);
+      return flagcxRemoteError;
+    }
+    pthread_mutex_unlock(&proxy->peerProducerMutexes[peer]);
+    sched_yield();
+    pthread_mutex_lock(&proxy->peerProducerMutexes[peer]);
   }
-  *out = d;
+  uint32_t pi = __atomic_load_n(&proxy->pis[peer], __ATOMIC_RELAXED);
+  uint32_t idx = pi & proxy->queueMask;
+  desc->peer = peer;
+  desc->next = NULL;
+  desc->request = NULL;
+  desc->opSeq = __atomic_add_fetch(&proxy->opSeqs[peer], 1, __ATOMIC_RELAXED);
+  proxy->circularBuffers[(size_t)peer * proxy->queueSize + idx] = desc;
+  // RELEASE so the progress thread sees desc contents before the pi bump.
+  __atomic_store_n(&proxy->pis[peer], pi + 1, __ATOMIC_RELEASE);
+  pthread_mutex_unlock(&proxy->peerProducerMutexes[peer]);
   return flagcxSuccess;
 }
 
-static void enqueuePending(struct flagcxRmaProxyState *proxy,
-                           struct flagcxRmaDesc *desc) {
-  desc->next = NULL;
-  pthread_mutex_lock(&proxy->pendingMutex);
-  if (proxy->pendingTail != NULL) {
-    proxy->pendingTail->next = desc;
-    proxy->pendingTail = desc;
-  } else {
-    proxy->pendingHead = proxy->pendingTail = desc;
+// Post a single desc via the net adaptor. desc->request is populated on
+// success. Returns the adaptor's result.
+static flagcxResult_t flagcxRmaProxyPostOp(struct flagcxHeteroComm *comm,
+                                           struct flagcxRmaDesc *desc,
+                                           void *sendComm) {
+  int p = desc->peer;
+  void **srcHandles = NULL, **dstHandles = NULL;
+  if (desc->size > 0 && desc->srcMrIdx >= 0) {
+    srcHandles = (void **)comm->oneSideHandles[desc->srcMrIdx];
+    dstHandles = (void **)comm->oneSideHandles[desc->dstMrIdx];
   }
-  pthread_mutex_unlock(&proxy->pendingMutex);
+  switch (desc->type) {
+    case FLAGCX_RMA_PUT:
+      return comm->netAdaptor->iput(sendComm, desc->srcOff, desc->dstOff,
+                                    desc->size, comm->rank, p, srcHandles,
+                                    dstHandles, &desc->request);
+    case FLAGCX_RMA_PUT_SIGNAL: {
+      void **sigHandles = (void **)comm->signalHandle;
+      return comm->netAdaptor->iputSignal(
+          sendComm, desc->srcOff, desc->dstOff, desc->size, comm->rank, p,
+          srcHandles, dstHandles, desc->signalOff, sigHandles,
+          desc->signalValue, &desc->request);
+    }
+    case FLAGCX_RMA_GET:
+      return comm->netAdaptor->iget(
+          sendComm, desc->srcOff, desc->dstOff, desc->size, p /* srcRank */,
+          comm->rank /* dstRank */, srcHandles, dstHandles, &desc->request);
+    case FLAGCX_RMA_PUT_VALUE: {
+      struct flagcxOneSideHandleInfo *stagingH = comm->stagingHandle;
+      if (stagingH == NULL || stagingH->baseVas == NULL) {
+        WARN("flagcxRmaProxyPostOp: staging handles not initialized");
+        return flagcxInternalError;
+      }
+      *(volatile uint64_t *)(stagingH->baseVas[comm->rank]) = desc->putValue;
+      void **stagingHandles = (void **)stagingH;
+      void **dstH = (void **)comm->oneSideHandles[desc->dstMrIdx];
+      return comm->netAdaptor->iput(sendComm, 0, desc->dstOff,
+                                    sizeof(uint64_t), comm->rank, p,
+                                    stagingHandles, dstH, &desc->request);
+    }
+  }
+  return flagcxInternalError;
 }
 
-static void rmaDescComplete(struct flagcxRmaProxyState *proxy,
-                            struct flagcxRmaDesc *desc) {
-  __atomic_fetch_add(&proxy->completionCount, 1ULL, __ATOMIC_RELEASE);
-  __atomic_store_n(&proxy->doneSeqs[desc->peer], desc->seq, __ATOMIC_RELEASE);
-  free(desc);
-}
-
-static void *flagcxRmaProgressThread(void *arg) {
-  struct flagcxRmaProxyState *proxy = (struct flagcxRmaProxyState *)arg;
+// Poll and retire completed descs at the head of inProgressQueues[peer].
+// Returns after the head desc is not yet complete (enforces per-peer FIFO).
+static bool
+flagcxRmaProxyPollNonPersistCompletion(struct flagcxRmaProxyState *proxy,
+                                       int peer) {
   struct flagcxHeteroComm *comm = proxy->comm;
-
-  bool stopping = false;
-  bool did_work = false;
-  while (!stopping || proxy->inProgressHead != NULL || did_work) {
-    if (__atomic_load_n(&proxy->stop, __ATOMIC_ACQUIRE))
-      stopping = true;
-
-    did_work = false;
-    struct flagcxRmaDesc *desc = NULL;
-
-    // ---- 1. Poll head of inProgress for completion ----
-    struct flagcxRmaDesc *head = proxy->inProgressHead;
-    if (head != NULL) {
-      int done = 0;
-      if (head->request != NULL) {
-        flagcxResult_t testRes =
-            comm->netAdaptor->test(head->request, &done, NULL);
-        if (testRes != flagcxSuccess) {
-          WARN("flagcxRmaProgressThread: test failed peer=%d res=%d",
-               head->peer, (int)testRes);
-          __atomic_store_n(&proxy->rmaError, 1, __ATOMIC_RELEASE);
-          proxy->inProgressHead = head->next;
-          if (proxy->inProgressHead == NULL)
-            proxy->inProgressTail = NULL;
-          free(head);
-          did_work = true;
-          goto next;
-        }
-      } else {
-        done = 1;
+  bool did = false;
+  while (!flagcxIntruQueueEmpty(&proxy->inProgressQueues[peer])) {
+    struct flagcxRmaDesc *desc =
+        flagcxIntruQueueHead(&proxy->inProgressQueues[peer]);
+    int done = 0;
+    if (desc->request != NULL) {
+      flagcxResult_t res = comm->netAdaptor->test(desc->request, &done, NULL);
+      if (res != flagcxSuccess) {
+        WARN("flagcxRmaProxyPollNonPersistCompletion: test failed peer=%d "
+             "res=%d",
+             peer, (int)res);
+        __atomic_store_n(&proxy->rmaError, 1, __ATOMIC_RELEASE);
+        done = 1; // retire to avoid deadlock
       }
-      if (done) {
-        proxy->inProgressHead = head->next;
-        if (proxy->inProgressHead == NULL)
-          proxy->inProgressTail = NULL;
-        rmaDescComplete(proxy, head);
-        did_work = true;
-      }
+    } else {
+      // Error path: issuance failed; treat as done so the ring can drain.
+      done = 1;
     }
+    if (!done)
+      break;
+    flagcxIntruQueueDequeue(&proxy->inProgressQueues[peer]);
+    // Publish completion: doneSeqs with RELEASE so waiters acquire-see it.
+    __atomic_store_n(&proxy->doneSeqs[peer], desc->opSeq, __ATOMIC_RELEASE);
+    __atomic_fetch_add(&proxy->completionCount, 1ULL, __ATOMIC_RELEASE);
+    free(desc);
+    did = true;
+  }
+  return did;
+}
 
-    // ---- 2. Dequeue one desc from pending and post IB op ----
-    // When stopping, skip posting new ops — just let inProgress drain.
+// Poll pending descs from the ring and issue them. On success advance
+// cis[peer] and move the desc to inProgressQueues[peer]. On
+// request-pool-full (flagcxInternalError) leave cis untouched and retry
+// next round. On other errors mark rmaError and push to inProgress with
+// NULL request so PollNonPersistCompletion retires it.
+static bool
+flagcxRmaProxyPollNonPersistDesc(struct flagcxRmaProxyState *proxy, int peer,
+                                 void *sendComm) {
+  struct flagcxHeteroComm *comm = proxy->comm;
+  bool did = false;
+  while (!flagcxRmaProxyCircularBufEmpty(proxy, peer)) {
+    uint32_t ci = __atomic_load_n(&proxy->cis[peer], __ATOMIC_RELAXED);
+    uint32_t idx = ci & proxy->queueMask;
+    struct flagcxRmaDesc *desc =
+        proxy->circularBuffers[(size_t)peer * proxy->queueSize + idx];
+    desc->request = NULL;
+    flagcxResult_t res = flagcxRmaProxyPostOp(comm, desc, sendComm);
+    if (res == flagcxInternalError) {
+      // Request pool exhausted; retry this slot next round (cis unchanged).
+      break;
+    }
+    if (res != flagcxSuccess) {
+      WARN("flagcxRmaProxyPollNonPersistDesc: op failed peer=%d type=%d "
+           "res=%d",
+           peer, (int)desc->type, (int)res);
+      __atomic_store_n(&proxy->rmaError, 1, __ATOMIC_RELEASE);
+      desc->request = NULL; // completion path will treat as done.
+    }
+    // RELEASE so the producer sees the slot freed.
+    __atomic_store_n(&proxy->cis[peer], ci + 1, __ATOMIC_RELEASE);
+    // Enqueue to inProgressQueues[peer] (progress-thread private).
+    desc->next = NULL;
+    flagcxIntruQueueEnqueue(&proxy->inProgressQueues[peer], desc);
+    did = true;
+  }
+  return did;
+}
+
+// One pass over all peers: poll completions and issue pending descs.
+// Returns true if any progress was made.
+static bool flagcxRmaProxyProgress(struct flagcxRmaProxyState *proxy,
+                                   bool stopping, bool *anyOutstanding) {
+  struct flagcxHeteroComm *comm = proxy->comm;
+  bool did = false;
+  *anyOutstanding = false;
+  for (int p = 0; p < proxy->nRanks; p++) {
+    if (flagcxRmaProxyPollNonPersistCompletion(proxy, p))
+      did = true;
+
     if (!stopping) {
-      pthread_mutex_lock(&proxy->pendingMutex);
-      desc = proxy->pendingHead;
-      if (desc != NULL) {
-        proxy->pendingHead = desc->next;
-        if (proxy->pendingHead == NULL)
-          proxy->pendingTail = NULL;
-      }
-      pthread_mutex_unlock(&proxy->pendingMutex);
-    }
-
-    if (desc != NULL) {
-      int p = desc->peer;
-      desc->next = NULL;
-      desc->request = NULL;
-
-      // Resolve sendComm from desc->peer.
+      // Resolve sendComm lazily; if absent, skip issuing this peer.
       void *sendComm = NULL;
       if (comm->oneSideHandleCount > 0 && comm->oneSideHandles[0] != NULL &&
           comm->oneSideHandles[0]->fullSendComms != NULL) {
         sendComm = comm->oneSideHandles[0]->fullSendComms[p];
       }
-      if (sendComm == NULL) {
-        WARN("flagcxRmaProgressThread: no sendComm for peer %d", p);
+      if (sendComm != NULL) {
+        if (flagcxRmaProxyPollNonPersistDesc(proxy, p, sendComm))
+          did = true;
+      } else if (!flagcxRmaProxyCircularBufEmpty(proxy, p)) {
+        WARN("flagcxRmaProxyProgress: no sendComm for peer %d", p);
         __atomic_store_n(&proxy->rmaError, 1, __ATOMIC_RELEASE);
-        free(desc);
-        did_work = true;
-        goto next;
       }
-
-      // Resolve data MR handles (NULL when size==0 or not applicable).
-      void **srcHandles = NULL, **dstHandles = NULL;
-      if (desc->size > 0 && desc->srcMrIdx >= 0) {
-        srcHandles = (void **)comm->oneSideHandles[desc->srcMrIdx];
-        dstHandles = (void **)comm->oneSideHandles[desc->dstMrIdx];
-      }
-
-      flagcxResult_t res = flagcxSuccess;
-      switch (desc->type) {
-        case FLAGCX_RMA_PUT:
-          res = comm->netAdaptor->iput(sendComm, desc->srcOff, desc->dstOff,
-                                       desc->size, comm->rank, p, srcHandles,
-                                       dstHandles, &desc->request);
-          break;
-
-        case FLAGCX_RMA_PUT_SIGNAL: {
-          void **sigHandles = (void **)comm->signalHandle;
-          res = comm->netAdaptor->iputSignal(
-              sendComm, desc->srcOff, desc->dstOff, desc->size, comm->rank, p,
-              srcHandles, dstHandles, desc->signalOff, sigHandles,
-              desc->signalValue, &desc->request);
-          break;
-        }
-
-        case FLAGCX_RMA_GET:
-          res = comm->netAdaptor->iget(
-              sendComm, desc->srcOff, desc->dstOff, desc->size, p /* srcRank */,
-              comm->rank /* dstRank */, srcHandles, dstHandles, &desc->request);
-          break;
-
-        case FLAGCX_RMA_PUT_VALUE: {
-          struct flagcxOneSideHandleInfo *stagingH = comm->stagingHandle;
-          if (stagingH == NULL || stagingH->baseVas == NULL) {
-            WARN("flagcxRmaProgressThread: staging handles not initialized");
-            res = flagcxInternalError;
-            break;
-          }
-          *(volatile uint64_t *)(stagingH->baseVas[comm->rank]) =
-              desc->putValue;
-          void **stagingHandles = (void **)stagingH;
-          void **dstH = (void **)comm->oneSideHandles[desc->dstMrIdx];
-          res = comm->netAdaptor->iput(sendComm, 0, desc->dstOff,
-                                       sizeof(uint64_t), comm->rank, p,
-                                       stagingHandles, dstH, &desc->request);
-          break;
-        }
-      }
-
-      if (res != flagcxSuccess) {
-        if (res == flagcxInternalError) {
-          // Request pool exhausted — put desc back to pending for retry
-          INFO(FLAGCX_ALL,
-               "flagcxRmaProgressThread: request pool full, "
-               "re-enqueue peer=%d type=%d",
-               p, (int)desc->type);
-          enqueuePending(proxy, desc);
-        } else {
-          WARN("flagcxRmaProgressThread: op failed peer=%d type=%d res=%d", p,
-               (int)desc->type, (int)res);
-          __atomic_store_n(&proxy->rmaError, 1, __ATOMIC_RELEASE);
-          free(desc);
-        }
-      } else {
-        // Enqueue to inProgress for later polling.
-        if (proxy->inProgressTail != NULL) {
-          proxy->inProgressTail->next = desc;
-          proxy->inProgressTail = desc;
-        } else {
-          proxy->inProgressHead = proxy->inProgressTail = desc;
-        }
-      }
-      did_work = true;
     }
 
-  next:
-    if (!did_work)
-      sched_yield();
+    if (!flagcxRmaProxyCircularBufEmpty(proxy, p) ||
+        !flagcxIntruQueueEmpty(&proxy->inProgressQueues[p]))
+      *anyOutstanding = true;
   }
+  return did;
+}
 
-  pthread_mutex_lock(&proxy->pendingMutex);
-  struct flagcxRmaDesc *d = proxy->pendingHead;
-  proxy->pendingHead = proxy->pendingTail = NULL;
-  pthread_mutex_unlock(&proxy->pendingMutex);
-  while (d) {
-    struct flagcxRmaDesc *nxt = d->next;
-    rmaDescComplete(proxy, d);
-    d = nxt;
+static void *flagcxRmaProxyProgressThread(void *arg) {
+  struct flagcxRmaProxyState *proxy = (struct flagcxRmaProxyState *)arg;
+  bool stopping = false;
+  while (true) {
+    if (__atomic_load_n(&proxy->stop, __ATOMIC_ACQUIRE))
+      stopping = true;
+    bool anyOutstanding = false;
+    bool did = flagcxRmaProxyProgress(proxy, stopping, &anyOutstanding);
+    if (stopping && !anyOutstanding && !did)
+      break;
+    if (!did)
+      sched_yield();
   }
   return NULL;
 }
@@ -225,35 +245,67 @@ flagcxResult_t flagcxHeteroRmaProxyStart(flagcxHeteroComm_t comm) {
 
   proxy->nRanks = nRanks;
   proxy->comm = comm;
-  // pendingHead/Tail and inProgressHead/Tail are single pointers, already
-  // zero-initialized by calloc above.
-  proxy->nextSeqs = (volatile uint64_t *)calloc(nRanks, sizeof(uint64_t));
+
+  uint32_t qs = (uint32_t)flagcxParamRmaQueueSize();
+  proxy->queueSize = qs;
+  proxy->queueMask = qs - 1;
+
+  size_t ringBytes = (size_t)nRanks * qs * sizeof(struct flagcxRmaDesc *);
+  proxy->circularBuffers = (struct flagcxRmaDesc **)calloc(1, ringBytes);
+  proxy->pis = (volatile uint32_t *)calloc(nRanks, sizeof(uint32_t));
+  proxy->cis = (volatile uint32_t *)calloc(nRanks, sizeof(uint32_t));
+  proxy->inProgressQueues =
+      (flagcxIntruQueue<struct flagcxRmaDesc, &flagcxRmaDesc::next> *)calloc(
+          nRanks,
+          sizeof(flagcxIntruQueue<struct flagcxRmaDesc, &flagcxRmaDesc::next>));
+  proxy->peerProducerMutexes =
+      (pthread_mutex_t *)calloc(nRanks, sizeof(pthread_mutex_t));
+  proxy->opSeqs = (volatile uint64_t *)calloc(nRanks, sizeof(uint64_t));
   proxy->doneSeqs = (volatile uint64_t *)calloc(nRanks, sizeof(uint64_t));
 
-  if (proxy->nextSeqs == NULL || proxy->doneSeqs == NULL) {
-    WARN("flagcxHeteroRmaProxyStart: failed to allocate seq arrays");
-    free((void *)proxy->nextSeqs);
+  if (proxy->circularBuffers == NULL || proxy->pis == NULL ||
+      proxy->cis == NULL || proxy->inProgressQueues == NULL ||
+      proxy->peerProducerMutexes == NULL || proxy->opSeqs == NULL ||
+      proxy->doneSeqs == NULL) {
+    WARN("flagcxHeteroRmaProxyStart: failed to allocate ring buffers");
+    free(proxy->circularBuffers);
+    free((void *)proxy->pis);
+    free((void *)proxy->cis);
+    free(proxy->inProgressQueues);
+    free(proxy->peerProducerMutexes);
+    free((void *)proxy->opSeqs);
     free((void *)proxy->doneSeqs);
     free(proxy);
     return flagcxSystemError;
   }
 
-  pthread_mutex_init(&proxy->pendingMutex, NULL);
+  for (int p = 0; p < nRanks; p++) {
+    pthread_mutex_init(&proxy->peerProducerMutexes[p], NULL);
+    flagcxIntruQueueConstruct(&proxy->inProgressQueues[p]);
+  }
+
   proxy->stop = 0;
   comm->rmaProxy = proxy;
 
-  if (pthread_create(&proxy->thread, NULL, flagcxRmaProgressThread, proxy) !=
-      0) {
+  if (pthread_create(&proxy->thread, NULL, flagcxRmaProxyProgressThread,
+                     proxy) != 0) {
     WARN("flagcxHeteroRmaProxyStart: pthread_create failed");
-    free((void *)proxy->nextSeqs);
+    for (int p = 0; p < nRanks; p++)
+      pthread_mutex_destroy(&proxy->peerProducerMutexes[p]);
+    free(proxy->circularBuffers);
+    free((void *)proxy->pis);
+    free((void *)proxy->cis);
+    free(proxy->inProgressQueues);
+    free(proxy->peerProducerMutexes);
+    free((void *)proxy->opSeqs);
     free((void *)proxy->doneSeqs);
-    pthread_mutex_destroy(&proxy->pendingMutex);
     free(proxy);
     comm->rmaProxy = NULL;
     return flagcxSystemError;
   }
 
-  INFO(FLAGCX_INIT, "RMA progress thread started (nRanks=%d)", nRanks);
+  INFO(FLAGCX_INIT, "RMA progress thread started (nRanks=%d queueSize=%u)",
+       nRanks, qs);
   return flagcxSuccess;
 }
 
@@ -265,9 +317,15 @@ flagcxResult_t flagcxHeteroRmaProxyStop(flagcxHeteroComm_t comm) {
   __atomic_store_n(&proxy->stop, 1, __ATOMIC_RELEASE);
   pthread_join(proxy->thread, NULL);
 
-  free((void *)proxy->nextSeqs);
+  for (int p = 0; p < proxy->nRanks; p++)
+    pthread_mutex_destroy(&proxy->peerProducerMutexes[p]);
+  free(proxy->circularBuffers);
+  free((void *)proxy->pis);
+  free((void *)proxy->cis);
+  free(proxy->inProgressQueues);
+  free(proxy->peerProducerMutexes);
+  free((void *)proxy->opSeqs);
   free((void *)proxy->doneSeqs);
-  pthread_mutex_destroy(&proxy->pendingMutex);
   free(proxy);
   comm->rmaProxy = NULL;
   return flagcxSuccess;
@@ -296,7 +354,7 @@ flagcxResult_t flagcxHeteroFlushAllRma(flagcxHeteroComm_t comm) {
   if (proxy == NULL)
     return flagcxSuccess;
   for (int p = 0; p < proxy->nRanks; p++) {
-    uint64_t target = __atomic_load_n(&proxy->nextSeqs[p], __ATOMIC_RELAXED);
+    uint64_t target = __atomic_load_n(&proxy->opSeqs[p], __ATOMIC_RELAXED);
     if (target == 0)
       continue;
     while (__atomic_load_n(&proxy->doneSeqs[p], __ATOMIC_ACQUIRE) < target) {
@@ -405,19 +463,20 @@ flagcxResult_t flagcxHeteroPut(flagcxHeteroComm_t comm, int peer,
     WARN("flagcxHeteroPut: rmaProxy not initialized");
     return flagcxInternalError;
   }
-  struct flagcxRmaDesc *desc;
-  FLAGCXCHECK(allocRmaDesc(&desc));
-  desc->peer = peer;
+  struct flagcxRmaDesc *desc =
+      (struct flagcxRmaDesc *)calloc(1, sizeof(*desc));
+  if (desc == NULL)
+    return flagcxSystemError;
   desc->type = FLAGCX_RMA_PUT;
   desc->srcOff = (uint64_t)srcOffset;
   desc->dstOff = (uint64_t)dstOffset;
   desc->size = size;
   desc->srcMrIdx = srcMrIdx;
   desc->dstMrIdx = dstMrIdx;
-  desc->seq =
-      __atomic_add_fetch(&comm->rmaProxy->nextSeqs[peer], 1, __ATOMIC_RELAXED);
-  enqueuePending(comm->rmaProxy, desc);
-  return flagcxSuccess;
+  flagcxResult_t res = flagcxRmaProxyEnqueueDesc(comm->rmaProxy, peer, desc);
+  if (res != flagcxSuccess)
+    free(desc);
+  return res;
 }
 
 flagcxResult_t flagcxHeteroGet(flagcxHeteroComm_t comm, int peer,
@@ -434,19 +493,20 @@ flagcxResult_t flagcxHeteroGet(flagcxHeteroComm_t comm, int peer,
     WARN("flagcxHeteroGet: rmaProxy not initialized");
     return flagcxInternalError;
   }
-  struct flagcxRmaDesc *desc;
-  FLAGCXCHECK(allocRmaDesc(&desc));
-  desc->peer = peer;
+  struct flagcxRmaDesc *desc =
+      (struct flagcxRmaDesc *)calloc(1, sizeof(*desc));
+  if (desc == NULL)
+    return flagcxSystemError;
   desc->type = FLAGCX_RMA_GET;
   desc->srcOff = (uint64_t)srcOffset;
   desc->dstOff = (uint64_t)dstOffset;
   desc->size = size;
   desc->srcMrIdx = srcMrIdx;
   desc->dstMrIdx = dstMrIdx;
-  desc->seq =
-      __atomic_add_fetch(&comm->rmaProxy->nextSeqs[peer], 1, __ATOMIC_RELAXED);
-  enqueuePending(comm->rmaProxy, desc);
-  return flagcxSuccess;
+  flagcxResult_t res = flagcxRmaProxyEnqueueDesc(comm->rmaProxy, peer, desc);
+  if (res != flagcxSuccess)
+    free(desc);
+  return res;
 }
 
 flagcxResult_t flagcxHeteroPutSignal(flagcxHeteroComm_t comm, int peer,
@@ -465,9 +525,10 @@ flagcxResult_t flagcxHeteroPutSignal(flagcxHeteroComm_t comm, int peer,
     WARN("flagcxHeteroPutSignal: rmaProxy not initialized");
     return flagcxInternalError;
   }
-  struct flagcxRmaDesc *desc;
-  FLAGCXCHECK(allocRmaDesc(&desc));
-  desc->peer = peer;
+  struct flagcxRmaDesc *desc =
+      (struct flagcxRmaDesc *)calloc(1, sizeof(*desc));
+  if (desc == NULL)
+    return flagcxSystemError;
   desc->type = FLAGCX_RMA_PUT_SIGNAL;
   desc->srcOff = (uint64_t)srcOffset;
   desc->dstOff = (uint64_t)dstOffset;
@@ -477,10 +538,10 @@ flagcxResult_t flagcxHeteroPutSignal(flagcxHeteroComm_t comm, int peer,
   desc->dstMrIdx = (size > 0) ? dstMrIdx : -1;
   desc->signalOff = (uint64_t)signalOffset;
   desc->signalValue = signalValue;
-  desc->seq =
-      __atomic_add_fetch(&comm->rmaProxy->nextSeqs[peer], 1, __ATOMIC_RELAXED);
-  enqueuePending(comm->rmaProxy, desc);
-  return flagcxSuccess;
+  flagcxResult_t res = flagcxRmaProxyEnqueueDesc(comm->rmaProxy, peer, desc);
+  if (res != flagcxSuccess)
+    free(desc);
+  return res;
 }
 
 flagcxResult_t flagcxHeteroFlush(flagcxHeteroComm_t comm, void *gpuAddr,
@@ -552,15 +613,18 @@ flagcxResult_t flagcxHeteroPutValue(flagcxHeteroComm_t comm, int peer,
     WARN("flagcxHeteroPutValue: rmaProxy not initialized");
     return flagcxInternalError;
   }
-  struct flagcxRmaDesc *desc;
-  FLAGCXCHECK(allocRmaDesc(&desc));
-  desc->peer = peer;
+  struct flagcxRmaDesc *desc =
+      (struct flagcxRmaDesc *)calloc(1, sizeof(*desc));
+  if (desc == NULL)
+    return flagcxSystemError;
   desc->type = FLAGCX_RMA_PUT_VALUE;
   desc->dstOff = (uint64_t)dstOffset;
   desc->dstMrIdx = dstMrIdx;
+  desc->size = 0;
+  desc->srcMrIdx = -1;
   desc->putValue = value;
-  desc->seq =
-      __atomic_add_fetch(&comm->rmaProxy->nextSeqs[peer], 1, __ATOMIC_RELAXED);
-  enqueuePending(comm->rmaProxy, desc);
-  return flagcxSuccess;
+  flagcxResult_t res = flagcxRmaProxyEnqueueDesc(comm->rmaProxy, peer, desc);
+  if (res != flagcxSuccess)
+    free(desc);
+  return res;
 }

--- a/flagcx/core/flagcx_hetero.cc
+++ b/flagcx/core/flagcx_hetero.cc
@@ -14,15 +14,16 @@
 #include <string.h>
 #include <unistd.h>
 
-// ---------------------------------------------------------------------------
-// Async RMA proxy implementation
-// ---------------------------------------------------------------------------
-
 #ifndef FLAGCX_RMA_QUEUE_SIZE
 #define FLAGCX_RMA_QUEUE_SIZE 256
 #endif
+#ifndef FLAGCX_RMA_BATCH_MAX
+#define FLAGCX_RMA_BATCH_MAX 256
+#endif
+#define FLAGCX_RMA_BATCH_MAX_LIMIT 256
 
 FLAGCX_PARAM(RmaQueueSize, "RMA_QUEUE_SIZE", FLAGCX_RMA_QUEUE_SIZE);
+FLAGCX_PARAM(RmaBatchMax, "RMA_BATCH_MAX", FLAGCX_RMA_BATCH_MAX);
 
 // ---- Circular buffer helpers ----
 
@@ -62,6 +63,42 @@ flagcxRmaProxyEnqueueDesc(struct flagcxRmaProxyState *proxy, int peer,
   proxy->circularBuffers[(size_t)peer * proxy->queueSize + idx] = desc;
   // RELEASE so the progress thread sees desc contents before the pi bump.
   __atomic_store_n(&proxy->pis[peer], pi + 1, __ATOMIC_RELEASE);
+  pthread_mutex_unlock(&proxy->peerProducerMutexes[peer]);
+  return flagcxSuccess;
+}
+
+static flagcxResult_t
+flagcxRmaProxyEnqueueDescBatch(struct flagcxRmaProxyState *proxy, int peer,
+                               struct flagcxRmaDesc **descs, size_t count,
+                               size_t *enqueued) {
+  *enqueued = 0;
+  if (count == 0)
+    return flagcxSuccess;
+
+  pthread_mutex_lock(&proxy->peerProducerMutexes[peer]);
+  for (size_t i = 0; i < count; i++) {
+    while (flagcxRmaProxyCircularBufFull(proxy, peer)) {
+      if (__atomic_load_n(&proxy->rmaError, __ATOMIC_ACQUIRE)) {
+        pthread_mutex_unlock(&proxy->peerProducerMutexes[peer]);
+        return flagcxRemoteError;
+      }
+      pthread_mutex_unlock(&proxy->peerProducerMutexes[peer]);
+      sched_yield();
+      pthread_mutex_lock(&proxy->peerProducerMutexes[peer]);
+    }
+
+    uint32_t pi = __atomic_load_n(&proxy->pis[peer], __ATOMIC_RELAXED);
+    uint32_t idx = pi & proxy->queueMask;
+    struct flagcxRmaDesc *desc = descs[i];
+    desc->peer = peer;
+    desc->next = NULL;
+    desc->request = NULL;
+    desc->opSeq = __atomic_add_fetch(&proxy->opSeqs[peer], 1,
+                                     __ATOMIC_RELAXED);
+    proxy->circularBuffers[(size_t)peer * proxy->queueSize + idx] = desc;
+    __atomic_store_n(&proxy->pis[peer], pi + 1, __ATOMIC_RELEASE);
+    (*enqueued)++;
+  }
   pthread_mutex_unlock(&proxy->peerProducerMutexes[peer]);
   return flagcxSuccess;
 }
@@ -110,6 +147,34 @@ static flagcxResult_t flagcxRmaProxyPostOp(struct flagcxHeteroComm *comm,
   return flagcxInternalError;
 }
 
+static flagcxResult_t
+flagcxRmaProxyPostPutBatch(struct flagcxHeteroComm *comm,
+                           struct flagcxRmaDesc **descs, int count,
+                           void *sendComm, void **requests, int *posted) {
+  *posted = 0;
+  if (count <= 0)
+    return flagcxSuccess;
+  if (comm->netAdaptor == NULL || comm->netAdaptor->iputBatch == NULL)
+    return flagcxNotSupported;
+
+  int p = descs[0]->peer;
+  uint64_t srcOffs[FLAGCX_RMA_BATCH_MAX_LIMIT];
+  uint64_t dstOffs[FLAGCX_RMA_BATCH_MAX_LIMIT];
+  size_t sizes[FLAGCX_RMA_BATCH_MAX_LIMIT];
+  for (int i = 0; i < count; i++) {
+    srcOffs[i] = descs[i]->srcOff;
+    dstOffs[i] = descs[i]->dstOff;
+    sizes[i] = descs[i]->size;
+    requests[i] = NULL;
+  }
+
+  void **srcHandles = (void **)comm->oneSideHandles[descs[0]->srcMrIdx];
+  void **dstHandles = (void **)comm->oneSideHandles[descs[0]->dstMrIdx];
+  return comm->netAdaptor->iputBatch(sendComm, count, srcOffs, dstOffs, sizes,
+                                     comm->rank, p, srcHandles, dstHandles,
+                                     requests, posted);
+}
+
 // Poll and retire completed descs at the head of inProgressQueues[peer].
 // Returns after the head desc is not yet complete (enforces per-peer FIFO).
 static bool
@@ -121,6 +186,7 @@ flagcxRmaProxyPollNonPersistCompletion(struct flagcxRmaProxyState *proxy,
     struct flagcxRmaDesc *desc =
         flagcxIntruQueueHead(&proxy->inProgressQueues[peer]);
     int done = 0;
+    bool failed = false;
     if (desc->request != NULL) {
       flagcxResult_t res = comm->netAdaptor->test(desc->request, &done, NULL);
       if (res != flagcxSuccess) {
@@ -128,18 +194,23 @@ flagcxRmaProxyPollNonPersistCompletion(struct flagcxRmaProxyState *proxy,
              "res=%d",
              peer, (int)res);
         __atomic_store_n(&proxy->rmaError, 1, __ATOMIC_RELEASE);
-        done = 1; // retire to avoid deadlock
+        done = 1;
+        failed = true; // retire without advancing counters
       }
     } else {
-      // Error path: issuance failed; treat as done so the ring can drain.
+      // Issuance already failed; drain without advancing counters.
       done = 1;
+      failed = true;
     }
     if (!done)
       break;
     flagcxIntruQueueDequeue(&proxy->inProgressQueues[peer]);
-    // Publish completion: doneSeqs with RELEASE so waiters acquire-see it.
-    __atomic_store_n(&proxy->doneSeqs[peer], desc->opSeq, __ATOMIC_RELEASE);
-    __atomic_fetch_add(&proxy->completionCount, 1ULL, __ATOMIC_RELEASE);
+    __atomic_fetch_sub(&proxy->inFlights[peer], 1, __ATOMIC_RELAXED);
+    if (!failed) {
+      // Publish completion: doneSeqs with RELEASE so waiters acquire-see it.
+      __atomic_store_n(&proxy->doneSeqs[peer], desc->opSeq, __ATOMIC_RELEASE);
+      __atomic_fetch_add(&proxy->completionCount, 1ULL, __ATOMIC_RELEASE);
+    }
     free(desc);
     did = true;
   }
@@ -157,10 +228,78 @@ flagcxRmaProxyPollNonPersistDesc(struct flagcxRmaProxyState *proxy, int peer,
   struct flagcxHeteroComm *comm = proxy->comm;
   bool did = false;
   while (!flagcxRmaProxyCircularBufEmpty(proxy, peer)) {
+    uint32_t inFlight =
+        __atomic_load_n(&proxy->inFlights[peer], __ATOMIC_RELAXED);
+    if (inFlight >= proxy->queueSize)
+      break;
     uint32_t ci = __atomic_load_n(&proxy->cis[peer], __ATOMIC_RELAXED);
     uint32_t idx = ci & proxy->queueMask;
     struct flagcxRmaDesc *desc =
         proxy->circularBuffers[(size_t)peer * proxy->queueSize + idx];
+
+    bool canBatch =
+        desc->type == FLAGCX_RMA_PUT && comm->netAdaptor != NULL &&
+        comm->netAdaptor->name != NULL &&
+        strcmp(comm->netAdaptor->name, "IB") == 0 &&
+        comm->netAdaptor->iputBatch != NULL;
+    if (canBatch) {
+      int64_t paramBatchMax = flagcxParamRmaBatchMax();
+      if (paramBatchMax <= 0)
+        paramBatchMax = 1;
+      if (paramBatchMax > FLAGCX_RMA_BATCH_MAX_LIMIT)
+        paramBatchMax = FLAGCX_RMA_BATCH_MAX_LIMIT;
+
+      uint32_t pi = __atomic_load_n(&proxy->pis[peer], __ATOMIC_ACQUIRE);
+      uint32_t ringAvailable = pi - ci;
+      uint32_t flightAvailable = proxy->queueSize - inFlight;
+      uint32_t batchLimit = ringAvailable < flightAvailable ? ringAvailable
+                                                            : flightAvailable;
+      if (batchLimit > (uint32_t)paramBatchMax)
+        batchLimit = (uint32_t)paramBatchMax;
+
+      struct flagcxRmaDesc *descs[FLAGCX_RMA_BATCH_MAX_LIMIT];
+      int batchCount = 0;
+      for (; batchCount < (int)batchLimit; batchCount++) {
+        uint32_t curIdx = (ci + (uint32_t)batchCount) & proxy->queueMask;
+        struct flagcxRmaDesc *cur =
+            proxy->circularBuffers[(size_t)peer * proxy->queueSize + curIdx];
+        if (cur->type != FLAGCX_RMA_PUT || cur->srcMrIdx != desc->srcMrIdx ||
+            cur->dstMrIdx != desc->dstMrIdx) {
+          break;
+        }
+        descs[batchCount] = cur;
+      }
+
+      if (batchCount > 1) {
+        void *requests[FLAGCX_RMA_BATCH_MAX_LIMIT];
+        int posted = 0;
+        flagcxResult_t res = flagcxRmaProxyPostPutBatch(
+            comm, descs, batchCount, sendComm, requests, &posted);
+        if (posted == 0) {
+          if (res != flagcxSuccess && res != flagcxSystemError &&
+              res != flagcxInternalError) {
+            WARN("flagcxRmaProxyPollNonPersistDesc: batch op failed peer=%d "
+                 "res=%d",
+                 peer, (int)res);
+            __atomic_store_n(&proxy->rmaError, 1, __ATOMIC_RELEASE);
+          }
+          break;
+        }
+
+        for (int i = 0; i < posted; i++) {
+          descs[i]->request = requests[i];
+          descs[i]->next = NULL;
+          flagcxIntruQueueEnqueue(&proxy->inProgressQueues[peer], descs[i]);
+        }
+        __atomic_store_n(&proxy->cis[peer], ci + (uint32_t)posted,
+                         __ATOMIC_RELEASE);
+        __atomic_fetch_add(&proxy->inFlights[peer], (uint32_t)posted,
+                           __ATOMIC_RELAXED);
+        did = true;
+        continue;
+      }
+    }
+
     desc->request = NULL;
     flagcxResult_t res = flagcxRmaProxyPostOp(comm, desc, sendComm);
     if (res == flagcxInternalError) {
@@ -179,33 +318,60 @@ flagcxRmaProxyPollNonPersistDesc(struct flagcxRmaProxyState *proxy, int peer,
     // Enqueue to inProgressQueues[peer] (progress-thread private).
     desc->next = NULL;
     flagcxIntruQueueEnqueue(&proxy->inProgressQueues[peer], desc);
+    __atomic_fetch_add(&proxy->inFlights[peer], 1, __ATOMIC_RELAXED);
     did = true;
   }
   return did;
+}
+
+// Drain the peer's ring without posting: dequeue, advance cis, free each
+// desc without bumping doneSeqs/completionCount. Called at shutdown when
+// no sendComm is available and we cannot actually issue the ops.
+static void flagcxRmaProxyDrainRing(struct flagcxRmaProxyState *proxy,
+                                    int peer) {
+  while (!flagcxRmaProxyCircularBufEmpty(proxy, peer)) {
+    uint32_t ci = __atomic_load_n(&proxy->cis[peer], __ATOMIC_RELAXED);
+    uint32_t idx = ci & proxy->queueMask;
+    struct flagcxRmaDesc *desc =
+        proxy->circularBuffers[(size_t)peer * proxy->queueSize + idx];
+    __atomic_store_n(&proxy->cis[peer], ci + 1, __ATOMIC_RELEASE);
+    free(desc);
+  }
 }
 
 // One pass over all peers: poll completions and issue pending descs.
 // Returns true if any progress was made.
 static bool flagcxRmaProxyProgress(struct flagcxRmaProxyState *proxy,
                                    bool stopping, bool *anyOutstanding) {
-  struct flagcxHeteroComm *comm = proxy->comm;
   bool did = false;
   *anyOutstanding = false;
+  // Read the cached fullSendComms once per pass (published exactly once
+  // from the registration path; NULL until then). See
+  // flagcxHeteroRmaProxyPublishSendComms() for why this is safe.
+  void *const *fullSendComms =
+      __atomic_load_n(&proxy->fullSendComms, __ATOMIC_ACQUIRE);
   for (int p = 0; p < proxy->nRanks; p++) {
     if (flagcxRmaProxyPollNonPersistCompletion(proxy, p))
       did = true;
 
-    if (!stopping) {
-      // Resolve sendComm lazily; if absent, skip issuing this peer.
-      void *sendComm = NULL;
-      if (comm->oneSideHandleCount > 0 && comm->oneSideHandles[0] != NULL &&
-          comm->oneSideHandles[0]->fullSendComms != NULL) {
-        sendComm = comm->oneSideHandles[0]->fullSendComms[p];
-      }
-      if (sendComm != NULL) {
-        if (flagcxRmaProxyPollNonPersistDesc(proxy, p, sendComm))
-          did = true;
-      } else if (!flagcxRmaProxyCircularBufEmpty(proxy, p)) {
+    void *sendComm =
+        (fullSendComms != NULL) ? fullSendComms[p] : NULL;
+    if (sendComm != NULL) {
+      if (flagcxRmaProxyPollNonPersistDesc(proxy, p, sendComm))
+        did = true;
+    } else if (!flagcxRmaProxyCircularBufEmpty(proxy, p)) {
+      if (stopping) {
+        // Shutdown with queued-but-unissued descs and no transport.
+        // Drain to let the thread exit; flag the error so waiters fail.
+        WARN("flagcxRmaProxyProgress: stop with queued descs but no "
+             "sendComm peer=%d; draining",
+             p);
+        __atomic_store_n(&proxy->rmaError, 1, __ATOMIC_RELEASE);
+        flagcxRmaProxyDrainRing(proxy, p);
+        did = true;
+      } else {
+        // Pre-registration: caller enqueued an op before the full mesh
+        // is ready. Surface as an error rather than spin forever.
         WARN("flagcxRmaProxyProgress: no sendComm for peer %d", p);
         __atomic_store_n(&proxy->rmaError, 1, __ATOMIC_RELEASE);
       }
@@ -262,11 +428,12 @@ flagcxResult_t flagcxHeteroRmaProxyStart(flagcxHeteroComm_t comm) {
       (pthread_mutex_t *)calloc(nRanks, sizeof(pthread_mutex_t));
   proxy->opSeqs = (volatile uint64_t *)calloc(nRanks, sizeof(uint64_t));
   proxy->doneSeqs = (volatile uint64_t *)calloc(nRanks, sizeof(uint64_t));
+  proxy->inFlights = (volatile uint32_t *)calloc(nRanks, sizeof(uint32_t));
 
   if (proxy->circularBuffers == NULL || proxy->pis == NULL ||
       proxy->cis == NULL || proxy->inProgressQueues == NULL ||
       proxy->peerProducerMutexes == NULL || proxy->opSeqs == NULL ||
-      proxy->doneSeqs == NULL) {
+      proxy->doneSeqs == NULL || proxy->inFlights == NULL) {
     WARN("flagcxHeteroRmaProxyStart: failed to allocate ring buffers");
     free(proxy->circularBuffers);
     free((void *)proxy->pis);
@@ -275,6 +442,7 @@ flagcxResult_t flagcxHeteroRmaProxyStart(flagcxHeteroComm_t comm) {
     free(proxy->peerProducerMutexes);
     free((void *)proxy->opSeqs);
     free((void *)proxy->doneSeqs);
+    free((void *)proxy->inFlights);
     free(proxy);
     return flagcxSystemError;
   }
@@ -299,6 +467,7 @@ flagcxResult_t flagcxHeteroRmaProxyStart(flagcxHeteroComm_t comm) {
     free(proxy->peerProducerMutexes);
     free((void *)proxy->opSeqs);
     free((void *)proxy->doneSeqs);
+    free((void *)proxy->inFlights);
     free(proxy);
     comm->rmaProxy = NULL;
     return flagcxSystemError;
@@ -326,8 +495,26 @@ flagcxResult_t flagcxHeteroRmaProxyStop(flagcxHeteroComm_t comm) {
   free(proxy->peerProducerMutexes);
   free((void *)proxy->opSeqs);
   free((void *)proxy->doneSeqs);
+  free((void *)proxy->inFlights);
   free(proxy);
   comm->rmaProxy = NULL;
+  return flagcxSuccess;
+}
+
+flagcxResult_t
+flagcxHeteroRmaProxyPublishSendComms(flagcxHeteroComm_t comm,
+                                     void *const *fullSendComms) {
+  if (comm == NULL || comm->rmaProxy == NULL)
+    return flagcxInvalidArgument;
+  if (fullSendComms == NULL)
+    return flagcxSuccess;
+  // Publish only if unset; later registrations reuse the same array.
+  void *const *cur =
+      __atomic_load_n(&comm->rmaProxy->fullSendComms, __ATOMIC_ACQUIRE);
+  if (cur == NULL) {
+    __atomic_store_n(&comm->rmaProxy->fullSendComms, fullSendComms,
+                     __ATOMIC_RELEASE);
+  }
   return flagcxSuccess;
 }
 
@@ -476,6 +663,64 @@ flagcxResult_t flagcxHeteroPut(flagcxHeteroComm_t comm, int peer,
   flagcxResult_t res = flagcxRmaProxyEnqueueDesc(comm->rmaProxy, peer, desc);
   if (res != flagcxSuccess)
     free(desc);
+  return res;
+}
+
+flagcxResult_t flagcxHeteroBatchPut(flagcxHeteroComm_t comm, int peer,
+                                    const size_t *srcOffsets,
+                                    const size_t *dstOffsets,
+                                    const size_t *sizes,
+                                    const int *srcMrIdxs,
+                                    const int *dstMrIdxs, size_t count) {
+  if (count == 0)
+    return flagcxSuccess;
+  if (comm == NULL || srcOffsets == NULL || dstOffsets == NULL ||
+      sizes == NULL || srcMrIdxs == NULL || dstMrIdxs == NULL)
+    return flagcxInvalidArgument;
+  if (comm->netAdaptor == NULL || comm->netAdaptor->iput == NULL)
+    return flagcxNotSupported;
+  if (peer < 0 || peer >= comm->nRanks) {
+    WARN("flagcxHeteroBatchPut: peer %d out of range (nRanks=%d)", peer,
+         comm->nRanks);
+    return flagcxInvalidArgument;
+  }
+  if (comm->rmaProxy == NULL) {
+    WARN("flagcxHeteroBatchPut: rmaProxy not initialized");
+    return flagcxInternalError;
+  }
+
+  struct flagcxRmaDesc **descs =
+      (struct flagcxRmaDesc **)calloc(count, sizeof(struct flagcxRmaDesc *));
+  if (descs == NULL)
+    return flagcxSystemError;
+
+  for (size_t i = 0; i < count; i++) {
+    struct flagcxRmaDesc *desc =
+        (struct flagcxRmaDesc *)calloc(1, sizeof(*desc));
+    if (desc == NULL) {
+      for (size_t j = 0; j < i; j++)
+        free(descs[j]);
+      free(descs);
+      return flagcxSystemError;
+    }
+    desc->type = FLAGCX_RMA_PUT;
+    desc->srcOff = (uint64_t)srcOffsets[i];
+    desc->dstOff = (uint64_t)dstOffsets[i];
+    desc->size = sizes[i];
+    desc->srcMrIdx = srcMrIdxs[i];
+    desc->dstMrIdx = dstMrIdxs[i];
+    descs[i] = desc;
+  }
+
+  size_t enqueued = 0;
+  flagcxResult_t res =
+      flagcxRmaProxyEnqueueDescBatch(comm->rmaProxy, peer, descs, count,
+                                     &enqueued);
+  if (res != flagcxSuccess) {
+    for (size_t i = enqueued; i < count; i++)
+      free(descs[i]);
+  }
+  free(descs);
   return res;
 }
 

--- a/flagcx/core/flagcx_hetero.cc
+++ b/flagcx/core/flagcx_hetero.cc
@@ -410,7 +410,7 @@ flagcxResult_t flagcxHeteroRmaProxyStart(flagcxHeteroComm_t comm) {
 
   uint32_t qs = (uint32_t)flagcxParamRmaQueueSize();
   if (qs < 2 || (qs & (qs - 1)) != 0) {
-    WARN("flagcxHeteroRmaProxyStart: invalid RMA queue size %u;" 
+    WARN("flagcxHeteroRmaProxyStart: invalid RMA queue size %u;"
          "FLAGCX_RMA_QUEUE_SIZE must be a power of two and >= 2",
          qs);
     free(proxy);

--- a/flagcx/core/flagcx_hetero.cc
+++ b/flagcx/core/flagcx_hetero.cc
@@ -93,8 +93,7 @@ flagcxRmaProxyEnqueueDescBatch(struct flagcxRmaProxyState *proxy, int peer,
     desc->peer = peer;
     desc->next = NULL;
     desc->request = NULL;
-    desc->opSeq = __atomic_add_fetch(&proxy->opSeqs[peer], 1,
-                                     __ATOMIC_RELAXED);
+    desc->opSeq = __atomic_add_fetch(&proxy->opSeqs[peer], 1, __ATOMIC_RELAXED);
     proxy->circularBuffers[(size_t)peer * proxy->queueSize + idx] = desc;
     __atomic_store_n(&proxy->pis[peer], pi + 1, __ATOMIC_RELEASE);
     (*enqueued)++;
@@ -139,18 +138,18 @@ static flagcxResult_t flagcxRmaProxyPostOp(struct flagcxHeteroComm *comm,
       *(volatile uint64_t *)(stagingH->baseVas[comm->rank]) = desc->putValue;
       void **stagingHandles = (void **)stagingH;
       void **dstH = (void **)comm->oneSideHandles[desc->dstMrIdx];
-      return comm->netAdaptor->iput(sendComm, 0, desc->dstOff,
-                                    sizeof(uint64_t), comm->rank, p,
-                                    stagingHandles, dstH, &desc->request);
+      return comm->netAdaptor->iput(sendComm, 0, desc->dstOff, sizeof(uint64_t),
+                                    comm->rank, p, stagingHandles, dstH,
+                                    &desc->request);
     }
   }
   return flagcxInternalError;
 }
 
-static flagcxResult_t
-flagcxRmaProxyPostPutBatch(struct flagcxHeteroComm *comm,
-                           struct flagcxRmaDesc **descs, int count,
-                           void *sendComm, void **requests, int *posted) {
+static flagcxResult_t flagcxRmaProxyPostPutBatch(struct flagcxHeteroComm *comm,
+                                                 struct flagcxRmaDesc **descs,
+                                                 int count, void *sendComm,
+                                                 void **requests, int *posted) {
   *posted = 0;
   if (count <= 0)
     return flagcxSuccess;
@@ -167,7 +166,7 @@ flagcxRmaProxyPostPutBatch(struct flagcxHeteroComm *comm,
     sizes[i] = descs[i]->size;
     requests[i] = NULL;
   }
-
+  assert(descs[0]->srcMrIdx >= 0 && descs[0]->dstMrIdx >= 0);
   void **srcHandles = (void **)comm->oneSideHandles[descs[0]->srcMrIdx];
   void **dstHandles = (void **)comm->oneSideHandles[descs[0]->dstMrIdx];
   return comm->netAdaptor->iputBatch(sendComm, count, srcOffs, dstOffs, sizes,
@@ -222,9 +221,8 @@ flagcxRmaProxyPollNonPersistCompletion(struct flagcxRmaProxyState *proxy,
 // request-pool-full (flagcxInternalError) leave cis untouched and retry
 // next round. On other errors mark rmaError and push to inProgress with
 // NULL request so PollNonPersistCompletion retires it.
-static bool
-flagcxRmaProxyPollNonPersistDesc(struct flagcxRmaProxyState *proxy, int peer,
-                                 void *sendComm) {
+static bool flagcxRmaProxyPollNonPersistDesc(struct flagcxRmaProxyState *proxy,
+                                             int peer, void *sendComm) {
   struct flagcxHeteroComm *comm = proxy->comm;
   bool did = false;
   while (!flagcxRmaProxyCircularBufEmpty(proxy, peer)) {
@@ -237,11 +235,10 @@ flagcxRmaProxyPollNonPersistDesc(struct flagcxRmaProxyState *proxy, int peer,
     struct flagcxRmaDesc *desc =
         proxy->circularBuffers[(size_t)peer * proxy->queueSize + idx];
 
-    bool canBatch =
-        desc->type == FLAGCX_RMA_PUT && comm->netAdaptor != NULL &&
-        comm->netAdaptor->name != NULL &&
-        strcmp(comm->netAdaptor->name, "IB") == 0 &&
-        comm->netAdaptor->iputBatch != NULL;
+    bool canBatch = desc->type == FLAGCX_RMA_PUT && comm->netAdaptor != NULL &&
+                    comm->netAdaptor->name != NULL &&
+                    strcmp(comm->netAdaptor->name, "IB") == 0 &&
+                    comm->netAdaptor->iputBatch != NULL;
     if (canBatch) {
       int64_t paramBatchMax = flagcxParamRmaBatchMax();
       if (paramBatchMax <= 0)
@@ -252,8 +249,8 @@ flagcxRmaProxyPollNonPersistDesc(struct flagcxRmaProxyState *proxy, int peer,
       uint32_t pi = __atomic_load_n(&proxy->pis[peer], __ATOMIC_ACQUIRE);
       uint32_t ringAvailable = pi - ci;
       uint32_t flightAvailable = proxy->queueSize - inFlight;
-      uint32_t batchLimit = ringAvailable < flightAvailable ? ringAvailable
-                                                            : flightAvailable;
+      uint32_t batchLimit =
+          ringAvailable < flightAvailable ? ringAvailable : flightAvailable;
       if (batchLimit > (uint32_t)paramBatchMax)
         batchLimit = (uint32_t)paramBatchMax;
 
@@ -354,8 +351,7 @@ static bool flagcxRmaProxyProgress(struct flagcxRmaProxyState *proxy,
     if (flagcxRmaProxyPollNonPersistCompletion(proxy, p))
       did = true;
 
-    void *sendComm =
-        (fullSendComms != NULL) ? fullSendComms[p] : NULL;
+    void *sendComm = (fullSendComms != NULL) ? fullSendComms[p] : NULL;
     if (sendComm != NULL) {
       if (flagcxRmaProxyPollNonPersistDesc(proxy, p, sendComm))
         did = true;
@@ -413,6 +409,13 @@ flagcxResult_t flagcxHeteroRmaProxyStart(flagcxHeteroComm_t comm) {
   proxy->comm = comm;
 
   uint32_t qs = (uint32_t)flagcxParamRmaQueueSize();
+  if (qs < 2 || (qs & (qs - 1)) != 0) {
+    WARN("flagcxHeteroRmaProxyStart: invalid RMA queue size %u;" 
+         "FLAGCX_RMA_QUEUE_SIZE must be a power of two and >= 2",
+         qs);
+    free(proxy);
+    return flagcxInvalidArgument;
+  }
   proxy->queueSize = qs;
   proxy->queueMask = qs - 1;
 
@@ -650,8 +653,7 @@ flagcxResult_t flagcxHeteroPut(flagcxHeteroComm_t comm, int peer,
     WARN("flagcxHeteroPut: rmaProxy not initialized");
     return flagcxInternalError;
   }
-  struct flagcxRmaDesc *desc =
-      (struct flagcxRmaDesc *)calloc(1, sizeof(*desc));
+  struct flagcxRmaDesc *desc = (struct flagcxRmaDesc *)calloc(1, sizeof(*desc));
   if (desc == NULL)
     return flagcxSystemError;
   desc->type = FLAGCX_RMA_PUT;
@@ -669,8 +671,7 @@ flagcxResult_t flagcxHeteroPut(flagcxHeteroComm_t comm, int peer,
 flagcxResult_t flagcxHeteroBatchPut(flagcxHeteroComm_t comm, int peer,
                                     const size_t *srcOffsets,
                                     const size_t *dstOffsets,
-                                    const size_t *sizes,
-                                    const int *srcMrIdxs,
+                                    const size_t *sizes, const int *srcMrIdxs,
                                     const int *dstMrIdxs, size_t count) {
   if (count == 0)
     return flagcxSuccess;
@@ -713,9 +714,8 @@ flagcxResult_t flagcxHeteroBatchPut(flagcxHeteroComm_t comm, int peer,
   }
 
   size_t enqueued = 0;
-  flagcxResult_t res =
-      flagcxRmaProxyEnqueueDescBatch(comm->rmaProxy, peer, descs, count,
-                                     &enqueued);
+  flagcxResult_t res = flagcxRmaProxyEnqueueDescBatch(comm->rmaProxy, peer,
+                                                      descs, count, &enqueued);
   if (res != flagcxSuccess) {
     for (size_t i = enqueued; i < count; i++)
       free(descs[i]);
@@ -738,8 +738,7 @@ flagcxResult_t flagcxHeteroGet(flagcxHeteroComm_t comm, int peer,
     WARN("flagcxHeteroGet: rmaProxy not initialized");
     return flagcxInternalError;
   }
-  struct flagcxRmaDesc *desc =
-      (struct flagcxRmaDesc *)calloc(1, sizeof(*desc));
+  struct flagcxRmaDesc *desc = (struct flagcxRmaDesc *)calloc(1, sizeof(*desc));
   if (desc == NULL)
     return flagcxSystemError;
   desc->type = FLAGCX_RMA_GET;
@@ -770,8 +769,7 @@ flagcxResult_t flagcxHeteroPutSignal(flagcxHeteroComm_t comm, int peer,
     WARN("flagcxHeteroPutSignal: rmaProxy not initialized");
     return flagcxInternalError;
   }
-  struct flagcxRmaDesc *desc =
-      (struct flagcxRmaDesc *)calloc(1, sizeof(*desc));
+  struct flagcxRmaDesc *desc = (struct flagcxRmaDesc *)calloc(1, sizeof(*desc));
   if (desc == NULL)
     return flagcxSystemError;
   desc->type = FLAGCX_RMA_PUT_SIGNAL;
@@ -858,8 +856,7 @@ flagcxResult_t flagcxHeteroPutValue(flagcxHeteroComm_t comm, int peer,
     WARN("flagcxHeteroPutValue: rmaProxy not initialized");
     return flagcxInternalError;
   }
-  struct flagcxRmaDesc *desc =
-      (struct flagcxRmaDesc *)calloc(1, sizeof(*desc));
+  struct flagcxRmaDesc *desc = (struct flagcxRmaDesc *)calloc(1, sizeof(*desc));
   if (desc == NULL)
     return flagcxSystemError;
   desc->type = FLAGCX_RMA_PUT_VALUE;

--- a/flagcx/core/include/flagcx_hetero.h
+++ b/flagcx/core/include/flagcx_hetero.h
@@ -26,31 +26,27 @@ struct flagcxRmaDesc {
   uint64_t signalValue; // PUT_SIGNAL only
   uint64_t putValue;    // PUT_VALUE only (value embedded in desc)
   void *request;        // filled by progress thread after posting IB op
-  uint64_t seq;         // per-peer monotonic sequence number
-  struct flagcxRmaDesc *next;
+  uint64_t opSeq;       // per-peer monotonic sequence number
+  struct flagcxRmaDesc *next; // intrusive link for inProgressQueues
 };
 
 // Per-comm async RMA proxy state.
 // pending queues: producer = caller (proxy kernel thread), consumer = progress
 // thread. inProgress queues: progress thread only (no locking needed).
 struct flagcxRmaProxyState {
-  // Single pending queue for all peers, protected by pendingMutex.
-  // desc->peer identifies the target; no need for per-peer slots.
-  struct flagcxRmaDesc *pendingHead;
-  struct flagcxRmaDesc *pendingTail;
-  pthread_mutex_t pendingMutex;
+  uint32_t queueSize; // power of two
+  uint32_t queueMask; // queueSize - 1
+  struct flagcxRmaDesc **circularBuffers; // [nRanks * queueSize]
+  volatile uint32_t *pis; // [nRanks] producer index
+  volatile uint32_t *cis; // [nRanks] consumer index
 
-  // Single in-progress queue (progress thread only, no locking needed).
-  struct flagcxRmaDesc *inProgressHead;
-  struct flagcxRmaDesc *inProgressTail;
-
-  // Per-peer sequence counters for flush semantics.
-  // nextSeqs[p]: last seq assigned for peer p (written by caller).
-  // doneSeqs[p]: last seq completed for peer p (written by progress thread).
-  volatile uint64_t *nextSeqs; // [nRanks]
+  pthread_mutex_t *peerProducerMutexes; // [nRanks]
+  struct flagcxIntruQueue<struct flagcxRmaDesc, &flagcxRmaDesc::next>
+      *inProgressQueues; // [nRanks]
+  volatile uint64_t *opSeqs;   // [nRanks]
   volatile uint64_t *doneSeqs; // [nRanks]
 
-  // Global completion counter: incremented once for every IB op that completes.
+  // Global completion counter: incremented once for every op that completes.
   // Callers record the value before issuing ops, then poll until it advances.
   volatile uint64_t completionCount;
 

--- a/flagcx/core/include/flagcx_hetero.h
+++ b/flagcx/core/include/flagcx_hetero.h
@@ -7,6 +7,9 @@
 #include <pthread.h>
 #include <stdint.h>
 
+template <typename T, T *T::*next>
+struct flagcxIntruQueue;
+
 enum flagcxRmaDescType {
   FLAGCX_RMA_PUT = 0,
   FLAGCX_RMA_PUT_SIGNAL = 1,
@@ -45,6 +48,7 @@ struct flagcxRmaProxyState {
       *inProgressQueues; // [nRanks]
   volatile uint64_t *opSeqs;   // [nRanks]
   volatile uint64_t *doneSeqs; // [nRanks]
+  volatile uint32_t *inFlights; // [nRanks]
 
   // Global completion counter: incremented once for every op that completes.
   // Callers record the value before issuing ops, then poll until it advances.
@@ -54,6 +58,7 @@ struct flagcxRmaProxyState {
   // error, or missing sendComm). Wait functions check this and return an error.
   volatile int rmaError;
 
+  void *const *fullSendComms; // [nRanks] or NULL until published
   int nRanks;
   struct flagcxHeteroComm *comm; // back-pointer
 
@@ -97,6 +102,13 @@ flagcxResult_t flagcxHeteroPut(flagcxHeteroComm_t comm, int peer,
                                size_t srcOffset, size_t dstOffset, size_t size,
                                int srcMrIdx, int dstMrIdx);
 
+flagcxResult_t flagcxHeteroBatchPut(flagcxHeteroComm_t comm, int peer,
+                                    const size_t *srcOffsets,
+                                    const size_t *dstOffsets,
+                                    const size_t *sizes,
+                                    const int *srcMrIdxs,
+                                    const int *dstMrIdxs, size_t count);
+
 // RDMA READ: pull data from remote peer's srcMrIdx buffer into local dstMrIdx
 // buffer
 flagcxResult_t flagcxHeteroGet(flagcxHeteroComm_t comm, int peer,
@@ -117,6 +129,10 @@ flagcxResult_t flagcxHeteroFlush(flagcxHeteroComm_t comm, void *gpuAddr,
 // Async RMA proxy lifecycle.
 flagcxResult_t flagcxHeteroRmaProxyStart(flagcxHeteroComm_t comm);
 flagcxResult_t flagcxHeteroRmaProxyStop(flagcxHeteroComm_t comm);
+
+// Publish the stable fullSendComms pointer to the proxy. 
+flagcxResult_t flagcxHeteroRmaProxyPublishSendComms(flagcxHeteroComm_t comm,
+                                                    void *const *fullSendComms);
 
 // Wait until all ops for a specific peer up to seq are complete.
 flagcxResult_t flagcxHeteroFlushRma(flagcxHeteroComm_t comm, int peer,

--- a/flagcx/core/include/flagcx_hetero.h
+++ b/flagcx/core/include/flagcx_hetero.h
@@ -25,11 +25,11 @@ struct flagcxRmaDesc {
   size_t size;
   int srcMrIdx; // -1 when not used (e.g. signal-only PutSignal)
   int dstMrIdx;
-  uint64_t signalOff;   // PUT_SIGNAL only
-  uint64_t signalValue; // PUT_SIGNAL only
-  uint64_t putValue;    // PUT_VALUE only (value embedded in desc)
-  void *request;        // filled by progress thread after posting IB op
-  uint64_t opSeq;       // per-peer monotonic sequence number
+  uint64_t signalOff;         // PUT_SIGNAL only
+  uint64_t signalValue;       // PUT_SIGNAL only
+  uint64_t putValue;          // PUT_VALUE only (value embedded in desc)
+  void *request;              // filled by progress thread after posting IB op
+  uint64_t opSeq;             // per-peer monotonic sequence number
   struct flagcxRmaDesc *next; // intrusive link for inProgressQueues
 };
 
@@ -37,17 +37,17 @@ struct flagcxRmaDesc {
 // pending queues: producer = caller (proxy kernel thread), consumer = progress
 // thread. inProgress queues: progress thread only (no locking needed).
 struct flagcxRmaProxyState {
-  uint32_t queueSize; // power of two
-  uint32_t queueMask; // queueSize - 1
+  uint32_t queueSize;                     // power of two
+  uint32_t queueMask;                     // queueSize - 1
   struct flagcxRmaDesc **circularBuffers; // [nRanks * queueSize]
-  volatile uint32_t *pis; // [nRanks] producer index
-  volatile uint32_t *cis; // [nRanks] consumer index
+  volatile uint32_t *pis;                 // [nRanks] producer index
+  volatile uint32_t *cis;                 // [nRanks] consumer index
 
   pthread_mutex_t *peerProducerMutexes; // [nRanks]
   struct flagcxIntruQueue<struct flagcxRmaDesc, &flagcxRmaDesc::next>
-      *inProgressQueues; // [nRanks]
-  volatile uint64_t *opSeqs;   // [nRanks]
-  volatile uint64_t *doneSeqs; // [nRanks]
+      *inProgressQueues;        // [nRanks]
+  volatile uint64_t *opSeqs;    // [nRanks]
+  volatile uint64_t *doneSeqs;  // [nRanks]
   volatile uint32_t *inFlights; // [nRanks]
 
   // Global completion counter: incremented once for every op that completes.
@@ -105,8 +105,7 @@ flagcxResult_t flagcxHeteroPut(flagcxHeteroComm_t comm, int peer,
 flagcxResult_t flagcxHeteroBatchPut(flagcxHeteroComm_t comm, int peer,
                                     const size_t *srcOffsets,
                                     const size_t *dstOffsets,
-                                    const size_t *sizes,
-                                    const int *srcMrIdxs,
+                                    const size_t *sizes, const int *srcMrIdxs,
                                     const int *dstMrIdxs, size_t count);
 
 // RDMA READ: pull data from remote peer's srcMrIdx buffer into local dstMrIdx
@@ -130,7 +129,7 @@ flagcxResult_t flagcxHeteroFlush(flagcxHeteroComm_t comm, void *gpuAddr,
 flagcxResult_t flagcxHeteroRmaProxyStart(flagcxHeteroComm_t comm);
 flagcxResult_t flagcxHeteroRmaProxyStop(flagcxHeteroComm_t comm);
 
-// Publish the stable fullSendComms pointer to the proxy. 
+// Publish the stable fullSendComms pointer to the proxy.
 flagcxResult_t flagcxHeteroRmaProxyPublishSendComms(flagcxHeteroComm_t comm,
                                                     void *const *fullSendComms);
 

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -461,6 +461,13 @@ flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
     heteroComm->oneSideHandles[slot] = info;
     heteroComm->oneSideHandleCount = slot + 1;
 
+    // Publish fullSendComms to the RMA proxy on the first registration so
+    // its progress thread can look up per-peer sendComms without racing
+    // on the realloc-resized oneSideHandles array.
+    if (slot == 0 && info->fullSendComms != NULL) {
+      flagcxHeteroRmaProxyPublishSendComms(heteroComm, info->fullSendComms);
+    }
+
     INFO(FLAGCX_REG,
          "One-sided register index %d allgather results (rank %d, nranks %d):",
          slot, state->rank, nranks);
@@ -2044,6 +2051,26 @@ flagcxResult_t flagcxGet(flagcxComm_t comm, int peer, size_t srcOffset,
     return flagcxInvalidArgument;
   return flagcxHeteroGet(comm->heteroComm, peer, srcOffset, dstOffset, size,
                          srcMrIdx, dstMrIdx);
+}
+
+flagcxResult_t flagcxPut(flagcxComm_t comm, int peer, size_t srcOffset,
+                         size_t dstOffset, size_t size, int srcMrIdx,
+                         int dstMrIdx) {
+  if (comm == NULL || comm->heteroComm == NULL)
+    return flagcxInvalidArgument;
+  return flagcxHeteroPut(comm->heteroComm, peer, srcOffset, dstOffset, size,
+                         srcMrIdx, dstMrIdx);
+}
+
+flagcxResult_t flagcxBatchPut(flagcxComm_t comm, int peer,
+                              const size_t *srcOffsets,
+                              const size_t *dstOffsets, const size_t *sizes,
+                              const int *srcMrIdxs, const int *dstMrIdxs,
+                              size_t count) {
+  if (comm == NULL || comm->heteroComm == NULL)
+    return flagcxInvalidArgument;
+  return flagcxHeteroBatchPut(comm->heteroComm, peer, srcOffsets, dstOffsets,
+                              sizes, srcMrIdxs, dstMrIdxs, count);
 }
 
 flagcxResult_t flagcxPutSignal(flagcxComm_t comm, int peer, size_t srcOffset,

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -461,6 +461,13 @@ flagcxResult_t flagcxOneSideRegister(const flagcxComm_t comm, void *buff,
     heteroComm->oneSideHandles[slot] = info;
     heteroComm->oneSideHandleCount = slot + 1;
 
+    // Publish fullSendComms to the RMA proxy on the first registration so
+    // its progress thread can look up per-peer sendComms without racing
+    // on the realloc-resized oneSideHandles array.
+    if (slot == 0 && info->fullSendComms != NULL) {
+      flagcxHeteroRmaProxyPublishSendComms(heteroComm, info->fullSendComms);
+    }
+
     INFO(FLAGCX_REG,
          "One-sided register index %d allgather results (rank %d, nranks %d):",
          slot, state->rank, nranks);
@@ -2233,6 +2240,26 @@ flagcxResult_t flagcxGet(flagcxComm_t comm, int peer, size_t srcOffset,
     return flagcxInvalidArgument;
   return flagcxHeteroGet(comm->heteroComm, peer, srcOffset, dstOffset, size,
                          srcMrIdx, dstMrIdx);
+}
+
+flagcxResult_t flagcxPut(flagcxComm_t comm, int peer, size_t srcOffset,
+                         size_t dstOffset, size_t size, int srcMrIdx,
+                         int dstMrIdx) {
+  if (comm == NULL || comm->heteroComm == NULL)
+    return flagcxInvalidArgument;
+  return flagcxHeteroPut(comm->heteroComm, peer, srcOffset, dstOffset, size,
+                         srcMrIdx, dstMrIdx);
+}
+
+flagcxResult_t flagcxBatchPut(flagcxComm_t comm, int peer,
+                              const size_t *srcOffsets,
+                              const size_t *dstOffsets, const size_t *sizes,
+                              const int *srcMrIdxs, const int *dstMrIdxs,
+                              size_t count) {
+  if (comm == NULL || comm->heteroComm == NULL)
+    return flagcxInvalidArgument;
+  return flagcxHeteroBatchPut(comm->heteroComm, peer, srcOffsets, dstOffsets,
+                              sizes, srcMrIdxs, dstMrIdxs, count);
 }
 
 flagcxResult_t flagcxPutSignal(flagcxComm_t comm, int peer, size_t srcOffset,

--- a/flagcx/include/flagcx.h
+++ b/flagcx/include/flagcx.h
@@ -478,6 +478,22 @@ flagcxResult_t flagcxGet(flagcxComm_t comm, int peer, size_t srcOffset,
                          size_t dstOffset, size_t size, int srcMrIdx,
                          int dstMrIdx);
 
+/* RDMA WRITE: push size bytes from local srcOffset to remote peer's buffer at
+ * dstOffset. srcMrIdx / dstMrIdx index the per-window MR handle table
+ * populated by flagcxOneSideRegister. */
+flagcxResult_t flagcxPut(flagcxComm_t comm, int peer, size_t srcOffset,
+                         size_t dstOffset, size_t size, int srcMrIdx,
+                         int dstMrIdx);
+
+/* Batch RDMA WRITE. Each entry uses srcOffsets[i], dstOffsets[i], sizes[i],
+ * srcMrIdxs[i], and dstMrIdxs[i]. Optimized net adaptors may submit the batch
+ * as one linked-list ibv_post_send. */
+flagcxResult_t flagcxBatchPut(flagcxComm_t comm, int peer,
+                              const size_t *srcOffsets,
+                              const size_t *dstOffsets, const size_t *sizes,
+                              const int *srcMrIdxs, const int *dstMrIdxs,
+                              size_t count);
+
 /* RDMA WRITE + ATOMIC: write size bytes from local srcOffset to remote
  * dstOffset, then atomically increment the remote signal at signalOffset by
  * signalValue. When size == 0, only the signal ATOMIC is posted. */

--- a/plugin/interservice/flagcx_wrapper.py
+++ b/plugin/interservice/flagcx_wrapper.py
@@ -287,6 +287,22 @@ class FLAGCXLibrary:
             ctypes.c_int, ctypes.c_int
         ]),
 
+        Function("flagcxPut", flagcxResult_t, [
+            flagcxComm_t, ctypes.c_int,
+            ctypes.c_size_t, ctypes.c_size_t, ctypes.c_size_t,
+            ctypes.c_int, ctypes.c_int
+        ]),
+
+        Function("flagcxBatchPut", flagcxResult_t, [
+            flagcxComm_t, ctypes.c_int,
+            ctypes.POINTER(ctypes.c_size_t),
+            ctypes.POINTER(ctypes.c_size_t),
+            ctypes.POINTER(ctypes.c_size_t),
+            ctypes.POINTER(ctypes.c_int),
+            ctypes.POINTER(ctypes.c_int),
+            ctypes.c_size_t,
+        ]),
+
         Function("flagcxPutSignal", flagcxResult_t, [
             flagcxComm_t, ctypes.c_int,
             ctypes.c_size_t, ctypes.c_size_t, ctypes.c_size_t,
@@ -503,6 +519,36 @@ class FLAGCXLibrary:
         self.FLAGCX_CHECK(self._funcs["flagcxGet"](
             comm, peer, ctypes.c_size_t(srcOffset), ctypes.c_size_t(dstOffset),
             ctypes.c_size_t(size), srcMrIdx, dstMrIdx))
+
+    def flagcxPut(self, comm: flagcxComm_t, peer: int,
+                  srcOffset: int, dstOffset: int, size: int,
+                  srcMrIdx: int, dstMrIdx: int) -> None:
+        self.FLAGCX_CHECK(self._funcs["flagcxPut"](
+            comm, peer, ctypes.c_size_t(srcOffset), ctypes.c_size_t(dstOffset),
+            ctypes.c_size_t(size), srcMrIdx, dstMrIdx))
+
+    def flagcxBatchPut(self, comm: flagcxComm_t, peer: int,
+                       srcOffsets: list[int], dstOffsets: list[int],
+                       sizes: list[int], srcMrIdxs: list[int],
+                       dstMrIdxs: list[int]) -> None:
+        count = len(sizes)
+        if count == 0:
+            return
+        if (
+            len(srcOffsets) != count or len(dstOffsets) != count
+            or len(srcMrIdxs) != count or len(dstMrIdxs) != count
+        ):
+            raise ValueError("flagcxBatchPut argument lengths do not match")
+        size_array = ctypes.c_size_t * count
+        int_array = ctypes.c_int * count
+        self.FLAGCX_CHECK(self._funcs["flagcxBatchPut"](
+            comm, peer,
+            size_array(*srcOffsets),
+            size_array(*dstOffsets),
+            size_array(*sizes),
+            int_array(*srcMrIdxs),
+            int_array(*dstMrIdxs),
+            ctypes.c_size_t(count)))
 
     def flagcxPutSignal(self, comm: flagcxComm_t, peer: int,
                         srcOffset: int, dstOffset: int, size: int,


### PR DESCRIPTION
### PR Category
CRL

### PR Types
Optimizations

### PR Description
- New net adaptor API: iputBatch() for submitting multiple RDMA WRITE descriptors in a single ibv_post_send call                                                               
  - IB adaptor: Implements flagcxIbIputBatch() using linked work requests                                                                                                      
  - RMA proxy refactor: Replaces single pending queue with per-peer circular buffers for better scalability                                                                      
  - New public APIs: flagcxPut() and flagcxBatchPut() for explicit one-sided WRITE                                                                                               
  - Environment variables:                                                                                                                                                       
    - FLAGCX_RMA_QUEUE_SIZE (default: 256) — per-peer circular buffer depth                                                                                                      
    - FLAGCX_RMA_BATCH_MAX (default: 256) — max descriptors batched per iputBatch