### PR TITLE
Make sure FlagCX can be compiled on non-NVIDIA platforms

### DIFF
--- a/flagcx/adaptor/include/nvidia_adaptor.h
+++ b/flagcx/adaptor/include/nvidia_adaptor.h
@@ -22,6 +22,8 @@ struct flagcxInnerDevComm {};
 
 #endif // NCCL_VERSION_CODE > NCCL_VERSION(2, 28, 0)
 
+#define FLAGCX_INNER_WINDOW_DEFINED
+
 #if NCCL_VERSION_CODE > NCCL_VERSION(2, 27, 0)
 
 struct flagcxInnerWindow {

--- a/flagcx/core/include/sym_heap.h
+++ b/flagcx/core/include/sym_heap.h
@@ -12,6 +12,13 @@
 #include "comm.h"
 #include "flagcx.h"
 
+#ifndef FLAGCX_INNER_WINDOW_DEFINED
+#define FLAGCX_INNER_WINDOW_DEFINED
+struct flagcxInnerWindow {
+  int winFlags;
+};
+#endif
+
 /* Concrete definition of the opaque flagcxWindow handle.
  * Internal only — external code must treat flagcxWindow_t as opaque. */
 struct flagcxWindow {


### PR DESCRIPTION
### PR Category

Others

### PR Types

Bug Fix

### PR Description

When compiling FlagCX on non-NVIDIA platforms, there is an error about the `flagcxInnerWindow` not defined. This PR fixes the problem.