### PR TITLE
[CRL] Reuse closed connection slots to fix proxy destroy hang

### DIFF
--- a/flagcx/core/group.cc
+++ b/flagcx/core/group.cc
@@ -144,6 +144,10 @@ static flagcxResult_t groupLaunch(struct flagcxAsyncJob *job_) {
     job = flagcxIntruQueueHead(asyncJobsMain);
     do {
       pthread_join(job->thread, nullptr);
+      if (job->result != flagcxSuccess) {
+        WARN("Async job failed with result %d", job->result);
+        ret = job->result;
+      }
       job = job->next;
     } while (job != nullptr);
 
@@ -265,6 +269,12 @@ static flagcxResult_t groupLaunch(struct flagcxAsyncJob *job_) {
                                  ->recv[0]
                                  .proxyConn.connection;
             op->stream = p2p->stream;
+            if (op->connection == NULL) {
+              WARN("groupLaunch: recv proxyConn.connection is NULL for rank %d "
+                   "peer %d channel %d",
+                   comm->rank, peer, op->channelId);
+              return flagcxInternalError;
+            }
             if (op->connection->transport == TRANSPORT_P2P) {
               op->args.chunkSize = computeP2pChunkSize(p2p->bytes);
               op->args.chunkSteps =
@@ -349,6 +359,12 @@ static flagcxResult_t groupLaunch(struct flagcxAsyncJob *job_) {
                                  ->send[0]
                                  .proxyConn.connection;
             op->stream = p2p->stream;
+            if (op->connection == NULL) {
+              WARN("groupLaunch: send proxyConn.connection is NULL for rank %d "
+                   "peer %d channel %d",
+                   comm->rank, peer, op->channelId);
+              return flagcxInternalError;
+            }
             if (op->connection->transport == TRANSPORT_P2P) {
               op->args.chunkSize = computeP2pChunkSize(p2p->bytes);
               op->args.chunkSteps =

--- a/flagcx/core/include/proxy.h
+++ b/flagcx/core/include/proxy.h
@@ -310,6 +310,15 @@ struct flagcxIpcHdr {
   uint64_t data[16]; // 128-bytes
 };
 
+// Tracks per-accepted-connection state in the service thread (like
+// ncclProxyLocalPeer)
+struct flagcxProxyLocalPeer {
+  struct flagcxSocket sock;
+  int tpRank;      // global rank of the peer that connected
+  int tpLocalRank; // local rank of the peer
+  struct flagcxProxyAsyncOp *asyncOps;
+};
+
 struct flagcxProxyState {
   int refCount;
   int tpRank;
@@ -329,7 +338,8 @@ struct flagcxProxyState {
   pthread_t threadUDS;
   struct flagcxSocket listenSock;
   struct flagcxSocket ipcSock;
-  int stop;
+  volatile int
+      stop; // Set by flagcxProxyStop, checked by service thread as backup
   flagcxResult_t asyncResult;
   int nRanks;
 

--- a/flagcx/core/include/proxy.h
+++ b/flagcx/core/include/proxy.h
@@ -310,8 +310,7 @@ struct flagcxIpcHdr {
   uint64_t data[16]; // 128-bytes
 };
 
-// Tracks per-accepted-connection state in the service thread (like
-// ncclProxyLocalPeer)
+// Tracks per-accepted-connection state in the service thread
 struct flagcxProxyLocalPeer {
   struct flagcxSocket sock;
   int tpRank;      // global rank of the peer that connected
@@ -338,8 +337,8 @@ struct flagcxProxyState {
   pthread_t threadUDS;
   struct flagcxSocket listenSock;
   struct flagcxSocket ipcSock;
-  volatile int
-      stop; // Set by flagcxProxyStop, checked by service thread as backup
+  // Set by flagcxProxyStop, checked by service thread as backup
+  volatile int stop;
   flagcxResult_t asyncResult;
   int nRanks;
 

--- a/flagcx/core/init.cc
+++ b/flagcx/core/init.cc
@@ -502,6 +502,9 @@ flagcxResult_t flagcxHeteroCommDestroy(flagcxHeteroComm_t comm) {
   FLAGCXCHECK(flagcxHeteroRmaProxyStop(comm));
   // Clean up P2P IPC handles while proxy is still alive and peerSocks valid
   FLAGCXCHECK(globalRegPool.removeAllP2pHandles(comm));
+  // Stop: send stop + close peerSocks (like ncclProxyStop)
+  flagcxProxyStop(comm);
+  // Destroy: join thread, free proxy resources (like ncclProxyDestroy)
   flagcxProxyDestroy(comm);
   for (int i = 0; i < MAXCHANNELS; i++) {
     for (int r = 0; r < comm->nRanks; r++) {
@@ -523,13 +526,6 @@ flagcxResult_t flagcxHeteroCommDestroy(flagcxHeteroComm_t comm) {
     // flagcxProxyConnection allocated and owned by the peer's service thread.
     // Do NOT free it here — the peer frees it when its service thread exits.
     free(comm->gproxyConn);
-  }
-  free(comm->proxyState->peerAddresses);
-  if (comm->proxyState->peerSocks != NULL) {
-    for (int i = 0; i < comm->proxyState->nPeerSocks; i++) {
-      flagcxSocketClose(&comm->proxyState->peerSocks[i]);
-    }
-    free(comm->proxyState->peerSocks);
   }
   free(comm->proxyState);
   free(comm->tasks.peers);

--- a/flagcx/core/init.cc
+++ b/flagcx/core/init.cc
@@ -176,7 +176,7 @@ static flagcxResult_t initTransportsRank(flagcxHeteroComm_t comm,
     comm->localRanks = comm->nodeRanks[comm->node].localRanks;
     comm->localRankToRank = comm->nodeRanks[comm->node].localRankToRank;
 
-    // Build p2pSchedule with two-level scheduling (like NCCL)
+    // Build p2pSchedule with two-level scheduling
     int node = comm->node;
     int local = comm->localRank;
     int nLocals = comm->maxLocalRanks;
@@ -297,16 +297,6 @@ static flagcxResult_t flagcxCommInitRankFunc(struct flagcxAsyncJob *job_) {
       FLAGCXCHECK(flagcxCalloc(&comm->channels[i].peers, nranks));
       for (int r = 0; r < nranks; r++) {
         FLAGCXCHECK(flagcxCalloc(&comm->channels[i].peers[r], nranks));
-      }
-    }
-    // Set tpRank = comm->rank for all channel connectors so local RPCs
-    // route through peerSocks[myRank] to the local service thread
-    for (int i = 0; i < MAXCHANNELS; i++) {
-      for (int r = 0; r < nranks; r++) {
-        for (int c = 0; c < FLAGCX_MAX_CONNS; c++) {
-          comm->channels[i].peers[r]->send[c].proxyConn.tpRank = comm->rank;
-          comm->channels[i].peers[r]->recv[c].proxyConn.tpRank = comm->rank;
-        }
       }
     }
     FLAGCXCHECK(flagcxCalloc(&comm->connectSend, nranks));
@@ -477,10 +467,10 @@ flagcxResult_t flagcxHeteroCommDestroy(flagcxHeteroComm_t comm) {
   FLAGCXCHECK(flagcxHeteroRmaProxyStop(comm));
   // Clean up P2P IPC handles while proxy is still alive and peerSocks valid
   FLAGCXCHECK(globalRegPool.removeAllP2pHandles(comm));
-  // Stop: send stop + close peerSocks (like ncclProxyStop)
-  flagcxProxyStop(comm);
-  // Destroy: join thread, free proxy resources (like ncclProxyDestroy)
-  flagcxProxyDestroy(comm);
+  // Stop: send stop + close peerSocks
+  FLAGCXCHECK(flagcxProxyStop(comm));
+  // Destroy: join thread, free proxy resources
+  FLAGCXCHECK(flagcxProxyDestroy(comm));
   for (int i = 0; i < MAXCHANNELS; i++) {
     for (int r = 0; r < comm->nRanks; r++) {
       free(comm->channels[i].peers[r]);

--- a/flagcx/core/init.cc
+++ b/flagcx/core/init.cc
@@ -341,7 +341,6 @@ static flagcxResult_t flagcxCommInitRankFunc(struct flagcxAsyncJob *job_) {
 
     comm->groupNext = reinterpret_cast<struct flagcxHeteroComm *>(0x1);
     comm->preconnectNext = reinterpret_cast<struct flagcxHeteroComm *>(0x1);
-    comm->proxyState->nRanks = comm->nRanks;
 
     bool runtimeProxy = false;
     const char *runtimeEnv = flagcxGetEnv("FLAGCX_RUNTIME_PROXY");
@@ -352,32 +351,8 @@ static flagcxResult_t flagcxCommInitRankFunc(struct flagcxAsyncJob *job_) {
     if (!runtimeProxy) {
       FLAGCXCHECK(flagcxProxyInit(comm));
 
-      // Allocate gproxyConn array and populate peerAddresses for peer proxy
-      // connections
+      // Allocate gproxyConn array for peer proxy connections
       FLAGCXCHECK(flagcxCalloc(&comm->gproxyConn, comm->nRanks));
-      FLAGCXCHECK(flagcxCalloc(&comm->proxyState->peerAddresses, comm->nRanks));
-      comm->proxyState->peerAddresses[comm->rank] =
-          comm->proxyState->listenSock.addr;
-      FLAGCXCHECK(bootstrapAllGather(comm->bootstrap,
-                                     comm->proxyState->peerAddresses,
-                                     sizeof(union flagcxSocketAddress)));
-
-      // Pre-connect all peer sockets (including self)
-      FLAGCXCHECK(flagcxCalloc(&comm->proxyState->peerSocks, comm->nRanks));
-      comm->proxyState->nPeerSocks = comm->nRanks;
-      for (int i = 0; i < comm->nRanks; i++) {
-        FLAGCXCHECK(flagcxSocketSetFd(-1, &comm->proxyState->peerSocks[i]));
-      }
-      for (int i = 0; i < comm->nRanks; i++) {
-        struct flagcxSocket *sock = &comm->proxyState->peerSocks[i];
-        FLAGCXCHECK(flagcxSocketInit(sock, comm->proxyState->peerAddresses + i,
-                                     comm->magic, flagcxSocketTypeProxy));
-        FLAGCXCHECK(flagcxSocketConnect(sock));
-        int ready = 0;
-        while (!ready) {
-          FLAGCXCHECK(flagcxSocketReady(sock, &ready));
-        }
-      }
     }
   }
 

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -141,7 +141,7 @@ flagcxProxyGetConnection(struct flagcxProxyConnectionPool *pool, int id,
                          struct flagcxProxyConnection **conn) {
   int bank = id >> FLAGCX_PROXY_CONN_POOL_SIZE_POW2;
   int offset = id & FLAGCX_PROXY_CONN_POOL_MASK;
-  if ((pool->pools == NULL) || (bank > pool->banks) ||
+  if ((id < 0) || (pool->pools == NULL) || (bank >= pool->banks) ||
       (pool->pools[bank] == NULL))
     return flagcxInternalError;
   *conn = pool->pools[bank] + offset;
@@ -972,6 +972,21 @@ proxyServiceInitOp(int type, struct flagcxProxyLocalPeer *peer,
                   fail);
   FLAGCXCHECKGOTO(flagcxSocketRecv(sock, &asyncOp->respSize, sizeof(int)), ret,
                   fail);
+
+  // Validate buffer sizes for Init to prevent heap corruption from
+  // malformed/version-mismatched peers
+  if (type == flagcxProxyMsgInit) {
+    if (asyncOp->reqSize != (int)sizeof(struct flagcxProxyInitReq) ||
+        asyncOp->respSize != (int)sizeof(struct flagcxProxyInitResp)) {
+      WARN("proxyServiceInitOp: Init message size mismatch "
+           "(reqSize=%d expected=%zu, respSize=%d expected=%zu)",
+           asyncOp->reqSize, sizeof(struct flagcxProxyInitReq),
+           asyncOp->respSize, sizeof(struct flagcxProxyInitResp));
+      ret = flagcxInternalError;
+      goto fail;
+    }
+  }
+
   if (asyncOp->reqSize) {
     FLAGCXCHECKGOTO(flagcxCalloc(&asyncOp->reqBuff, asyncOp->reqSize), ret,
                     fail);

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -6,6 +6,7 @@
 
 #include "proxy.h"
 #include "adaptor.h"
+#include "bootstrap.h"
 #include "comm.h"
 #include "device_api/flagcx_device.h" // flagcxDevCommInternal, devComm
 #include "flagcx_hetero.h"
@@ -924,7 +925,35 @@ flagcxResult_t flagcxProxyInit(struct flagcxHeteroComm *comm) {
                                flagcxSocketTypeProxy, NULL, 1));
   FLAGCXCHECK(flagcxSocketListen(&comm->proxyState->listenSock));
 
+  // Allgather proxy listen addresses
+  FLAGCXCHECK(flagcxCalloc(&comm->proxyState->peerAddresses, comm->nRanks));
+  comm->proxyState->peerAddresses[comm->rank] =
+      comm->proxyState->listenSock.addr;
+  FLAGCXCHECK(bootstrapAllGather(comm->bootstrap,
+                                 comm->proxyState->peerAddresses,
+                                 sizeof(union flagcxSocketAddress)));
+
+  // Pre-connect all peer sockets (including self)
+  // TODO: support lazy connection
+  FLAGCXCHECK(flagcxCalloc(&comm->proxyState->peerSocks, comm->nRanks));
+  comm->proxyState->nPeerSocks = comm->nRanks;
+  for (int i = 0; i < comm->nRanks; i++) {
+    FLAGCXCHECK(flagcxSocketSetFd(-1, &comm->proxyState->peerSocks[i]));
+  }
+  for (int i = 0; i < comm->nRanks; i++) {
+    struct flagcxSocket *sock = &comm->proxyState->peerSocks[i];
+    FLAGCXCHECK(flagcxSocketInit(sock, comm->proxyState->peerAddresses + i,
+                                 comm->magic, flagcxSocketTypeProxy));
+    FLAGCXCHECK(flagcxSocketConnect(sock));
+    int ready = 0;
+    while (!ready) {
+      FLAGCXCHECK(flagcxSocketReady(sock, &ready));
+    }
+  }
+
   comm->proxyState->cudaDev = comm->cudaDev;
+  comm->proxyState->nRanks = comm->nRanks;
+  comm->proxyState->stop = 0;
   pthread_create(&comm->proxyState->thread, NULL, flagcxProxyService,
                  (void *)comm);
   pthread_create(&comm->proxyState->progressState.thread, NULL,
@@ -987,8 +1016,8 @@ void *flagcxProxyService(void *args) {
   int maxConns = comm->nRanks + 1;
   struct pollfd *pollfds =
       (struct pollfd *)calloc(maxConns + 1, sizeof(struct pollfd));
-  struct flagcxSocket *connSocks =
-      (struct flagcxSocket *)calloc(maxConns, sizeof(struct flagcxSocket));
+  struct flagcxProxyLocalPeer *peers = (struct flagcxProxyLocalPeer *)calloc(
+      maxConns, sizeof(struct flagcxProxyLocalPeer));
   int npeers = 0;
   int maxnpeers = 0;
   struct flagcxProxyConnection **allocatedConns = NULL;
@@ -1002,11 +1031,19 @@ void *flagcxProxyService(void *args) {
   for (int i = 0; i < maxConns; i++) {
     pollfds[i].fd = -1;
     pollfds[i].events = POLLIN;
+    peers[i].tpRank = -1;
+    peers[i].tpLocalRank = -1;
   }
   pollfds[maxConns].fd = comm->proxyState->listenSock.fd;
   pollfds[maxConns].events = POLLIN;
 
   while (!stop || npeers > 0) {
+    // Check backup atomic stop flag
+    if (!stop && __atomic_load_n(&comm->proxyState->stop, __ATOMIC_ACQUIRE)) {
+      stop = 1;
+      INFO(FLAGCX_PROXY,
+           "[Service thread] Stop flag detected via atomic, npeers=%d", npeers);
+    }
     int ret;
     do {
       ret = poll(pollfds, maxConns + 1, asyncOpCount ? 0 : 500);
@@ -1175,12 +1212,14 @@ void *flagcxProxyService(void *args) {
       }
 
       if (slot >= 0) {
-        struct flagcxSocket *newSock = &connSocks[slot];
+        struct flagcxSocket *newSock = &peers[slot].sock;
         FLAGCXCHECKGOTO(flagcxSocketInit(newSock), res, out);
         res = flagcxSocketAccept(newSock, &comm->proxyState->listenSock);
         if (res == flagcxSuccess) {
           pollfds[slot].fd = newSock->fd;
           pollfds[slot].events = POLLIN;
+          peers[slot].tpRank = -1;
+          peers[slot].tpLocalRank = -1;
           npeers++;
           if (maxnpeers < slot + 1)
             maxnpeers = slot + 1;
@@ -1202,16 +1241,19 @@ void *flagcxProxyService(void *args) {
       if (pollfds[i].revents & (POLLHUP | POLLERR)) {
         closeConn = true;
       } else if (pollfds[i].revents & POLLIN) {
-        if (!processSocket(&connSocks[i]))
+        if (!processSocket(&peers[i].sock))
           closeConn = true;
       }
       if (closeConn) {
-        flagcxSocketClose(&connSocks[i]);
+        flagcxSocketClose(&peers[i].sock);
         pollfds[i].fd = -1;
         npeers--;
         INFO(FLAGCX_PROXY,
-             "[Service thread] Closed connection at slot %d (npeers=%d)", i,
-             npeers);
+             "[Service thread] Closed connection at slot %d tpRank %d "
+             "(npeers=%d)",
+             i, peers[i].tpRank, npeers);
+        peers[i].tpRank = -1;
+        peers[i].tpLocalRank = -1;
       }
     }
 
@@ -1267,12 +1309,12 @@ out:
   // Close sockets (skip already-closed ones marked with fd = -1)
   for (int i = 0; i < maxConns; i++) {
     if (pollfds[i].fd != -1) {
-      flagcxSocketClose(&connSocks[i]);
+      flagcxSocketClose(&peers[i].sock);
     }
   }
   flagcxSocketClose(&comm->proxyState->listenSock);
   free(pollfds);
-  free(connSocks);
+  free(peers);
 
   // Dequeue unhandled ops
   list = opHead;
@@ -1635,7 +1677,8 @@ flagcxResult_t flagcxProxyStop(struct flagcxHeteroComm *comm) {
   }
 
   INFO(FLAGCX_PROXY, "flagcxProxyStop: sending stop to service thread...");
-  // 1. Send stop to own service thread via listen socket
+  // 1. Send MsgStop to own service thread via listen socket
+  // 1984-1991)
   struct flagcxSocket sock;
   int type = flagcxProxyMsgStop;
   FLAGCXCHECK(flagcxSocketInit(&sock, &comm->proxyState->listenSock.addr,
@@ -1649,20 +1692,25 @@ flagcxResult_t flagcxProxyStop(struct flagcxHeteroComm *comm) {
   }
   (void)flagcxSocketClose(&sock);
 
-  // 2. Send Close + close each peerSock (tells peer service threads to
-  //    close the accepted connection, decrementing their npeers)
+  // 2. Send MsgClose + close each peerSock
+  //    This tells peer service threads to close the accepted connection,
+  //    decrementing their npeers.
   if (comm->proxyState->peerSocks != NULL) {
     for (int i = 0; i < comm->proxyState->nPeerSocks; i++) {
       if (comm->proxyState->peerSocks[i].fd >= 0) {
-        int type = flagcxProxyMsgClose;
-        (void)flagcxSocketSend(&comm->proxyState->peerSocks[i], &type,
+        int closeType = flagcxProxyMsgClose;
+        (void)flagcxSocketSend(&comm->proxyState->peerSocks[i], &closeType,
                                sizeof(int));
         flagcxSocketClose(&comm->proxyState->peerSocks[i]);
       }
     }
   }
 
-  // 3. Signal kernel threads to stop
+  // 3. Set atomic stop flag
+  //    Backup: service thread checks this every 500ms poll timeout
+  __atomic_store_n(&comm->proxyState->stop, 1, __ATOMIC_RELEASE);
+
+  // 4. Signal kernel threads to stop
   comm->proxyState->kernelState.stop = 1;
   INFO(FLAGCX_PROXY, "flagcxProxyStop: done");
   return flagcxSuccess;
@@ -1670,13 +1718,15 @@ flagcxResult_t flagcxProxyStop(struct flagcxHeteroComm *comm) {
 
 flagcxResult_t flagcxProxyDestroy(struct flagcxHeteroComm *comm) {
   if (comm->proxyState->initialized == 1) {
+    // Join service thread
     INFO(FLAGCX_PROXY, "flagcxProxyDestroy: joining service thread...");
     pthread_join(comm->proxyState->thread, nullptr);
     INFO(FLAGCX_PROXY, "flagcxProxyDestroy: service thread joined, freeing...");
+    // Free transport resources (must happen after thread join)
     flagcxProxyFree(comm);
     INFO(FLAGCX_PROXY, "flagcxProxyDestroy: done");
   }
-  // Free heap arrays (sockets already closed by flagcxProxyStop)
+  // free peerSocks
   if (comm->proxyState->peerSocks != NULL) {
     free(comm->proxyState->peerSocks);
     comm->proxyState->peerSocks = NULL;

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -1158,15 +1158,29 @@ void *flagcxProxyService(void *args) {
 
     // Check listenSock for new connections (nRanks peers + 1 stop connection)
     if (pollfds[0].revents & POLLIN) {
-      if (nConns < comm->nRanks + 1) {
-        struct flagcxSocket *newSock = &connSocks[nConns];
+      // Find a free slot (either nConns < limit, or a closed slot with fd ==
+      // -1)
+      int slot = -1;
+      for (int i = 0; i < nConns; i++) {
+        if (pollfds[1 + i].fd == -1) {
+          slot = i;
+          break;
+        }
+      }
+      if (slot == -1 && nConns < comm->nRanks + 1) {
+        slot = nConns;
+        nConns++;
+      }
+
+      if (slot >= 0) {
+        struct flagcxSocket *newSock = &connSocks[slot];
         FLAGCXCHECKGOTO(flagcxSocketInit(newSock), res, out);
         res = flagcxSocketAccept(newSock, &comm->proxyState->listenSock);
         if (res == flagcxSuccess) {
-          pollfds[1 + nConns].fd = newSock->fd;
-          pollfds[1 + nConns].events = POLLIN;
-          nConns++;
-          INFO(FLAGCX_PROXY, "[Service thread] Accepted connection %d", nConns);
+          pollfds[1 + slot].fd = newSock->fd;
+          pollfds[1 + slot].events = POLLIN;
+          INFO(FLAGCX_PROXY, "[Service thread] Accepted connection at slot %d",
+               slot);
         }
       }
     }

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -62,12 +62,12 @@ flagcxProxyProgressChannelJoin(struct flagcxProxyState *proxyState,
   return flagcxSuccess;
 }
 
-static flagcxResult_t asyncProxyOpEnqueue(flagcxProxyAsyncOp **opHead,
+static flagcxResult_t asyncProxyOpEnqueue(struct flagcxProxyLocalPeer *peer,
                                           flagcxProxyAsyncOp *newOp) {
-  flagcxProxyAsyncOp *list = *opHead;
-  if (list == NULL)
-    *opHead = newOp;
-  else {
+  flagcxProxyAsyncOp *list = peer->asyncOps;
+  if (list == NULL) {
+    peer->asyncOps = newOp;
+  } else {
     while (list->next)
       list = list->next;
     list->next = newOp;
@@ -76,10 +76,10 @@ static flagcxResult_t asyncProxyOpEnqueue(flagcxProxyAsyncOp **opHead,
   return flagcxSuccess;
 }
 
-static flagcxResult_t asyncProxyOpDequeue(flagcxProxyAsyncOp **opHead,
+static flagcxResult_t asyncProxyOpDequeue(struct flagcxProxyLocalPeer *peer,
                                           flagcxProxyAsyncOp *op) {
-  if (*opHead == op)
-    *opHead = op->next;
+  if (peer->asyncOps == op)
+    peer->asyncOps = op->next;
   if (op->next)
     op->next->prev = op->prev;
   if (op->prev)
@@ -526,7 +526,7 @@ flagcxResult_t flagcxPollProxyResponse(struct flagcxHeteroComm *comm,
   return res;
 }
 
-static flagcxResult_t proxyProgressAsync(flagcxProxyAsyncOp **opHead,
+static flagcxResult_t proxyProgressAsync(struct flagcxProxyLocalPeer *peer,
                                          flagcxProxyAsyncOp *op,
                                          int *asyncOpCount) {
   int done = 0;
@@ -772,7 +772,7 @@ static flagcxResult_t proxyProgressAsync(flagcxProxyAsyncOp **opHead,
           flagcxSocketSend(op->connection->sock, op->respBuff, op->respSize));
     }
 
-    asyncProxyOpDequeue(opHead, op);
+    asyncProxyOpDequeue(peer, op);
     (*asyncOpCount)--;
     return flagcxSuccess;
   }
@@ -810,10 +810,11 @@ error:
   return ret;
 }
 
-static flagcxResult_t proxyServiceInitOp(int type, struct flagcxSocket *sock,
-                                         struct flagcxProxyAsyncOp **opHead,
+static flagcxResult_t proxyServiceInitOp(int type,
+                                         struct flagcxProxyLocalPeer *peer,
                                          flagcxHeteroComm_t comm,
                                          int *asyncOpCount) {
+  struct flagcxSocket *sock = &peer->sock;
   struct flagcxProxyAsyncOp *asyncOp;
   FLAGCXCHECK(flagcxCalloc(&asyncOp, 1));
 
@@ -834,9 +835,9 @@ static flagcxResult_t proxyServiceInitOp(int type, struct flagcxSocket *sock,
   if (asyncOp->respSize)
     FLAGCXCHECK(flagcxCalloc(&asyncOp->respBuff, asyncOp->respSize));
 
-  FLAGCXCHECK(asyncProxyOpEnqueue(opHead, asyncOp));
+  FLAGCXCHECK(asyncProxyOpEnqueue(peer, asyncOp));
   (*asyncOpCount)++;
-  FLAGCXCHECK(proxyProgressAsync(opHead, asyncOp, asyncOpCount));
+  FLAGCXCHECK(proxyProgressAsync(peer, asyncOp, asyncOpCount));
   return flagcxSuccess;
 }
 
@@ -1007,8 +1008,6 @@ void *flagcxProxyService(void *args) {
   int stop = 0;
   int asyncOpCount = 0;
   struct flagcxHeteroComm *comm = (struct flagcxHeteroComm *)args;
-  struct flagcxProxyAsyncOp *opHead = NULL;
-  struct flagcxProxyAsyncOp *list = NULL;
   flagcxResult_t res = flagcxSuccess;
 
   // Peer slots [0..maxConns-1], listen socket at [maxConns]
@@ -1052,23 +1051,29 @@ void *flagcxProxyService(void *args) {
       break;
     }
 
-    // Progress all ops
-    list = opHead;
-    while (list) {
-      struct flagcxProxyAsyncOp *opNext = list->next;
-      res = proxyProgressAsync(&opHead, list, &asyncOpCount);
-      if (res == flagcxSuccess || res == flagcxInProgress) {
-        list = opNext;
-      } else {
-        WARN("[Service thread] Error encountered progressing operation with "
-             "res=%d",
-             res);
-        break;
+    // Progress async ops per-peer (NCCL-aligned)
+    for (int i = 0; i < maxnpeers; i++) {
+      if (pollfds[i].fd == -1)
+        continue;
+      struct flagcxProxyLocalPeer *peer = &peers[i];
+      struct flagcxProxyAsyncOp *op = peer->asyncOps;
+      while (op) {
+        struct flagcxProxyAsyncOp *opNext = op->next;
+        res = proxyProgressAsync(peer, op, &asyncOpCount);
+        if (res == flagcxSuccess || res == flagcxInProgress) {
+          op = opNext;
+        } else {
+          WARN("[Service thread] Error encountered progressing operation with "
+               "res=%d",
+               res);
+          break;
+        }
       }
     }
 
     // Helper lambda to process incoming data on a socket
-    auto processSocket = [&](struct flagcxSocket *sock) -> bool {
+    auto processSocket = [&](struct flagcxProxyLocalPeer *curPeer) -> bool {
+      struct flagcxSocket *sock = &curPeer->sock;
       int type;
       int closed = 0;
       res = flagcxSocketTryRecv(sock, &type, sizeof(int), &closed,
@@ -1182,7 +1187,7 @@ void *flagcxProxyService(void *args) {
           }
           return false;
         } else if (proxyMatchOpType(type)) {
-          res = proxyServiceInitOp(type, sock, &opHead, comm, &asyncOpCount);
+          res = proxyServiceInitOp(type, curPeer, comm, &asyncOpCount);
           if (res != flagcxSuccess) {
             WARN("[Service thread] Error encountered initializing operation "
                  "with res=%d",
@@ -1219,6 +1224,7 @@ void *flagcxProxyService(void *args) {
           pollfds[slot].events = POLLIN;
           peers[slot].tpRank = -1;
           peers[slot].tpLocalRank = -1;
+          peers[slot].asyncOps = NULL;
           npeers++;
           if (maxnpeers < slot + 1)
             maxnpeers = slot + 1;
@@ -1240,10 +1246,15 @@ void *flagcxProxyService(void *args) {
       if (pollfds[i].revents & (POLLHUP | POLLERR)) {
         closeConn = true;
       } else if (pollfds[i].revents & POLLIN) {
-        if (!processSocket(&peers[i].sock))
+        if (!processSocket(&peers[i]))
           closeConn = true;
       }
       if (closeConn) {
+        // Drain any remaining async ops for this peer (NCCL-aligned)
+        while (peers[i].asyncOps) {
+          asyncProxyOpDequeue(&peers[i], peers[i].asyncOps);
+          asyncOpCount--;
+        }
         flagcxSocketClose(&peers[i].sock);
         pollfds[i].fd = -1;
         npeers--;
@@ -1253,6 +1264,7 @@ void *flagcxProxyService(void *args) {
              i, peers[i].tpRank, npeers);
         peers[i].tpRank = -1;
         peers[i].tpLocalRank = -1;
+        peers[i].asyncOps = NULL;
       }
     }
 
@@ -1305,23 +1317,18 @@ out:
     free(allocatedConns[i]);
   free(allocatedConns);
 
-  // Close sockets (skip already-closed ones marked with fd = -1)
+  // Close sockets and drain any remaining async ops
   for (int i = 0; i < maxConns; i++) {
     if (pollfds[i].fd != -1) {
+      while (peers[i].asyncOps) {
+        asyncProxyOpDequeue(&peers[i], peers[i].asyncOps);
+      }
       flagcxSocketClose(&peers[i].sock);
     }
   }
   flagcxSocketClose(&comm->proxyState->listenSock);
   free(pollfds);
   free(peers);
-
-  // Dequeue unhandled ops
-  list = opHead;
-  while (list) {
-    struct flagcxProxyAsyncOp *opNext = list->next;
-    asyncProxyOpDequeue(&opHead, list);
-    list = opNext;
-  }
 
   INFO(FLAGCX_PROXY,
        "[Service thread] Wait for progress thread joined and free resources");

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -983,13 +983,13 @@ void *flagcxProxyService(void *args) {
   struct flagcxProxyAsyncOp *list = NULL;
   flagcxResult_t res = flagcxSuccess;
 
-  // Max connections: 1 listenSock + nRanks peer connections + 1 stop connection
-  int maxConns = 1 + comm->nRanks + 1;
+  // Peer slots [0..maxConns-1], listen socket at [maxConns] (NCCL pattern)
+  int maxConns = comm->nRanks + 1;
   struct pollfd *pollfds =
-      (struct pollfd *)calloc(maxConns, sizeof(struct pollfd));
-  struct flagcxSocket *connSocks = (struct flagcxSocket *)calloc(
-      comm->nRanks + 1, sizeof(struct flagcxSocket));
-  int nConns = 0;
+      (struct pollfd *)calloc(maxConns + 1, sizeof(struct pollfd));
+  struct flagcxSocket *connSocks =
+      (struct flagcxSocket *)calloc(maxConns, sizeof(struct flagcxSocket));
+  int npeers = 0;
   struct flagcxProxyConnection **allocatedConns = NULL;
   int nAllocatedConns = 0;
   FLAGCXCHECKGOTO(flagcxCalloc(&allocatedConns, comm->nRanks), res, out);
@@ -997,15 +997,18 @@ void *flagcxProxyService(void *args) {
   // Set device context
   FLAGCXCHECKGOTO(deviceAdaptor->setDevice(comm->cudaDev), res, out);
 
-  // pollfds[0] = listenSock, pollfds[1..] = accepted connections
-  pollfds[0].fd = comm->proxyState->listenSock.fd;
-  pollfds[0].events = POLLIN;
+  // All peer slots start invalid; listen socket at last index
+  for (int i = 0; i < maxConns; i++) {
+    pollfds[i].fd = -1;
+    pollfds[i].events = POLLIN;
+  }
+  pollfds[maxConns].fd = comm->proxyState->listenSock.fd;
+  pollfds[maxConns].events = POLLIN;
 
   while (!stop || (stop && opHead)) {
-    int nfds = 1 + nConns;
     int ret;
     do {
-      ret = poll(pollfds, nfds, asyncOpCount ? 0 : 500);
+      ret = poll(pollfds, maxConns + 1, asyncOpCount ? 0 : 500);
     } while (ret < 0 && errno == EINTR);
     if (ret < 0) {
       WARN("[Proxy Service] Poll failed: %s", strerror(errno));
@@ -1156,20 +1159,15 @@ void *flagcxProxyService(void *args) {
       return true;
     };
 
-    // Check listenSock for new connections (nRanks peers + 1 stop connection)
-    if (pollfds[0].revents & POLLIN) {
-      // Find a free slot (either nConns < limit, or a closed slot with fd ==
-      // -1)
+    // Check listenSock for new connections (at last index)
+    if (pollfds[maxConns].revents & POLLIN) {
+      // Find first free slot (fd == -1)
       int slot = -1;
-      for (int i = 0; i < nConns; i++) {
-        if (pollfds[1 + i].fd == -1) {
+      for (int i = 0; i < maxConns; i++) {
+        if (pollfds[i].fd == -1) {
           slot = i;
           break;
         }
-      }
-      if (slot == -1 && nConns < comm->nRanks + 1) {
-        slot = nConns;
-        nConns++;
       }
 
       if (slot >= 0) {
@@ -1177,21 +1175,32 @@ void *flagcxProxyService(void *args) {
         FLAGCXCHECKGOTO(flagcxSocketInit(newSock), res, out);
         res = flagcxSocketAccept(newSock, &comm->proxyState->listenSock);
         if (res == flagcxSuccess) {
-          pollfds[1 + slot].fd = newSock->fd;
-          pollfds[1 + slot].events = POLLIN;
-          INFO(FLAGCX_PROXY, "[Service thread] Accepted connection at slot %d",
-               slot);
+          pollfds[slot].fd = newSock->fd;
+          pollfds[slot].events = POLLIN;
+          npeers++;
+          INFO(FLAGCX_PROXY,
+               "[Service thread] Accepted connection at slot %d (npeers=%d)",
+               slot, npeers);
         }
+      } else {
+        WARN("[Service thread] No free slot for new connection (npeers=%d)",
+             npeers);
       }
     }
 
-    // Check all connected sockets
-    for (int i = 0; i < nConns && !stop; i++) {
-      if (pollfds[1 + i].revents & POLLIN) {
+    // Check all peer slots
+    for (int i = 0; i < maxConns && !stop; i++) {
+      if (pollfds[i].fd == -1)
+        continue;
+      if (pollfds[i].revents & POLLIN) {
         if (!processSocket(&connSocks[i])) {
           // Connection closed — close socket and mark fd as invalid
           flagcxSocketClose(&connSocks[i]);
-          pollfds[1 + i].fd = -1;
+          pollfds[i].fd = -1;
+          npeers--;
+          INFO(FLAGCX_PROXY,
+               "[Service thread] Closed connection at slot %d (npeers=%d)", i,
+               npeers);
         }
       }
     }
@@ -1246,8 +1255,8 @@ out:
   free(allocatedConns);
 
   // Close sockets (skip already-closed ones marked with fd = -1)
-  for (int i = 0; i < nConns; i++) {
-    if (pollfds[1 + i].fd != -1) {
+  for (int i = 0; i < maxConns; i++) {
+    if (pollfds[i].fd != -1) {
       flagcxSocketClose(&connSocks[i]);
     }
   }
@@ -1625,10 +1634,11 @@ flagcxResult_t flagcxProxyDestroy(struct flagcxHeteroComm *comm) {
       }
       (void)flagcxSocketSend(&sock, &type, sizeof(int));
     }
-    (void)flagcxSocketClose(&sock);
     comm->proxyState->kernelState.stop = 1;
     INFO(FLAGCX_PROXY, "flagcxProxyDestroy: joining service thread...");
     pthread_join(comm->proxyState->thread, nullptr);
+    // Close stop socket after service thread exits to avoid broken pipe
+    (void)flagcxSocketClose(&sock);
     INFO(FLAGCX_PROXY, "flagcxProxyDestroy: service thread joined, freeing...");
     flagcxProxyFree(comm);
     INFO(FLAGCX_PROXY, "flagcxProxyDestroy: done");

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -174,7 +174,7 @@ proxyConnInit(struct flagcxProxyLocalPeer *peer,
        "transport %d",
        (*connection)->send ? "send" : "recv", id, (*connection)->tpLocalRank,
        (*connection)->transport);
-  (*connection)->state = connInitialized;
+  __atomic_store_n(&(*connection)->state, connInitialized, __ATOMIC_RELEASE);
   return flagcxSuccess;
 }
 
@@ -660,6 +660,7 @@ proxyProgressAsync(struct flagcxProxyLocalPeer *peer, flagcxProxyAsyncOp *op,
                    struct flagcxProxyConnectionPool *connectionPool,
                    struct flagcxHeteroComm *comm) {
   int done = 0;
+  flagcxResult_t res = flagcxSuccess;
   const char *dmaBufEnable = flagcxGetEnv("FLAGCX_DMABUF_ENABLE");
   bool dmaEnabled = false; // disabled by default
   if (dmaBufEnable != NULL) {
@@ -674,7 +675,7 @@ proxyProgressAsync(struct flagcxProxyLocalPeer *peer, flagcxProxyAsyncOp *op,
   dmaBufferSupport = dmaEnabled && dmaBufferSupport;
   if (op->type == flagcxProxyMsgInit) {
     // Allocate connection from pool
-    flagcxResult_t res = proxyConnInit(
+    res = proxyConnInit(
         peer, connectionPool, comm, (struct flagcxProxyInitReq *)op->reqBuff,
         (struct flagcxProxyInitResp *)op->respBuff, &op->connection);
     if (res != flagcxSuccess)
@@ -890,7 +891,10 @@ proxyProgressAsync(struct flagcxProxyLocalPeer *peer, flagcxProxyAsyncOp *op,
          "done",
          op->opId, op->type, op->reqBuff, op->respSize);
     if (op->connection->transport == TRANSPORT_NET) {
-      if (op->type == flagcxProxyMsgConnect)
+      if (op->type == flagcxProxyMsgSetup)
+        __atomic_store_n(&op->connection->state, connSetupDone,
+                         __ATOMIC_RELEASE);
+      else if (op->type == flagcxProxyMsgConnect)
         __atomic_store_n(&op->connection->state, connConnected,
                          __ATOMIC_RELEASE);
     }
@@ -900,7 +904,7 @@ proxyProgressAsync(struct flagcxProxyLocalPeer *peer, flagcxProxyAsyncOp *op,
      * If we still choose to abort and close the connection, it can cause
      * segfault if the requester is using the respBuff. */
 
-    flagcxProxyRpcResponseHeader resp = {op->opId, flagcxSuccess, op->respSize};
+    flagcxProxyRpcResponseHeader resp = {op->opId, res, op->respSize};
 
     // Send the opId for referencing async operation
     FLAGCXCHECK(flagcxSocketSend(op->connection->sock, &resp, sizeof(resp)));
@@ -913,6 +917,9 @@ proxyProgressAsync(struct flagcxProxyLocalPeer *peer, flagcxProxyAsyncOp *op,
     asyncProxyOpDequeue(peer, op);
     (*asyncOpCount)--;
     return flagcxSuccess;
+  } else if (comm->abortFlag &&
+             __atomic_load_n(comm->abortFlag, __ATOMIC_ACQUIRE) != 0) {
+    return flagcxInternalError;
   }
 
   return flagcxInProgress;
@@ -952,25 +959,33 @@ static flagcxResult_t
 proxyServiceInitOp(int type, struct flagcxProxyLocalPeer *peer,
                    struct flagcxProxyConnectionPool *connectionPool,
                    flagcxHeteroComm_t comm, int *asyncOpCount) {
+  flagcxResult_t ret = flagcxSuccess;
   struct flagcxSocket *sock = &peer->sock;
   struct flagcxProxyAsyncOp *asyncOp;
   FLAGCXCHECK(flagcxCalloc(&asyncOp, 1));
 
   asyncOp->type = type;
-  FLAGCXCHECK(flagcxSocketRecv(sock, &asyncOp->connection, sizeof(void *)));
+  FLAGCXCHECKGOTO(flagcxSocketRecv(sock, &asyncOp->connection, sizeof(void *)),
+                  ret, fail);
 
-  FLAGCXCHECK(flagcxSocketRecv(sock, &asyncOp->reqSize, sizeof(int)));
-  FLAGCXCHECK(flagcxSocketRecv(sock, &asyncOp->respSize, sizeof(int)));
+  FLAGCXCHECKGOTO(flagcxSocketRecv(sock, &asyncOp->reqSize, sizeof(int)), ret,
+                  fail);
+  FLAGCXCHECKGOTO(flagcxSocketRecv(sock, &asyncOp->respSize, sizeof(int)), ret,
+                  fail);
   if (asyncOp->reqSize) {
-    FLAGCXCHECK(flagcxCalloc(&asyncOp->reqBuff, asyncOp->reqSize));
-    FLAGCXCHECK(flagcxSocketRecv(sock, asyncOp->reqBuff, asyncOp->reqSize));
+    FLAGCXCHECKGOTO(flagcxCalloc(&asyncOp->reqBuff, asyncOp->reqSize), ret,
+                    fail);
+    FLAGCXCHECKGOTO(flagcxSocketRecv(sock, asyncOp->reqBuff, asyncOp->reqSize),
+                    ret, fail);
   }
 
   // Store opId for completion response
-  FLAGCXCHECK(flagcxSocketRecv(sock, &asyncOp->opId, sizeof(asyncOp->opId)));
+  FLAGCXCHECKGOTO(flagcxSocketRecv(sock, &asyncOp->opId, sizeof(asyncOp->opId)),
+                  ret, fail);
 
   if (asyncOp->respSize)
-    FLAGCXCHECK(flagcxCalloc(&asyncOp->respBuff, asyncOp->respSize));
+    FLAGCXCHECKGOTO(flagcxCalloc(&asyncOp->respBuff, asyncOp->respSize), ret,
+                    fail);
 
   // For Init messages, connection is NULL (will be allocated from pool in
   // proxyProgressAsync). For other messages, set the socket on the connection.
@@ -978,11 +993,18 @@ proxyServiceInitOp(int type, struct flagcxProxyLocalPeer *peer,
     asyncOp->connection->sock = sock;
   }
 
-  FLAGCXCHECK(asyncProxyOpEnqueue(peer, asyncOp));
+  asyncProxyOpEnqueue(peer, asyncOp);
   (*asyncOpCount)++;
   FLAGCXCHECK(
       proxyProgressAsync(peer, asyncOp, asyncOpCount, connectionPool, comm));
   return flagcxSuccess;
+fail:
+  if (asyncOp->reqBuff)
+    free(asyncOp->reqBuff);
+  if (asyncOp->respBuff)
+    free(asyncOp->respBuff);
+  free(asyncOp);
+  return ret;
 }
 
 flagcxResult_t flagcxProxyCallBlocking(struct flagcxHeteroComm *comm,
@@ -1077,7 +1099,7 @@ flagcxResult_t flagcxProxyInit(struct flagcxHeteroComm *comm) {
   INFO(FLAGCX_INIT, "rank=%d flagcxProxyInit called.", comm->rank);
   FLAGCXCHECK(flagcxSocketInit(&comm->proxyState->listenSock,
                                &bootstrapNetIfAddr, comm->magic,
-                               flagcxSocketTypeProxy, NULL, 1));
+                               flagcxSocketTypeProxy, NULL, 0));
   FLAGCXCHECK(flagcxSocketListen(&comm->proxyState->listenSock));
 
   // Allgather proxy listen addresses
@@ -1266,26 +1288,10 @@ void *flagcxProxyService(void *args) {
       if (slot >= 0) {
         struct flagcxSocket *newSock = &peers[slot].sock;
         FLAGCXCHECKGOTO(flagcxSocketInit(newSock), res, out);
-        res = flagcxSocketAccept(newSock, &comm->proxyState->listenSock);
-        if (res == flagcxSuccess) {
-          // The listen socket has asyncFlag=1, which gets copied into newSock
-          // via memcpy in flagcxSocketAccept. This means the accept may return
-          // before the handshake (magic+type exchange) is complete. We must
-          // finish the handshake before adding the socket to the poll set,
-          // otherwise processSocket will read handshake bytes as proxy
-          // commands.
-          if (newSock->state != flagcxSocketStateReady) {
-            newSock->asyncFlag = 0; // force blocking to complete handshake
-            int ready = 0;
-            do {
-              FLAGCXCHECKGOTO(flagcxSocketReady(newSock, &ready), res, out);
-            } while (!ready && newSock->state != flagcxSocketStateError);
-            if (newSock->state != flagcxSocketStateReady) {
-              WARN("[Service thread] Socket handshake failed at slot %d", slot);
-              flagcxSocketClose(newSock);
-              continue;
-            }
-          }
+        if (flagcxSocketAccept(newSock, &comm->proxyState->listenSock) !=
+            flagcxSuccess) {
+          INFO(FLAGCX_PROXY, "[Service thread] Accept failed");
+        } else {
           pollfds[slot].fd = newSock->fd;
           pollfds[slot].events = POLLIN;
           peers[slot].tpRank = -1;

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -1683,24 +1683,24 @@ flagcxResult_t flagcxProxyStop(struct flagcxHeteroComm *comm) {
   }
 
   INFO(FLAGCX_PROXY, "flagcxProxyStop: sending stop to service thread...");
-  // 1. Send MsgStop to own service thread via listen socket
-  // 1984-1991)
-  struct flagcxSocket sock;
-  int type = flagcxProxyMsgStop;
-  FLAGCXCHECK(flagcxSocketInit(&sock, &comm->proxyState->listenSock.addr,
-                               comm->magic, flagcxSocketTypeProxy));
-  if (flagcxSocketConnect(&sock) == flagcxSuccess) {
-    int ready = 0;
-    while (!ready) {
-      (void)flagcxSocketReady(&sock, &ready);
+  // 1. Send MsgStop to own service thread via listen socket (best-effort)
+  {
+    struct flagcxSocket sock;
+    int type = flagcxProxyMsgStop;
+    if (flagcxSocketInit(&sock, &comm->proxyState->listenSock.addr, comm->magic,
+                         flagcxSocketTypeProxy) == flagcxSuccess) {
+      if (flagcxSocketConnect(&sock) == flagcxSuccess) {
+        int ready = 0;
+        while (!ready) {
+          (void)flagcxSocketReady(&sock, &ready);
+        }
+        (void)flagcxSocketSend(&sock, &type, sizeof(int));
+      }
+      (void)flagcxSocketClose(&sock);
     }
-    (void)flagcxSocketSend(&sock, &type, sizeof(int));
   }
-  (void)flagcxSocketClose(&sock);
 
-  // 2. Send MsgClose + close each peerSock
-  //    This tells peer service threads to close the accepted connection,
-  //    decrementing their npeers.
+  // 2. Send MsgClose + close each peerSock (best-effort)
   if (comm->proxyState->peerSocks != NULL) {
     for (int i = 0; i < comm->proxyState->nPeerSocks; i++) {
       if (comm->proxyState->peerSocks[i].fd >= 0) {
@@ -1712,11 +1712,10 @@ flagcxResult_t flagcxProxyStop(struct flagcxHeteroComm *comm) {
     }
   }
 
-  // 3. Set atomic stop flag
-  //    Backup: service thread checks this every 500ms poll timeout
+  // 3. Set atomic stop flag (unconditional — authoritative shutdown signal)
   __atomic_store_n(&comm->proxyState->stop, 1, __ATOMIC_RELEASE);
 
-  // 4. Signal kernel threads to stop
+  // 4. Signal kernel threads to stop (unconditional)
   comm->proxyState->kernelState.stop = 1;
   INFO(FLAGCX_PROXY, "flagcxProxyStop: done");
   return flagcxSuccess;

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -1020,7 +1020,8 @@ void *flagcxProxyService(void *args) {
   int maxnpeers = 0;
   struct flagcxProxyConnection **allocatedConns = NULL;
   int nAllocatedConns = 0;
-  FLAGCXCHECKGOTO(flagcxCalloc(&allocatedConns, comm->nRanks), res, out);
+  int maxAllocatedConns = comm->nRanks * MAXCHANNELS * 2;
+  FLAGCXCHECKGOTO(flagcxCalloc(&allocatedConns, maxAllocatedConns), res, out);
 
   // Set device context
   FLAGCXCHECKGOTO(deviceAdaptor->setDevice(comm->cudaDev), res, out);
@@ -1148,6 +1149,12 @@ void *flagcxProxyService(void *args) {
           newConn->sock = sock;
 
           asyncOp->connection = newConn;
+          if (nAllocatedConns >= maxAllocatedConns) {
+            WARN("[Service thread] allocatedConns overflow (%d >= %d)",
+                 nAllocatedConns, maxAllocatedConns);
+            initRes = flagcxInternalError;
+            goto initFail;
+          }
           allocatedConns[nAllocatedConns++] = newConn;
           FLAGCXCHECKGOTO(flagcxCalloc(&asyncOp->respBuff, asyncOp->respSize),
                           initRes, initFail);
@@ -1293,7 +1300,8 @@ out:
     for (int c = 0; c < MAXCHANNELS; c++) {
       if (comm->channels[c].peers[peer]->recv[0].connected == 1) {
         struct flagcxConnector *conn = comm->channels[c].peers[peer]->recv;
-        if (conn->proxyConn.connection->transport == TRANSPORT_P2P) {
+        if (conn->proxyConn.connection &&
+            conn->proxyConn.connection->transport == TRANSPORT_P2P) {
           struct flagcxP2pResources *resources =
               (struct flagcxP2pResources *)
                   conn->proxyConn.connection->transportResources;
@@ -1302,7 +1310,8 @@ out:
       }
       if (comm->channels[c].peers[peer]->send[0].connected == 1) {
         struct flagcxConnector *conn = comm->channels[c].peers[peer]->send;
-        if (conn->proxyConn.connection->transport == TRANSPORT_P2P) {
+        if (conn->proxyConn.connection &&
+            conn->proxyConn.connection->transport == TRANSPORT_P2P) {
           struct flagcxP2pResources *resources =
               (struct flagcxP2pResources *)
                   conn->proxyConn.connection->transportResources;
@@ -1312,9 +1321,8 @@ out:
     }
   }
 
-  // Free allocated proxy connections
-  for (int i = 0; i < nAllocatedConns; i++)
-    free(allocatedConns[i]);
+  // Connection structs are freed by flagcxProxyFree after service thread exits.
+  // Only free the tracking array here.
   free(allocatedConns);
 
   // Close sockets and drain any remaining async ops
@@ -1652,24 +1660,30 @@ flagcxResult_t flagcxProxyFree(struct flagcxHeteroComm *comm) {
     for (int c = 0; c < MAXCHANNELS; c++) {
       if (comm->channels[c].peers[peer]->recv[0].connected == 1) {
         struct flagcxConnector *conn = comm->channels[c].peers[peer]->recv;
-        int transport = conn->proxyConn.connection->transport;
-
-        if (transport == TRANSPORT_NET) {
-          struct recvNetResources *resources =
-              (struct recvNetResources *)
-                  conn->proxyConn.connection->transportResources;
-          flagcxRecvProxyFree(resources);
+        if (conn->proxyConn.connection) {
+          int transport = conn->proxyConn.connection->transport;
+          if (transport == TRANSPORT_NET) {
+            struct recvNetResources *resources =
+                (struct recvNetResources *)
+                    conn->proxyConn.connection->transportResources;
+            flagcxRecvProxyFree(resources);
+          }
+          free(conn->proxyConn.connection);
+          conn->proxyConn.connection = NULL;
         }
       }
       if (comm->channels[c].peers[peer]->send[0].connected == 1) {
         struct flagcxConnector *conn = comm->channels[c].peers[peer]->send;
-        int transport = conn->proxyConn.connection->transport;
-
-        if (transport == TRANSPORT_NET) {
-          struct sendNetResources *resources =
-              (struct sendNetResources *)
-                  conn->proxyConn.connection->transportResources;
-          flagcxSendProxyFree(resources);
+        if (conn->proxyConn.connection) {
+          int transport = conn->proxyConn.connection->transport;
+          if (transport == TRANSPORT_NET) {
+            struct sendNetResources *resources =
+                (struct sendNetResources *)
+                    conn->proxyConn.connection->transportResources;
+            flagcxSendProxyFree(resources);
+          }
+          free(conn->proxyConn.connection);
+          conn->proxyConn.connection = NULL;
         }
       }
     }

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -92,6 +92,134 @@ static flagcxResult_t asyncProxyOpDequeue(struct flagcxProxyLocalPeer *peer,
   return flagcxSuccess;
 }
 
+// ============================================================
+// Proxy Init Request/Response (forward declarations for connection pool)
+// ============================================================
+
+struct flagcxProxyInitReq {
+  int transport;
+  int send;
+  int tpLocalRank;
+  int tpRank;
+  int sameProcess;
+};
+
+struct flagcxProxyInitResp {
+  flagcxProxyConnection *connection;
+};
+
+// ============================================================
+// Connection Pool
+// ============================================================
+
+#define FLAGCX_PROXY_CONN_POOL_SIZE_POW2 7
+#define FLAGCX_PROXY_CONN_POOL_SIZE (1 << (FLAGCX_PROXY_CONN_POOL_SIZE_POW2))
+#define FLAGCX_PROXY_CONN_POOL_MASK ((FLAGCX_PROXY_CONN_POOL_SIZE)-1)
+
+struct flagcxProxyConnectionPool {
+  struct flagcxProxyConnection **pools;
+  int banks;
+  int offset;
+};
+
+static flagcxResult_t
+flagcxProxyNewConnection(struct flagcxProxyConnectionPool *pool, int *id) {
+  if (pool->offset == FLAGCX_PROXY_CONN_POOL_SIZE) {
+    FLAGCXCHECK(flagcxRealloc(&pool->pools, pool->banks, pool->banks + 1));
+    FLAGCXCHECK(
+        flagcxCalloc(pool->pools + pool->banks, FLAGCX_PROXY_CONN_POOL_SIZE));
+    pool->banks++;
+    pool->offset = 0;
+  }
+  *id = ((pool->banks - 1) << FLAGCX_PROXY_CONN_POOL_SIZE_POW2) + pool->offset;
+  pool->offset++;
+  return flagcxSuccess;
+}
+
+static flagcxResult_t
+flagcxProxyGetConnection(struct flagcxProxyConnectionPool *pool, int id,
+                         struct flagcxProxyConnection **conn) {
+  int bank = id >> FLAGCX_PROXY_CONN_POOL_SIZE_POW2;
+  int offset = id & FLAGCX_PROXY_CONN_POOL_MASK;
+  if ((pool->pools == NULL) || (bank > pool->banks) ||
+      (pool->pools[bank] == NULL))
+    return flagcxInternalError;
+  *conn = pool->pools[bank] + offset;
+  return flagcxSuccess;
+}
+
+static flagcxResult_t
+proxyConnInit(struct flagcxProxyLocalPeer *peer,
+              struct flagcxProxyConnectionPool *connectionPool,
+              struct flagcxHeteroComm *comm, struct flagcxProxyInitReq *req,
+              struct flagcxProxyInitResp *resp,
+              struct flagcxProxyConnection **connection) {
+  int id;
+  FLAGCXCHECK(flagcxProxyNewConnection(connectionPool, &id));
+  FLAGCXCHECK(flagcxProxyGetConnection(connectionPool, id, connection));
+
+  (*connection)->sock = &peer->sock;
+  (*connection)->transport = req->transport;
+  (*connection)->send = req->send;
+  (*connection)->tpLocalRank = req->tpLocalRank;
+  (*connection)->sameProcess = req->sameProcess;
+  (*connection)->cudaDev = comm->cudaDev;
+  peer->tpLocalRank = req->tpLocalRank;
+  peer->tpRank = req->tpRank;
+
+  resp->connection = *connection;
+
+  INFO(FLAGCX_PROXY,
+       "[Service thread] New proxy %s connection %d from local rank %d, "
+       "transport %d",
+       (*connection)->send ? "send" : "recv", id, (*connection)->tpLocalRank,
+       (*connection)->transport);
+  (*connection)->state = connInitialized;
+  return flagcxSuccess;
+}
+
+static flagcxResult_t
+proxyFreeConnection(struct flagcxProxyConnection *connection,
+                    struct flagcxHeteroComm *comm) {
+  if (connection->transportResources) {
+    if (connection->transport == TRANSPORT_P2P) {
+      if (connection->send) {
+        flagcxP2pSendProxyFree(
+            (struct flagcxP2pResources *)connection->transportResources);
+      } else {
+        flagcxP2pRecvProxyFree(
+            (struct flagcxP2pResources *)connection->transportResources);
+      }
+    } else if (connection->transport == TRANSPORT_NET) {
+      if (connection->send) {
+        flagcxSendProxyFree(
+            (struct sendNetResources *)connection->transportResources);
+      } else {
+        flagcxRecvProxyFree(
+            (struct recvNetResources *)connection->transportResources);
+      }
+    }
+  }
+  return flagcxSuccess;
+}
+
+static flagcxResult_t
+flagcxProxyFreeConnections(struct flagcxProxyConnectionPool *pool,
+                           struct flagcxHeteroComm *comm) {
+  for (int b = 0; b < pool->banks; b++) {
+    int max = b == pool->banks - 1 ? pool->offset : FLAGCX_PROXY_CONN_POOL_SIZE;
+    for (int i = 0; i < max; i++) {
+      struct flagcxProxyConnection *connection = pool->pools[b] + i;
+      if (connection->state != connUninitialized) {
+        proxyFreeConnection(connection, comm);
+      }
+    }
+    free(pool->pools[b]);
+  }
+  free(pool->pools);
+  return flagcxSuccess;
+}
+
 static flagcxResult_t SaveProxy(struct flagcxHeteroComm *comm,
                                 struct flagcxChannel *channel, int type,
                                 int peer, struct flagcxProxyOp *op,
@@ -526,9 +654,11 @@ flagcxResult_t flagcxPollProxyResponse(struct flagcxHeteroComm *comm,
   return res;
 }
 
-static flagcxResult_t proxyProgressAsync(struct flagcxProxyLocalPeer *peer,
-                                         flagcxProxyAsyncOp *op,
-                                         int *asyncOpCount) {
+static flagcxResult_t
+proxyProgressAsync(struct flagcxProxyLocalPeer *peer, flagcxProxyAsyncOp *op,
+                   int *asyncOpCount,
+                   struct flagcxProxyConnectionPool *connectionPool,
+                   struct flagcxHeteroComm *comm) {
   int done = 0;
   const char *dmaBufEnable = flagcxGetEnv("FLAGCX_DMABUF_ENABLE");
   bool dmaEnabled = false; // disabled by default
@@ -542,7 +672,15 @@ static flagcxResult_t proxyProgressAsync(struct flagcxProxyLocalPeer *peer,
     deviceAdaptor->dmaSupport(&dmaBufferSupport);
   }
   dmaBufferSupport = dmaEnabled && dmaBufferSupport;
-  if (op->type == flagcxProxyMsgConnect) {
+  if (op->type == flagcxProxyMsgInit) {
+    // Allocate connection from pool
+    flagcxResult_t res = proxyConnInit(
+        peer, connectionPool, comm, (struct flagcxProxyInitReq *)op->reqBuff,
+        (struct flagcxProxyInitResp *)op->respBuff, &op->connection);
+    if (res != flagcxSuccess)
+      return res;
+    done = 1;
+  } else if (op->type == flagcxProxyMsgConnect) {
     TRACE(FLAGCX_PROXY,
           "proxyProgressAsync::flagcxProxyMsgConnect opId=%p op.reqBuff=%p, "
           "op->reqSize=%d, op->respSize=%d, transport=%d",
@@ -810,10 +948,10 @@ error:
   return ret;
 }
 
-static flagcxResult_t proxyServiceInitOp(int type,
-                                         struct flagcxProxyLocalPeer *peer,
-                                         flagcxHeteroComm_t comm,
-                                         int *asyncOpCount) {
+static flagcxResult_t
+proxyServiceInitOp(int type, struct flagcxProxyLocalPeer *peer,
+                   struct flagcxProxyConnectionPool *connectionPool,
+                   flagcxHeteroComm_t comm, int *asyncOpCount) {
   struct flagcxSocket *sock = &peer->sock;
   struct flagcxProxyAsyncOp *asyncOp;
   FLAGCXCHECK(flagcxCalloc(&asyncOp, 1));
@@ -831,13 +969,19 @@ static flagcxResult_t proxyServiceInitOp(int type,
   // Store opId for completion response
   FLAGCXCHECK(flagcxSocketRecv(sock, &asyncOp->opId, sizeof(asyncOp->opId)));
 
-  asyncOp->connection->sock = sock;
   if (asyncOp->respSize)
     FLAGCXCHECK(flagcxCalloc(&asyncOp->respBuff, asyncOp->respSize));
 
+  // For Init messages, connection is NULL (will be allocated from pool in
+  // proxyProgressAsync). For other messages, set the socket on the connection.
+  if (type != flagcxProxyMsgInit) {
+    asyncOp->connection->sock = sock;
+  }
+
   FLAGCXCHECK(asyncProxyOpEnqueue(peer, asyncOp));
   (*asyncOpCount)++;
-  FLAGCXCHECK(proxyProgressAsync(peer, asyncOp, asyncOpCount));
+  FLAGCXCHECK(
+      proxyProgressAsync(peer, asyncOp, asyncOpCount, connectionPool, comm));
   return flagcxSuccess;
 }
 
@@ -867,19 +1011,6 @@ fail:
 struct flagcxProxyKernelServiceArg {
   struct flagcxHeteroComm *comm;
   int contextId;
-};
-
-// Proxy init request/response for peer proxy connections
-struct flagcxProxyInitReq {
-  int transport;
-  int send;
-  int tpLocalRank;
-  int tpRank;
-  int sameProcess;
-};
-
-struct flagcxProxyInitResp {
-  flagcxProxyConnection *connection;
 };
 
 flagcxResult_t flagcxProxyConnect(struct flagcxHeteroComm *comm, int transport,
@@ -930,6 +1061,12 @@ flagcxResult_t flagcxProxyConnect(struct flagcxHeteroComm *comm, int transport,
   FLAGCXCHECK(flagcxProxyCallBlocking(comm, proxyConn, flagcxProxyMsgInit, &req,
                                       sizeof(req), &resp, sizeof(resp)));
   proxyConn->connection = resp.connection;
+  if (proxyConn->connection == NULL) {
+    WARN("flagcxProxyConnect: service thread returned NULL connection for rank "
+         "%d -> peer %d",
+         comm->rank, proxyRank);
+    return flagcxInternalError;
+  }
   INFO(FLAGCX_PROXY,
        "flagcxProxyConnect rank %d -> peer %d connection %p sameProcess %d",
        comm->rank, proxyRank, proxyConn->connection, proxyConn->sameProcess);
@@ -1018,10 +1155,12 @@ void *flagcxProxyService(void *args) {
       maxConns, sizeof(struct flagcxProxyLocalPeer));
   int npeers = 0;
   int maxnpeers = 0;
-  struct flagcxProxyConnection **allocatedConns = NULL;
-  int nAllocatedConns = 0;
-  int maxAllocatedConns = comm->nRanks * MAXCHANNELS * 2;
-  FLAGCXCHECKGOTO(flagcxCalloc(&allocatedConns, maxAllocatedConns), res, out);
+
+  // Connection pool — owns all connection structs
+  struct flagcxProxyConnectionPool connectionPool;
+  connectionPool.pools = NULL;
+  connectionPool.banks = 0;
+  connectionPool.offset = FLAGCX_PROXY_CONN_POOL_SIZE;
 
   // Set device context
   FLAGCXCHECKGOTO(deviceAdaptor->setDevice(comm->cudaDev), res, out);
@@ -1052,7 +1191,7 @@ void *flagcxProxyService(void *args) {
       break;
     }
 
-    // Progress async ops per-peer (NCCL-aligned)
+    // Progress async ops per-peer
     for (int i = 0; i < maxnpeers; i++) {
       if (pollfds[i].fd == -1)
         continue;
@@ -1060,7 +1199,8 @@ void *flagcxProxyService(void *args) {
       struct flagcxProxyAsyncOp *op = peer->asyncOps;
       while (op) {
         struct flagcxProxyAsyncOp *opNext = op->next;
-        res = proxyProgressAsync(peer, op, &asyncOpCount);
+        res =
+            proxyProgressAsync(peer, op, &asyncOpCount, &connectionPool, comm);
         if (res == flagcxSuccess || res == flagcxInProgress) {
           op = opNext;
         } else {
@@ -1093,108 +1233,9 @@ void *flagcxProxyService(void *args) {
         } else if (type == flagcxProxyMsgClose) {
           INFO(FLAGCX_PROXY, "[Service thread] Received close from peer");
           return false; // graceful close from peer
-        } else if (type == flagcxProxyMsgInit) {
-          // Peer proxy init: create a new flagcxProxyConnection
-          struct flagcxProxyAsyncOp *asyncOp = NULL;
-          flagcxResult_t initRes = flagcxSuccess;
-          void *dummyConn = NULL;
-          struct flagcxProxyConnection *newConn = NULL;
-          struct flagcxProxyInitReq *req = NULL;
-          flagcxProxyRpcResponseHeader resp = {};
-
-          FLAGCXCHECKGOTO(flagcxCalloc(&asyncOp, 1), initRes, initFail);
-          asyncOp->type = type;
-
-          // For Init, connection pointer sent is NULL — read and discard it
-          FLAGCXCHECKGOTO(flagcxSocketRecv(sock, &dummyConn, sizeof(void *)),
-                          initRes, initFail);
-          FLAGCXCHECKGOTO(
-              flagcxSocketRecv(sock, &asyncOp->reqSize, sizeof(int)), initRes,
-              initFail);
-          FLAGCXCHECKGOTO(
-              flagcxSocketRecv(sock, &asyncOp->respSize, sizeof(int)), initRes,
-              initFail);
-
-          // Validate sizes
-          if (asyncOp->reqSize != (int)sizeof(struct flagcxProxyInitReq)) {
-            WARN("[Service thread] Invalid reqSize %d for Init, expected %zu",
-                 asyncOp->reqSize, sizeof(struct flagcxProxyInitReq));
-            initRes = flagcxInvalidArgument;
-            goto initFail;
-          }
-          if (asyncOp->respSize != (int)sizeof(struct flagcxProxyInitResp)) {
-            WARN("[Service thread] Invalid respSize %d for Init, expected %zu",
-                 asyncOp->respSize, sizeof(struct flagcxProxyInitResp));
-            initRes = flagcxInvalidArgument;
-            goto initFail;
-          }
-
-          FLAGCXCHECKGOTO(flagcxCalloc(&asyncOp->reqBuff, asyncOp->reqSize),
-                          initRes, initFail);
-          FLAGCXCHECKGOTO(
-              flagcxSocketRecv(sock, asyncOp->reqBuff, asyncOp->reqSize),
-              initRes, initFail);
-          FLAGCXCHECKGOTO(
-              flagcxSocketRecv(sock, &asyncOp->opId, sizeof(asyncOp->opId)),
-              initRes, initFail);
-
-          // Create a new connection for this peer
-          FLAGCXCHECKGOTO(flagcxCalloc(&newConn, 1), initRes, initFail);
-          req = (struct flagcxProxyInitReq *)asyncOp->reqBuff;
-          newConn->transport = req->transport;
-          newConn->send = req->send;
-          newConn->tpLocalRank = req->tpLocalRank;
-          newConn->sameProcess = req->sameProcess;
-          newConn->cudaDev = comm->cudaDev;
-          newConn->sock = sock;
-
-          asyncOp->connection = newConn;
-          if (nAllocatedConns >= maxAllocatedConns) {
-            WARN("[Service thread] allocatedConns overflow (%d >= %d)",
-                 nAllocatedConns, maxAllocatedConns);
-            initRes = flagcxInternalError;
-            goto initFail;
-          }
-          allocatedConns[nAllocatedConns++] = newConn;
-          FLAGCXCHECKGOTO(flagcxCalloc(&asyncOp->respBuff, asyncOp->respSize),
-                          initRes, initFail);
-
-          // Fill response with the connection pointer
-          if (asyncOp->respSize >= (int)sizeof(void *)) {
-            memcpy(asyncOp->respBuff, &newConn, sizeof(void *));
-          }
-
-          INFO(FLAGCX_PROXY,
-               "[Service thread] Peer proxy init: transport=%d send=%d "
-               "tpLocalRank=%d sameProcess=%d conn=%p",
-               req->transport, req->send, req->tpLocalRank, req->sameProcess,
-               newConn);
-
-          // Send response immediately
-          resp.opId = asyncOp->opId;
-          resp.res = flagcxSuccess;
-          resp.respSize = asyncOp->respSize;
-          FLAGCXCHECKGOTO(flagcxSocketSend(sock, &resp, sizeof(resp)), initRes,
-                          initFail);
-          if (asyncOp->respSize) {
-            FLAGCXCHECKGOTO(
-                flagcxSocketSend(sock, asyncOp->respBuff, asyncOp->respSize),
-                initRes, initFail);
-          }
-          free(asyncOp->reqBuff);
-          free(asyncOp->respBuff);
-          free(asyncOp);
-          return true;
-
-        initFail:
-          if (asyncOp) {
-            free(asyncOp->reqBuff);
-            free(asyncOp->respBuff);
-            free(asyncOp);
-          }
-          return false;
         } else if (proxyMatchOpType(type)) {
-          res = proxyServiceInitOp(type, curPeer, comm, &asyncOpCount);
+          res = proxyServiceInitOp(type, curPeer, &connectionPool, comm,
+                                   &asyncOpCount);
           if (res != flagcxSuccess) {
             WARN("[Service thread] Error encountered initializing operation "
                  "with res=%d",
@@ -1227,6 +1268,24 @@ void *flagcxProxyService(void *args) {
         FLAGCXCHECKGOTO(flagcxSocketInit(newSock), res, out);
         res = flagcxSocketAccept(newSock, &comm->proxyState->listenSock);
         if (res == flagcxSuccess) {
+          // The listen socket has asyncFlag=1, which gets copied into newSock
+          // via memcpy in flagcxSocketAccept. This means the accept may return
+          // before the handshake (magic+type exchange) is complete. We must
+          // finish the handshake before adding the socket to the poll set,
+          // otherwise processSocket will read handshake bytes as proxy
+          // commands.
+          if (newSock->state != flagcxSocketStateReady) {
+            newSock->asyncFlag = 0; // force blocking to complete handshake
+            int ready = 0;
+            do {
+              FLAGCXCHECKGOTO(flagcxSocketReady(newSock, &ready), res, out);
+            } while (!ready && newSock->state != flagcxSocketStateError);
+            if (newSock->state != flagcxSocketStateReady) {
+              WARN("[Service thread] Socket handshake failed at slot %d", slot);
+              flagcxSocketClose(newSock);
+              continue;
+            }
+          }
           pollfds[slot].fd = newSock->fd;
           pollfds[slot].events = POLLIN;
           peers[slot].tpRank = -1;
@@ -1257,7 +1316,7 @@ void *flagcxProxyService(void *args) {
           closeConn = true;
       }
       if (closeConn) {
-        // Drain any remaining async ops for this peer (NCCL-aligned)
+        // Drain any remaining async ops for this peer
         while (peers[i].asyncOps) {
           asyncProxyOpDequeue(&peers[i], peers[i].asyncOps);
           asyncOpCount--;
@@ -1294,37 +1353,6 @@ out:
   pthread_cond_destroy(&comm->proxyState->kernelState.initCond);
 #endif
 
-  // Free P2P resources in proxy thread (CUDA resources must be freed in the
-  // same thread where they were created)
-  for (int peer = 0; peer < comm->nRanks; peer++) {
-    for (int c = 0; c < MAXCHANNELS; c++) {
-      if (comm->channels[c].peers[peer]->recv[0].connected == 1) {
-        struct flagcxConnector *conn = comm->channels[c].peers[peer]->recv;
-        if (conn->proxyConn.connection &&
-            conn->proxyConn.connection->transport == TRANSPORT_P2P) {
-          struct flagcxP2pResources *resources =
-              (struct flagcxP2pResources *)
-                  conn->proxyConn.connection->transportResources;
-          flagcxP2pRecvProxyFree(resources);
-        }
-      }
-      if (comm->channels[c].peers[peer]->send[0].connected == 1) {
-        struct flagcxConnector *conn = comm->channels[c].peers[peer]->send;
-        if (conn->proxyConn.connection &&
-            conn->proxyConn.connection->transport == TRANSPORT_P2P) {
-          struct flagcxP2pResources *resources =
-              (struct flagcxP2pResources *)
-                  conn->proxyConn.connection->transportResources;
-          flagcxP2pSendProxyFree(resources);
-        }
-      }
-    }
-  }
-
-  // Connection structs are freed by flagcxProxyFree after service thread exits.
-  // Only free the tracking array here.
-  free(allocatedConns);
-
   // Close sockets and drain any remaining async ops
   for (int i = 0; i < maxConns; i++) {
     if (pollfds[i].fd != -1) {
@@ -1334,6 +1362,11 @@ out:
       flagcxSocketClose(&peers[i].sock);
     }
   }
+
+  // Free all connections from pool (all resource cleanup happens
+  // inside the service thread before it exits)
+  flagcxProxyFreeConnections(&connectionPool, comm);
+
   flagcxSocketClose(&comm->proxyState->listenSock);
   free(pollfds);
   free(peers);
@@ -1656,35 +1689,16 @@ out:
 }
 
 flagcxResult_t flagcxProxyFree(struct flagcxHeteroComm *comm) {
+  // Connection structs and transport resources are now freed by the service
+  // thread via flagcxProxyFreeConnections. We only NULL out
+  // the pointers here to prevent dangling references.
   for (int peer = 0; peer < comm->nRanks; peer++) {
     for (int c = 0; c < MAXCHANNELS; c++) {
       if (comm->channels[c].peers[peer]->recv[0].connected == 1) {
-        struct flagcxConnector *conn = comm->channels[c].peers[peer]->recv;
-        if (conn->proxyConn.connection) {
-          int transport = conn->proxyConn.connection->transport;
-          if (transport == TRANSPORT_NET) {
-            struct recvNetResources *resources =
-                (struct recvNetResources *)
-                    conn->proxyConn.connection->transportResources;
-            flagcxRecvProxyFree(resources);
-          }
-          free(conn->proxyConn.connection);
-          conn->proxyConn.connection = NULL;
-        }
+        comm->channels[c].peers[peer]->recv[0].proxyConn.connection = NULL;
       }
       if (comm->channels[c].peers[peer]->send[0].connected == 1) {
-        struct flagcxConnector *conn = comm->channels[c].peers[peer]->send;
-        if (conn->proxyConn.connection) {
-          int transport = conn->proxyConn.connection->transport;
-          if (transport == TRANSPORT_NET) {
-            struct sendNetResources *resources =
-                (struct sendNetResources *)
-                    conn->proxyConn.connection->transportResources;
-            flagcxSendProxyFree(resources);
-          }
-          free(conn->proxyConn.connection);
-          conn->proxyConn.connection = NULL;
-        }
+        comm->channels[c].peers[peer]->send[0].proxyConn.connection = NULL;
       }
     }
   }

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -983,13 +983,14 @@ void *flagcxProxyService(void *args) {
   struct flagcxProxyAsyncOp *list = NULL;
   flagcxResult_t res = flagcxSuccess;
 
-  // Peer slots [0..maxConns-1], listen socket at [maxConns] (NCCL pattern)
+  // Peer slots [0..maxConns-1], listen socket at [maxConns]
   int maxConns = comm->nRanks + 1;
   struct pollfd *pollfds =
       (struct pollfd *)calloc(maxConns + 1, sizeof(struct pollfd));
   struct flagcxSocket *connSocks =
       (struct flagcxSocket *)calloc(maxConns, sizeof(struct flagcxSocket));
   int npeers = 0;
+  int maxnpeers = 0;
   struct flagcxProxyConnection **allocatedConns = NULL;
   int nAllocatedConns = 0;
   FLAGCXCHECKGOTO(flagcxCalloc(&allocatedConns, comm->nRanks), res, out);
@@ -1005,7 +1006,7 @@ void *flagcxProxyService(void *args) {
   pollfds[maxConns].fd = comm->proxyState->listenSock.fd;
   pollfds[maxConns].events = POLLIN;
 
-  while (!stop || (stop && opHead)) {
+  while (!stop || npeers > 0) {
     int ret;
     do {
       ret = poll(pollfds, maxConns + 1, asyncOpCount ? 0 : 500);
@@ -1046,7 +1047,10 @@ void *flagcxProxyService(void *args) {
       } else if (res == flagcxSuccess) {
         if (type == flagcxProxyMsgStop) {
           stop = 1;
-          return true;
+          return false; // close the stop socket
+        } else if (type == flagcxProxyMsgClose) {
+          INFO(FLAGCX_PROXY, "[Service thread] Received close from peer");
+          return false; // graceful close from peer
         } else if (type == flagcxProxyMsgInit) {
           // Peer proxy init: create a new flagcxProxyConnection
           struct flagcxProxyAsyncOp *asyncOp = NULL;
@@ -1178,6 +1182,8 @@ void *flagcxProxyService(void *args) {
           pollfds[slot].fd = newSock->fd;
           pollfds[slot].events = POLLIN;
           npeers++;
+          if (maxnpeers < slot + 1)
+            maxnpeers = slot + 1;
           INFO(FLAGCX_PROXY,
                "[Service thread] Accepted connection at slot %d (npeers=%d)",
                slot, npeers);
@@ -1188,24 +1194,28 @@ void *flagcxProxyService(void *args) {
       }
     }
 
-    // Check all peer slots
-    for (int i = 0; i < maxConns && !stop; i++) {
+    // Check all peer slots (only up to high-water mark)
+    for (int i = 0; i < maxnpeers; i++) {
       if (pollfds[i].fd == -1)
         continue;
-      if (pollfds[i].revents & POLLIN) {
-        if (!processSocket(&connSocks[i])) {
-          // Connection closed — close socket and mark fd as invalid
-          flagcxSocketClose(&connSocks[i]);
-          pollfds[i].fd = -1;
-          npeers--;
-          INFO(FLAGCX_PROXY,
-               "[Service thread] Closed connection at slot %d (npeers=%d)", i,
-               npeers);
-        }
+      bool closeConn = false;
+      if (pollfds[i].revents & (POLLHUP | POLLERR)) {
+        closeConn = true;
+      } else if (pollfds[i].revents & POLLIN) {
+        if (!processSocket(&connSocks[i]))
+          closeConn = true;
+      }
+      if (closeConn) {
+        flagcxSocketClose(&connSocks[i]);
+        pollfds[i].fd = -1;
+        npeers--;
+        INFO(FLAGCX_PROXY,
+             "[Service thread] Closed connection at slot %d (npeers=%d)", i,
+             npeers);
       }
     }
 
-    if (stop && !opHead)
+    if (stop && npeers == 0)
       break;
   }
 out:
@@ -1619,29 +1629,61 @@ flagcxResult_t flagcxProxyFree(struct flagcxHeteroComm *comm) {
   return flagcxSuccess;
 }
 
+flagcxResult_t flagcxProxyStop(struct flagcxHeteroComm *comm) {
+  if (comm->proxyState->initialized != 1) {
+    return flagcxSuccess;
+  }
+
+  INFO(FLAGCX_PROXY, "flagcxProxyStop: sending stop to service thread...");
+  // 1. Send stop to own service thread via listen socket
+  struct flagcxSocket sock;
+  int type = flagcxProxyMsgStop;
+  FLAGCXCHECK(flagcxSocketInit(&sock, &comm->proxyState->listenSock.addr,
+                               comm->magic, flagcxSocketTypeProxy));
+  if (flagcxSocketConnect(&sock) == flagcxSuccess) {
+    int ready = 0;
+    while (!ready) {
+      (void)flagcxSocketReady(&sock, &ready);
+    }
+    (void)flagcxSocketSend(&sock, &type, sizeof(int));
+  }
+  (void)flagcxSocketClose(&sock);
+
+  // 2. Send Close + close each peerSock (tells peer service threads to
+  //    close the accepted connection, decrementing their npeers)
+  if (comm->proxyState->peerSocks != NULL) {
+    for (int i = 0; i < comm->proxyState->nPeerSocks; i++) {
+      if (comm->proxyState->peerSocks[i].fd >= 0) {
+        int type = flagcxProxyMsgClose;
+        (void)flagcxSocketSend(&comm->proxyState->peerSocks[i], &type,
+                               sizeof(int));
+        flagcxSocketClose(&comm->proxyState->peerSocks[i]);
+      }
+    }
+  }
+
+  // 3. Signal kernel threads to stop
+  comm->proxyState->kernelState.stop = 1;
+  INFO(FLAGCX_PROXY, "flagcxProxyStop: done");
+  return flagcxSuccess;
+}
+
 flagcxResult_t flagcxProxyDestroy(struct flagcxHeteroComm *comm) {
   if (comm->proxyState->initialized == 1) {
-    INFO(FLAGCX_PROXY, "flagcxProxyDestroy: sending stop to service thread...");
-    // Send stop via a temporary socket to own listenSock (like NCCL)
-    struct flagcxSocket sock;
-    int type = flagcxProxyMsgStop;
-    FLAGCXCHECK(flagcxSocketInit(&sock, &comm->proxyState->listenSock.addr,
-                                 comm->magic, flagcxSocketTypeProxy));
-    if (flagcxSocketConnect(&sock) == flagcxSuccess) {
-      int ready = 0;
-      while (!ready) {
-        (void)flagcxSocketReady(&sock, &ready);
-      }
-      (void)flagcxSocketSend(&sock, &type, sizeof(int));
-    }
-    comm->proxyState->kernelState.stop = 1;
     INFO(FLAGCX_PROXY, "flagcxProxyDestroy: joining service thread...");
     pthread_join(comm->proxyState->thread, nullptr);
-    // Close stop socket after service thread exits to avoid broken pipe
-    (void)flagcxSocketClose(&sock);
     INFO(FLAGCX_PROXY, "flagcxProxyDestroy: service thread joined, freeing...");
     flagcxProxyFree(comm);
     INFO(FLAGCX_PROXY, "flagcxProxyDestroy: done");
+  }
+  // Free heap arrays (sockets already closed by flagcxProxyStop)
+  if (comm->proxyState->peerSocks != NULL) {
+    free(comm->proxyState->peerSocks);
+    comm->proxyState->peerSocks = NULL;
+  }
+  if (comm->proxyState->peerAddresses != NULL) {
+    free(comm->proxyState->peerAddresses);
+    comm->proxyState->peerAddresses = NULL;
   }
   return flagcxSuccess;
 }

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -325,13 +325,13 @@ inline void *flagcxProxyProgress(void *proxyState_) {
   struct flagcxProxyState *proxyState = (flagcxProxyState *)proxyState_;
   // flag indicating if there is any in-operating operation
   int idle = 1;
-  /* Too frequent call of ncclProxyGetPostedOps() will result in perf regression
-   * for small message communication. proxyOpAppendCounter is a counter that
-   * helps us decide if we need to append proxy ops. After each progress,
-   * proxyOpAppendCounter will increase by 1 and compare with environment
-   * variable ncclParamProgressAppendOpFreq(). If they are equal, we will append
-   * proxy ops. This will decrease the frequency of calling
-   * ncclProxyGetPostedOps() and reduce the perf impact. */
+  /* Too frequent call of flagcxProxyGetPostedOps() will result in perf
+   * regression for small message communication. proxyOpAppendCounter is a
+   * counter that helps us decide if we need to append proxy ops. After each
+   * progress, proxyOpAppendCounter will increase by 1 and compare with
+   * environment variable flagcxParamProgressAppendOpFreq(). If they are equal,
+   * we will append proxy ops. This will decrease the frequency of calling
+   * flagcxProxyGetPostedOps() and reduce the perf impact. */
   int proxyOpAppendCounter = 0;
   deviceAdaptor->setDevice(proxyState->cudaDev);
   struct flagcxProxyProgressState *state = &proxyState->progressState;
@@ -894,9 +894,26 @@ flagcxResult_t flagcxProxyConnect(struct flagcxHeteroComm *comm, int transport,
   proxyConn->tpRank = proxyRank;
   proxyConn->tpLocalRank = 0;
 
-  // peerSocks must already be allocated and connected during init
-  if (comm->proxyState->peerSocks == NULL)
-    return flagcxInternalError;
+  // Lazy peerSocks allocation
+  struct flagcxProxyState *sharedProxyState = comm->proxyState;
+  if (sharedProxyState->peerSocks == NULL) {
+    FLAGCXCHECK(flagcxCalloc(&sharedProxyState->peerSocks, comm->nRanks));
+    sharedProxyState->nPeerSocks = comm->nRanks;
+    for (int i = 0; i < comm->nRanks; i++)
+      FLAGCXCHECK(flagcxSocketSetFd(-1, &sharedProxyState->peerSocks[i]));
+  }
+  // Lazy connect to peer
+  {
+    struct flagcxSocket *sock = &sharedProxyState->peerSocks[proxyRank];
+    int ready = 0;
+    FLAGCXCHECK(flagcxSocketReady(sock, &ready));
+    if (!ready) {
+      FLAGCXCHECK(flagcxSocketInit(sock,
+                                   sharedProxyState->peerAddresses + proxyRank,
+                                   comm->magic, flagcxSocketTypeProxy));
+      FLAGCXCHECK(flagcxSocketConnect(sock));
+    }
+  }
 
   struct flagcxProxyInitReq req = {};
   req.transport = transport;
@@ -932,24 +949,6 @@ flagcxResult_t flagcxProxyInit(struct flagcxHeteroComm *comm) {
   FLAGCXCHECK(bootstrapAllGather(comm->bootstrap,
                                  comm->proxyState->peerAddresses,
                                  sizeof(union flagcxSocketAddress)));
-
-  // Pre-connect all peer sockets (including self)
-  // TODO: support lazy connection
-  FLAGCXCHECK(flagcxCalloc(&comm->proxyState->peerSocks, comm->nRanks));
-  comm->proxyState->nPeerSocks = comm->nRanks;
-  for (int i = 0; i < comm->nRanks; i++) {
-    FLAGCXCHECK(flagcxSocketSetFd(-1, &comm->proxyState->peerSocks[i]));
-  }
-  for (int i = 0; i < comm->nRanks; i++) {
-    struct flagcxSocket *sock = &comm->proxyState->peerSocks[i];
-    FLAGCXCHECK(flagcxSocketInit(sock, comm->proxyState->peerAddresses + i,
-                                 comm->magic, flagcxSocketTypeProxy));
-    FLAGCXCHECK(flagcxSocketConnect(sock));
-    int ready = 0;
-    while (!ready) {
-      FLAGCXCHECK(flagcxSocketReady(sock, &ready));
-    }
-  }
 
   comm->proxyState->cudaDev = comm->cudaDev;
   comm->proxyState->nRanks = comm->nRanks;

--- a/flagcx/core/transport.cc
+++ b/flagcx/core/transport.cc
@@ -41,20 +41,10 @@ flagcxResult_t flagcxTransportP2pSetup(struct flagcxHeteroComm *comm,
           INFO(FLAGCX_P2P,
                "P2P Recv setup: rank %d <- peer %d channel %d (same node)",
                comm->rank, peer, c);
-          FLAGCXCHECK(flagcxCalloc(&conn->proxyConn.connection, 1));
+          FLAGCXCHECK(flagcxProxyConnect(comm, TRANSPORT_P2P, 0, comm->rank,
+                                         &conn->proxyConn));
           struct flagcxP2pResources *resources;
           FLAGCXCHECK(flagcxCalloc(&resources, 1));
-          conn->proxyConn.connection->transport = TRANSPORT_P2P;
-          conn->proxyConn.connection->send = 0;
-          conn->proxyConn.connection->cudaDev = comm->cudaDev;
-          conn->proxyConn.connection->sameProcess =
-              (comm->peerInfo != NULL &&
-               comm->peerInfo[peer].hostHash ==
-                   comm->peerInfo[comm->rank].hostHash &&
-               comm->peerInfo[peer].pidHash ==
-                   comm->peerInfo[comm->rank].pidHash)
-                  ? 1
-                  : 0;
           conn->proxyConn.connection->transportResources = (void *)resources;
           if (peer != comm->rank) {
             struct flagcxP2pRequest req = {(size_t(flagcxP2pBufferSize)), 0};
@@ -64,8 +54,7 @@ flagcxResult_t flagcxTransportP2pSetup(struct flagcxHeteroComm *comm,
             FLAGCXCHECK(flagcxProxyCallBlocking(
                 comm, &conn->proxyConn, flagcxProxyMsgSetup, &req, sizeof(req),
                 &connectInfo.p2pBuff, sizeof(connectInfo.p2pBuff)));
-            // Use the buffer directly without offset， it's equal to nccl
-            // p2pMap function
+            // Use the buffer directly without offset
             char *recvBuffer = (char *)connectInfo.p2pBuff.directPtr;
             conn->conn.buffs[FLAGCX_PROTO_SIMPLE] = recvBuffer;
             FLAGCXCHECK(bootstrapSend(comm->bootstrap, peer, 2000 + c,
@@ -75,11 +64,10 @@ flagcxResult_t flagcxTransportP2pSetup(struct flagcxHeteroComm *comm,
           INFO(FLAGCX_NET,
                "NET Recv setup: rank %d <- peer %d channel %d (different node)",
                comm->rank, peer, c);
-          FLAGCXCHECK(flagcxCalloc(&conn->proxyConn.connection, 1));
+          FLAGCXCHECK(flagcxProxyConnect(comm, TRANSPORT_NET, 0, comm->rank,
+                                         &conn->proxyConn));
           struct recvNetResources *resources;
           FLAGCXCHECK(flagcxCalloc(&resources, 1));
-          conn->proxyConn.connection->transport = TRANSPORT_NET;
-          conn->proxyConn.connection->send = 0;
           conn->proxyConn.connection->transportResources = (void *)resources;
           resources->netDev = comm->netDev;
           resources->netAdaptor = comm->netAdaptor;
@@ -129,20 +117,10 @@ flagcxResult_t flagcxTransportP2pSetup(struct flagcxHeteroComm *comm,
           INFO(FLAGCX_P2P,
                "P2P Send setup: rank %d -> peer %d channel %d (same node)",
                comm->rank, peer, c);
-          FLAGCXCHECK(flagcxCalloc(&conn->proxyConn.connection, 1));
+          FLAGCXCHECK(flagcxProxyConnect(comm, TRANSPORT_P2P, 1, comm->rank,
+                                         &conn->proxyConn));
           struct flagcxP2pResources *resources;
           FLAGCXCHECK(flagcxCalloc(&resources, 1));
-          conn->proxyConn.connection->transport = TRANSPORT_P2P;
-          conn->proxyConn.connection->send = 1;
-          conn->proxyConn.connection->cudaDev = comm->cudaDev;
-          conn->proxyConn.connection->sameProcess =
-              (comm->peerInfo != NULL &&
-               comm->peerInfo[peer].hostHash ==
-                   comm->peerInfo[comm->rank].hostHash &&
-               comm->peerInfo[peer].pidHash ==
-                   comm->peerInfo[comm->rank].pidHash)
-                  ? 1
-                  : 0;
           conn->proxyConn.connection->transportResources = (void *)resources;
           if (peer != comm->rank) {
             struct flagcxP2pConnectInfo connectInfo = {0};
@@ -170,11 +148,10 @@ flagcxResult_t flagcxTransportP2pSetup(struct flagcxHeteroComm *comm,
           INFO(FLAGCX_NET,
                "NET Send setup: rank %d -> peer %d channel %d (different node)",
                comm->rank, peer, c);
-          FLAGCXCHECK(flagcxCalloc(&conn->proxyConn.connection, 1));
+          FLAGCXCHECK(flagcxProxyConnect(comm, TRANSPORT_NET, 1, comm->rank,
+                                         &conn->proxyConn));
           struct sendNetResources *resources;
           FLAGCXCHECK(flagcxCalloc(&resources, 1));
-          conn->proxyConn.connection->send = 1;
-          conn->proxyConn.connection->transport = TRANSPORT_NET;
           conn->proxyConn.connection->transportResources = (void *)resources;
           resources->netDev = comm->netDev;
           resources->netAdaptor = comm->netAdaptor;

--- a/test/unittest/runner/main_mpi.cpp
+++ b/test/unittest/runner/main_mpi.cpp
@@ -77,6 +77,9 @@ void FlagCXCollTest::TearDown() {
 
   flagcxHandleFree(handler);
   FlagCXTest::TearDown();
+
+  // Synchronize all ranks before the next test to prevent bootstrap hangs
+  MPI_Barrier(MPI_COMM_WORLD);
 }
 
 // ---------- main ----------


### PR DESCRIPTION
### PR Category
CRL

### PR Types
Bug Fixes

### PR Description
This PR updates the proxy service thread’s accept logic to reuse previously closed connection slots (identified by pollfds[].fd == -1), which should prevent hangs during proxy teardown when the stop connection can’t be accepted due to exhausted slot indices.