### PR TITLE
[CRL] Deprecate flagcxHandlerGroup, separate device handle/uniqueId/comm lifecycle

### DIFF
--- a/flagcx/adaptor/include/device_api/sunrise_comm_traits.h
+++ b/flagcx/adaptor/include/device_api/sunrise_comm_traits.h
@@ -7,13 +7,6 @@
 #ifndef FLAGCX_SUNRISE_COMM_TRAITS_H_
 #define FLAGCX_SUNRISE_COMM_TRAITS_H_
 
-// Sunrise/PCCL inner-type stubs: never populated at runtime on the
-// sunrise path; only here to satisfy public type signatures.
-struct flagcxInnerWindow {
-  int winFlags;
-};
-struct flagcxInnerDevComm {};
-
 // Sunrise default backend: reuse Default<DefaultPlatform> (IPC barriers +
 // FIFO one-sided). PCCL/PTPU already provide collectives, so FlagCX needs
 // no SIMT kernels of its own.

--- a/flagcx/adaptor/include/sunrise_adaptor.h
+++ b/flagcx/adaptor/include/sunrise_adaptor.h
@@ -7,6 +7,12 @@
 #include "tang.h"
 #include "tang_runtime.h"
 #include <map>
+
+struct flagcxInnerWindow {
+  int winFlags;
+};
+struct flagcxInnerDevComm {};
+
 struct flagcxInnerComm {
   pcclComm_t base;
 };

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -156,44 +156,57 @@ bool useHeteroComm() {
   return false;
 }
 
-flagcxResult_t flagcxHandleInit(flagcxHandlerGroup_t *handler) {
+flagcxResult_t flagcxDeviceHandleInit(flagcxDeviceHandle_t *devHandle) {
   flagcxResult_t res = flagcxSuccess;
   flagcxDeviceAdaptorPluginInit();
   flagcxCCLAdaptorPluginInit();
-  (*handler) = NULL;
-  FLAGCXCHECKGOTO(flagcxCalloc(handler, 1), res, fail);
-  FLAGCXCHECKGOTO(flagcxCalloc(&(*handler)->uniqueId, 1), res, fail);
-  // comm left NULL — allocated by flagcxCommInitRank
-  FLAGCXCHECKGOTO(flagcxCalloc(&(*handler)->devHandle, 1), res, fail);
-  *(*handler)->devHandle = globalDeviceHandle;
+  (*devHandle) = NULL;
+  FLAGCXCHECKGOTO(flagcxCalloc(devHandle, 1), res, fail);
+  **devHandle = globalDeviceHandle;
   return flagcxSuccess;
 
 fail:
-  if (*handler) {
-    free((*handler)->uniqueId);
-    free((*handler)->devHandle);
-    free(*handler);
-    *handler = NULL;
+  if (*devHandle) {
+    free(*devHandle);
+    *devHandle = NULL;
   }
   flagcxCCLAdaptorPluginFinalize();
   flagcxDeviceAdaptorPluginFinalize();
   return res;
 }
 
-flagcxResult_t flagcxHandleFree(flagcxHandlerGroup_t handler) {
-  if (handler != NULL) {
-    if (handler->uniqueId)
-      free(handler->uniqueId);
-    if (handler->devHandle)
-      free(handler->devHandle);
-    handler->uniqueId = NULL;
-    handler->comm = NULL;
-    handler->devHandle = NULL;
-    free(handler);
-    handler = NULL;
+flagcxResult_t flagcxDeviceHandleFree(flagcxDeviceHandle_t devHandle) {
+  if (devHandle != NULL) {
+    free(devHandle);
   }
   flagcxCCLAdaptorPluginFinalize();
   flagcxDeviceAdaptorPluginFinalize();
+  return flagcxSuccess;
+}
+
+flagcxResult_t flagcxHandleInit(flagcxHandlerGroup_t *handler) {
+  flagcxResult_t res = flagcxSuccess;
+  (*handler) = NULL;
+  FLAGCXCHECKGOTO(flagcxCalloc(handler, 1), res, fail);
+  FLAGCXCHECKGOTO(flagcxDeviceHandleInit(&(*handler)->devHandle), res, fail);
+  return flagcxSuccess;
+
+fail:
+  if (*handler) {
+    free(*handler);
+    *handler = NULL;
+  }
+  return res;
+}
+
+flagcxResult_t flagcxHandleFree(flagcxHandlerGroup_t handler) {
+  if (handler != NULL) {
+    flagcxDeviceHandleFree(handler->devHandle);
+    handler->devHandle = NULL;
+    handler->uniqueId = NULL;
+    handler->comm = NULL;
+    free(handler);
+  }
   return flagcxSuccess;
 }
 
@@ -1180,10 +1193,10 @@ flagcxResult_t flagcxGetVersion(int *version) {
   return flagcxHeteroGetVersion(version);
 }
 
-flagcxResult_t flagcxGetUniqueId(flagcxUniqueId_t *uniqueId) {
-  // Allocate if caller passed a NULL pointer
-  if (*uniqueId == nullptr) {
-    FLAGCXCHECK(flagcxCalloc(uniqueId, 1));
+flagcxResult_t flagcxGetUniqueId(flagcxUniqueId_t uniqueId) {
+  if (uniqueId == NULL) {
+    WARN("flagcxGetUniqueId: uniqueId is NULL");
+    return flagcxInvalidArgument;
   }
 
   // Init bootstrap net
@@ -1194,9 +1207,9 @@ flagcxResult_t flagcxGetUniqueId(flagcxUniqueId_t *uniqueId) {
   FLAGCXCHECK(bootstrapGetUniqueId(&handle));
   // flagcxUniqueId and bootstrapHandle don't have the same size and alignment
   // reset to 0 to avoid undefined data
-  memset((void *)*uniqueId, 0, sizeof(**uniqueId));
+  memset((void *)uniqueId, 0, sizeof(*uniqueId));
   // copy to avoid alignment mismatch
-  memcpy((void *)*uniqueId, &handle, sizeof(handle));
+  memcpy((void *)uniqueId, &handle, sizeof(handle));
   return flagcxSuccess;
 }
 
@@ -1523,6 +1536,10 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
     WARN("Invalid rank requested : %d/%d", rank, nranks);
     return flagcxInvalidArgument;
   }
+
+  // Ensure device/CCL plugins are loaded (idempotent, ref-counted)
+  flagcxDeviceAdaptorPluginInit();
+  flagcxCCLAdaptorPluginInit();
 
   (*comm) = NULL;
   flagcxCalloc(comm, 1);
@@ -2019,6 +2036,10 @@ flagcxResult_t flagcxCommDestroy(flagcxComm_t comm) {
 
   // Finalize net adaptor plugin (dlclose)
   FLAGCXCHECK(flagcxNetAdaptorPluginFinalize());
+
+  // Finalize device/CCL adaptor plugins (ref-counted)
+  flagcxCCLAdaptorPluginFinalize();
+  flagcxDeviceAdaptorPluginFinalize();
 
   free(comm);
   return flagcxSuccess;

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -157,6 +157,10 @@ bool useHeteroComm() {
 }
 
 flagcxResult_t flagcxDeviceHandleInit(flagcxDeviceHandle_t *devHandle) {
+  if (devHandle == NULL) {
+    WARN("flagcxDeviceHandleInit: devHandle is NULL");
+    return flagcxInvalidArgument;
+  }
   flagcxResult_t res = flagcxSuccess;
   flagcxDeviceAdaptorPluginInit();
   flagcxCCLAdaptorPluginInit();
@@ -176,9 +180,9 @@ fail:
 }
 
 flagcxResult_t flagcxDeviceHandleFree(flagcxDeviceHandle_t devHandle) {
-  if (devHandle != NULL) {
-    free(devHandle);
-  }
+  if (devHandle == NULL)
+    return flagcxSuccess;
+  free(devHandle);
   flagcxCCLAdaptorPluginFinalize();
   flagcxDeviceAdaptorPluginFinalize();
   return flagcxSuccess;
@@ -1536,6 +1540,10 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
     WARN("Invalid rank requested : %d/%d", rank, nranks);
     return flagcxInvalidArgument;
   }
+  if (commId == NULL || comm == NULL) {
+    WARN("flagcxCommInitRank: commId or comm is NULL");
+    return flagcxInvalidArgument;
+  }
 
   // Ensure device/CCL plugins are loaded (idempotent, ref-counted)
   flagcxDeviceAdaptorPluginInit();
@@ -1746,7 +1754,8 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
   INFO(FLAGCX_INIT, "Flagcx USE_TUNER flag set to %d", useTuner);
   if (useTuner) {
     (*comm)->tuner = &internalTuner;
-    (*comm)->commId = commId;
+    FLAGCXCHECK(flagcxCalloc(&(*comm)->commId, 1));
+    memcpy((*comm)->commId, commId, sizeof(flagcxUniqueId));
     (*comm)->uniqueIdData = uniqueIdData;
     (*comm)->tunerInnerComm = NULL;
     (*comm)->isTunningComm = false;
@@ -2030,8 +2039,9 @@ flagcxResult_t flagcxCommDestroy(flagcxComm_t comm) {
   // Destroy tuner
   if (comm->tuner) {
     comm->tuner->destroy(comm->tunerContext);
-    // Free uniqueIdData
+    // Free uniqueIdData and commId
     free(comm->uniqueIdData);
+    free(comm->commId);
   }
 
   // Finalize net adaptor plugin (dlclose)

--- a/flagcx/include/flagcx.h
+++ b/flagcx/include/flagcx.h
@@ -174,6 +174,17 @@ struct flagcxDeviceHandle {
 };
 typedef struct flagcxDeviceHandle *flagcxDeviceHandle_t;
 
+/* Initialize device handle — loads device/CCL adaptor plugins, returns a
+ * populated device handle. Call before flagcxCommInitRank if you need device
+ * operations (setDevice, getDeviceCount, streamCreate, etc.) early.
+ * If not called explicitly, flagcxCommInitRank will load plugins internally. */
+flagcxResult_t flagcxDeviceHandleInit(flagcxDeviceHandle_t *devHandle);
+
+/* Free device handle — finalizes device/CCL adaptor plugins. */
+flagcxResult_t flagcxDeviceHandleFree(flagcxDeviceHandle_t devHandle);
+
+/* Deprecated: use flagcxDeviceHandleInit/Free and manage comm/uniqueId
+ * separately */
 struct flagcxHandlerGroup {
   flagcxUniqueId_t uniqueId;
   flagcxComm_t comm;
@@ -181,9 +192,10 @@ struct flagcxHandlerGroup {
 };
 typedef struct flagcxHandlerGroup *flagcxHandlerGroup_t;
 
-/* Init and free FlagCX handls including flagcxComm_t, flagcxStream_t */
+/* Deprecated: use flagcxDeviceHandleInit instead */
 flagcxResult_t flagcxHandleInit(flagcxHandlerGroup_t *handler);
 
+/* Deprecated: use flagcxDeviceHandleFree instead */
 flagcxResult_t flagcxHandleFree(flagcxHandlerGroup_t handler);
 
 /* User buffer registration functions. The actual allocated size might
@@ -224,8 +236,9 @@ flagcxResult_t flagcxGetVersion(int *version);
 
 /* Generates an Id to be used in flagcxCommInitRank. flagcxGetUniqueId should be
  * called once and the Id should be distributed to all ranks in the
- * communicator before calling flagcxCommInitRank. */
-flagcxResult_t flagcxGetUniqueId(flagcxUniqueId_t *uniqueId);
+ * communicator before calling flagcxCommInitRank.
+ * The caller must provide a valid pointer to a flagcxUniqueId struct. */
+flagcxResult_t flagcxGetUniqueId(flagcxUniqueId_t uniqueId);
 
 /* Creates a new communicator (multi thread/process version).
  * rank must be between 0 and nranks-1 and unique within a communicator clique.

--- a/plugin/interservice/flagcx_wrapper.py
+++ b/plugin/interservice/flagcx_wrapper.py
@@ -21,7 +21,6 @@ flagcxMemType_t = ctypes.c_int
 flagcxEventType_t = ctypes.c_int
 flagcxIpcMemHandle_t = ctypes.c_void_p
 
-flagcxHandlerGroup_t = ctypes.c_void_p
 flagcxComm_t = ctypes.c_void_p
 flagcxEvent_t = ctypes.c_void_p
 flagcxStream_t = ctypes.c_void_p
@@ -212,15 +211,15 @@ class Function:
 
 class FLAGCXLibrary:
     exported_functions = [
-        Function("flagcxHandleInit", flagcxResult_t,
-                [ctypes.POINTER(flagcxHandlerGroup_t)]),
-        Function("flagcxHandleFree", flagcxResult_t,
-                [flagcxHandlerGroup_t]),
+        Function("flagcxDeviceHandleInit", flagcxResult_t,
+                [ctypes.POINTER(flagcxDeviceHandle_t)]),
+        Function("flagcxDeviceHandleFree", flagcxResult_t,
+                [flagcxDeviceHandle_t]),
         Function("flagcxGetErrorString", ctypes.c_char_p, [flagcxResult_t]),
         Function("flagcxGetVersion", flagcxResult_t,
                  [ctypes.POINTER(ctypes.c_int)]),
         Function("flagcxGetUniqueId", flagcxResult_t,
-                [ctypes.POINTER(ctypes.POINTER(flagcxUniqueId))]),
+                [ctypes.POINTER(flagcxUniqueId)]),
         # Note that flagcxComm_t is a pointer type, so the first argument
         # is a pointer to a pointer
         Function("flagcxCommInitRank", flagcxResult_t, [
@@ -432,13 +431,13 @@ class FLAGCXLibrary:
             FLAGCXLibrary.path_to_dict_mapping[so_file] = _funcs
         self._funcs = FLAGCXLibrary.path_to_dict_mapping[so_file]
 
-        # init flagcx handler to call device-related apis
-        self.handler = flagcxHandlerGroup_t()
-        self.FLAGCX_CHECK(self._funcs["flagcxHandleInit"](ctypes.byref(self.handler)))
-    
+        # init flagcx device handle to call device-related apis
+        self.devHandle = flagcxDeviceHandle_t()
+        self.FLAGCX_CHECK(self._funcs["flagcxDeviceHandleInit"](ctypes.byref(self.devHandle)))
+
     def __del__(self):
-        # free flagcx handler
-        self.FLAGCX_CHECK(self._funcs["flagcxHandleFree"](self.handler))
+        # free flagcx device handle
+        self.FLAGCX_CHECK(self._funcs["flagcxDeviceHandleFree"](self.devHandle))
 
     def flagcxGetErrorString(self, result: flagcxResult_t) -> str:
         return self._funcs["flagcxGetErrorString"](result).decode("utf-8")
@@ -459,7 +458,7 @@ class FLAGCXLibrary:
         return f"{major}.{minor}.{patch}"
 
     def flagcxGetUniqueId(self) -> flagcxUniqueId:
-        unique_id = ctypes.POINTER(flagcxUniqueId)()
+        unique_id = flagcxUniqueId()
         self.FLAGCX_CHECK(self._funcs["flagcxGetUniqueId"](
             ctypes.byref(unique_id)))
         return unique_id
@@ -715,26 +714,26 @@ class FLAGCXLibrary:
 
     def adaptor_stream_create(self):
         new_stream = flagcxStream_t()
-        self.FLAGCX_CHECK(self.handler.contents.devHandle.contents.streamCreate(ctypes.byref(new_stream)))
+        self.FLAGCX_CHECK(self.devHandle.contents.streamCreate(ctypes.byref(new_stream)))
         return new_stream
 
     def adaptor_stream_copy(self, old_stream):
         new_stream = flagcxStream_t()
         raw_stream = getattr(old_stream, 'musa_stream', old_stream.cuda_stream)
-        self.FLAGCX_CHECK(self.handler.contents.devHandle.contents.streamCopy(ctypes.byref(new_stream), ctypes.c_void_p(raw_stream)))
+        self.FLAGCX_CHECK(self.devHandle.contents.streamCopy(ctypes.byref(new_stream), ctypes.c_void_p(raw_stream)))
         return new_stream
 
     def adaptor_stream_free(self, stream):
-        self.FLAGCX_CHECK(self.handler.contents.devHandle.contents.streamFree(stream))
+        self.FLAGCX_CHECK(self.devHandle.contents.streamFree(stream))
 
     def adaptor_stream_destroy(self, stream):
-        self.FLAGCX_CHECK(self.handler.contents.devHandle.contents.streamDestroy(stream))
+        self.FLAGCX_CHECK(self.devHandle.contents.streamDestroy(stream))
     
     def sync_stream(self, stream):
-        self.FLAGCX_CHECK(self.handler.contents.devHandle.contents.streamSynchronize(stream))
+        self.FLAGCX_CHECK(self.devHandle.contents.streamSynchronize(stream))
 
 
 __all__ = [
     "FLAGCXLibrary", "flagcxDataTypeEnum", "flagcxRedOpTypeEnum", "flagcxUniqueId",
-    "flagcxHandlerGroup_t", "flagcxComm_t", "flagcxStream_t", "flagcxEvent_t", "buffer_type"
+    "flagcxDeviceHandle_t", "flagcxComm_t", "flagcxStream_t", "flagcxEvent_t", "buffer_type"
 ]

--- a/plugin/interservice/flagcx_wrapper.py
+++ b/plugin/interservice/flagcx_wrapper.py
@@ -485,7 +485,7 @@ class FLAGCXLibrary:
                          rank: int) -> flagcxComm_t:
         comm = flagcxComm_t()
         self.FLAGCX_CHECK(self._funcs["flagcxCommInitRank"](ctypes.byref(comm),
-                                                        world_size, unique_id,
+                                                        world_size, ctypes.byref(unique_id),
                                                         rank))
         return comm
 

--- a/plugin/nccl/src/nccl_wrapper.cc
+++ b/plugin/nccl/src/nccl_wrapper.cc
@@ -165,7 +165,8 @@ static realNccl &getRealNccl() {
  * ────────────────────────────────────────────────────────────────────── */
 
 struct ncclComm {
-  flagcxHandlerGroup_t handler; // handler group (uniqueId, comm, devHandle)
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
   int rank;
   int nranks;
   flagcxResult_t asyncError;
@@ -332,7 +333,7 @@ const char *ncclGetLastError(ncclComm_t comm) {
   recursionGuard guard(inWrapper);
   if (comm == nullptr)
     return nullptr;
-  return flagcxGetLastError(comm->handler->comm);
+  return flagcxGetLastError(comm->comm);
 }
 
 /* ──────────────────────────────────────────────────────────────────────
@@ -347,7 +348,7 @@ ncclResult_t ncclGetUniqueId(ncclUniqueId *uniqueId) {
   if (uniqueId == nullptr)
     return ncclInvalidArgument;
 
-  flagcxUniqueId_t flagcxId = nullptr;
+  flagcxUniqueId flagcxId;
   flagcxResult_t res = flagcxGetUniqueId(&flagcxId);
   if (res != flagcxSuccess) {
     return toNcclResult(res);
@@ -356,9 +357,8 @@ ncclResult_t ncclGetUniqueId(ncclUniqueId *uniqueId) {
   /* flagcxBootstrapHandle fits in NCCL_UNIQUE_ID_BYTES (128).
    * Copy the first 128 bytes of the 256-byte flagcxUniqueId. */
   memset(uniqueId, 0, sizeof(ncclUniqueId));
-  memcpy(uniqueId->internal, flagcxId->internal, NCCL_UNIQUE_ID_BYTES);
+  memcpy(uniqueId->internal, flagcxId.internal, NCCL_UNIQUE_ID_BYTES);
 
-  free(flagcxId);
   return ncclSuccess;
 }
 
@@ -379,8 +379,8 @@ ncclResult_t ncclCommInitRank(ncclComm_t *comm, int nranks, ncclUniqueId commId,
   if (c == nullptr)
     return ncclSystemError;
 
-  /* Init FlagCX handler group */
-  flagcxResult_t res = flagcxHandleInit(&c->handler);
+  /* Init FlagCX device handle */
+  flagcxResult_t res = flagcxDeviceHandleInit(&c->devHandle);
   if (res != flagcxSuccess) {
     free(c);
     return toNcclResult(res);
@@ -388,14 +388,14 @@ ncclResult_t ncclCommInitRank(ncclComm_t *comm, int nranks, ncclUniqueId commId,
 
   /* Reconstruct a flagcxUniqueId from the NCCL 128-byte id.
    * Zero-init the full 256-byte struct, then copy in the 128-byte handle. */
-  memset(c->handler->uniqueId, 0, sizeof(flagcxUniqueId));
-  memcpy(c->handler->uniqueId->internal, commId.internal, NCCL_UNIQUE_ID_BYTES);
+  flagcxUniqueId uniqueId;
+  memset(&uniqueId, 0, sizeof(flagcxUniqueId));
+  memcpy(uniqueId.internal, commId.internal, NCCL_UNIQUE_ID_BYTES);
 
   /* Init the FlagCX communicator */
-  res =
-      flagcxCommInitRank(&c->handler->comm, nranks, c->handler->uniqueId, rank);
+  res = flagcxCommInitRank(&c->comm, nranks, &uniqueId, rank);
   if (res != flagcxSuccess) {
-    flagcxHandleFree(c->handler);
+    flagcxDeviceHandleFree(c->devHandle);
     free(c);
     return toNcclResult(res);
   }
@@ -424,7 +424,7 @@ ncclResult_t ncclCommFinalize(ncclComm_t comm) {
   recursionGuard guard(inWrapper);
   if (comm == nullptr)
     return ncclInvalidArgument;
-  return toNcclResult(flagcxCommFinalize(comm->handler->comm));
+  return toNcclResult(flagcxCommFinalize(comm->comm));
 }
 
 ncclResult_t ncclCommDestroy(ncclComm_t comm) {
@@ -434,10 +434,10 @@ ncclResult_t ncclCommDestroy(ncclComm_t comm) {
   recursionGuard guard(inWrapper);
   if (comm == nullptr)
     return ncclInvalidArgument;
-  flagcxResult_t res = flagcxCommDestroy(comm->handler->comm);
-  /* flagcxCommDestroy frees the comm struct. flagcxHandleFree frees the
-   * remaining handler members (uniqueId, devHandle) and the handler itself. */
-  flagcxHandleFree(comm->handler);
+  flagcxResult_t res = flagcxCommDestroy(comm->comm);
+  /* flagcxCommDestroy finalizes plugins. flagcxDeviceHandleFree frees the
+   * device handle and decrements plugin ref counts. */
+  flagcxDeviceHandleFree(comm->devHandle);
   free(comm);
   return toNcclResult(res);
 }
@@ -449,8 +449,8 @@ ncclResult_t ncclCommAbort(ncclComm_t comm) {
   recursionGuard guard(inWrapper);
   if (comm == nullptr)
     return ncclInvalidArgument;
-  flagcxResult_t res = flagcxCommAbort(comm->handler->comm);
-  flagcxHandleFree(comm->handler);
+  flagcxResult_t res = flagcxCommAbort(comm->comm);
+  flagcxDeviceHandleFree(comm->devHandle);
   free(comm);
   return toNcclResult(res);
 }
@@ -466,7 +466,7 @@ ncclResult_t ncclCommCount(const ncclComm_t comm, int *count) {
   recursionGuard guard(inWrapper);
   if (comm == nullptr)
     return ncclInvalidArgument;
-  return toNcclResult(flagcxCommCount(comm->handler->comm, count));
+  return toNcclResult(flagcxCommCount(comm->comm, count));
 }
 
 ncclResult_t ncclCommCuDevice(const ncclComm_t comm, int *device) {
@@ -476,7 +476,7 @@ ncclResult_t ncclCommCuDevice(const ncclComm_t comm, int *device) {
   recursionGuard guard(inWrapper);
   if (comm == nullptr)
     return ncclInvalidArgument;
-  return toNcclResult(flagcxCommGetDeviceNumber(comm->handler->comm, device));
+  return toNcclResult(flagcxCommGetDeviceNumber(comm->comm, device));
 }
 
 ncclResult_t ncclCommUserRank(const ncclComm_t comm, int *rank) {
@@ -486,7 +486,7 @@ ncclResult_t ncclCommUserRank(const ncclComm_t comm, int *rank) {
   recursionGuard guard(inWrapper);
   if (comm == nullptr)
     return ncclInvalidArgument;
-  return toNcclResult(flagcxCommUserRank(comm->handler->comm, rank));
+  return toNcclResult(flagcxCommUserRank(comm->comm, rank));
 }
 
 ncclResult_t ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t *asyncError) {
@@ -497,8 +497,7 @@ ncclResult_t ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t *asyncError) {
   if (comm == nullptr)
     return ncclInvalidArgument;
   flagcxResult_t flagcxAsync;
-  flagcxResult_t res =
-      flagcxCommGetAsyncError(comm->handler->comm, &flagcxAsync);
+  flagcxResult_t res = flagcxCommGetAsyncError(comm->comm, &flagcxAsync);
   if (res != flagcxSuccess)
     return toNcclResult(res);
   *asyncError = toNcclResult(flagcxAsync);
@@ -517,8 +516,7 @@ ncclResult_t ncclCommRegister(const ncclComm_t comm, void *buff, size_t size,
   recursionGuard guard(inWrapper);
   if (comm == nullptr)
     return ncclInvalidArgument;
-  return toNcclResult(
-      flagcxCommRegister(comm->handler->comm, buff, size, handle));
+  return toNcclResult(flagcxCommRegister(comm->comm, buff, size, handle));
 }
 
 ncclResult_t ncclCommDeregister(const ncclComm_t comm, void *handle) {
@@ -528,7 +526,7 @@ ncclResult_t ncclCommDeregister(const ncclComm_t comm, void *handle) {
   recursionGuard guard(inWrapper);
   if (comm == nullptr)
     return ncclInvalidArgument;
-  return toNcclResult(flagcxCommDeregister(comm->handler->comm, handle));
+  return toNcclResult(flagcxCommDeregister(comm->comm, handle));
 }
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 27, 3)
@@ -542,7 +540,7 @@ ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void *buff, size_t size,
   if (comm == nullptr)
     return ncclInvalidArgument;
   return toNcclResult(flagcxCommWindowRegister(
-      comm->handler->comm, buff, size, (flagcxWindow_t *)win, winFlags));
+      comm->comm, buff, size, (flagcxWindow_t *)win, winFlags));
 }
 
 ncclResult_t ncclCommWindowDeregister(ncclComm_t comm, ncclWindow_t win) {
@@ -553,7 +551,7 @@ ncclResult_t ncclCommWindowDeregister(ncclComm_t comm, ncclWindow_t win) {
   if (comm == nullptr)
     return ncclInvalidArgument;
   return toNcclResult(
-      flagcxCommWindowDeregister(comm->handler->comm, (flagcxWindow_t)win));
+      flagcxCommWindowDeregister(comm->comm, (flagcxWindow_t)win));
 }
 #endif
 
@@ -620,7 +618,7 @@ ncclResult_t ncclAllReduce(const void *sendbuff, void *recvbuff, size_t count,
     return r;
   FlagcxStreamWrapper sw(stream);
   return toNcclResult(flagcxAllReduce(sendbuff, recvbuff, count, fType, fOp,
-                                      comm->handler->comm, sw.stream));
+                                      comm->comm, sw.stream));
 }
 
 ncclResult_t ncclBroadcast(const void *sendbuff, void *recvbuff, size_t count,
@@ -639,7 +637,7 @@ ncclResult_t ncclBroadcast(const void *sendbuff, void *recvbuff, size_t count,
     return r;
   FlagcxStreamWrapper sw(stream);
   return toNcclResult(flagcxBroadcast(sendbuff, recvbuff, count, fType, root,
-                                      comm->handler->comm, sw.stream));
+                                      comm->comm, sw.stream));
 }
 
 ncclResult_t ncclReduce(const void *sendbuff, void *recvbuff, size_t count,
@@ -661,7 +659,7 @@ ncclResult_t ncclReduce(const void *sendbuff, void *recvbuff, size_t count,
     return r;
   FlagcxStreamWrapper sw(stream);
   return toNcclResult(flagcxReduce(sendbuff, recvbuff, count, fType, fOp, root,
-                                   comm->handler->comm, sw.stream));
+                                   comm->comm, sw.stream));
 }
 
 ncclResult_t ncclAllGather(const void *sendbuff, void *recvbuff,
@@ -680,7 +678,7 @@ ncclResult_t ncclAllGather(const void *sendbuff, void *recvbuff,
     return r;
   FlagcxStreamWrapper sw(stream);
   return toNcclResult(flagcxAllGather(sendbuff, recvbuff, sendcount, fType,
-                                      comm->handler->comm, sw.stream));
+                                      comm->comm, sw.stream));
 }
 
 ncclResult_t ncclReduceScatter(const void *sendbuff, void *recvbuff,
@@ -703,7 +701,7 @@ ncclResult_t ncclReduceScatter(const void *sendbuff, void *recvbuff,
     return r;
   FlagcxStreamWrapper sw(stream);
   return toNcclResult(flagcxReduceScatter(sendbuff, recvbuff, recvcount, fType,
-                                          fOp, comm->handler->comm, sw.stream));
+                                          fOp, comm->comm, sw.stream));
 }
 
 /* ──────────────────────────────────────────────────────────────────────
@@ -726,7 +724,7 @@ ncclResult_t ncclSend(const void *sendbuff, size_t count,
     return r;
   FlagcxStreamWrapper sw(stream);
   return toNcclResult(
-      flagcxSend(sendbuff, count, fType, peer, comm->handler->comm, sw.stream));
+      flagcxSend(sendbuff, count, fType, peer, comm->comm, sw.stream));
 }
 
 ncclResult_t ncclRecv(void *recvbuff, size_t count, ncclDataType_t datatype,
@@ -744,7 +742,7 @@ ncclResult_t ncclRecv(void *recvbuff, size_t count, ncclDataType_t datatype,
     return r;
   FlagcxStreamWrapper sw(stream);
   return toNcclResult(
-      flagcxRecv(recvbuff, count, fType, peer, comm->handler->comm, sw.stream));
+      flagcxRecv(recvbuff, count, fType, peer, comm->comm, sw.stream));
 }
 
 /* ──────────────────────────────────────────────────────────────────────

--- a/plugin/torch/flagcx/include/backend_flagcx.hpp
+++ b/plugin/torch/flagcx/include/backend_flagcx.hpp
@@ -33,14 +33,14 @@ class flagcxWork : public Work {
 
 public:
   flagcxWork(OpType opType, flagcxStream_t stream = nullptr,
-             flagcxDeviceHandle_t handler = nullptr,
+             flagcxDeviceHandle_t devHandle = nullptr,
              c10::intrusive_ptr<c10::ivalue::Future> future =
                  nullptr, // future of the output
              int deviceId = 0)
       : Work(-1, // rank, only used by recvAnySource, irrelevant in this
                  // implementation
              opType),
-        stream_(stream), handler_(handler), future_(std::move(future)),
+        stream_(stream), devHandle_(devHandle), future_(std::move(future)),
         deviceId_(deviceId), isBarrierOp_(false) {
 #ifdef USE_NVIDIA_ADAPTOR
     event_ = std::make_unique<flagcxCudaEvent>();
@@ -75,7 +75,7 @@ public:
 
 private:
   flagcxStream_t stream_;
-  flagcxDeviceHandle_t handler_;
+  flagcxDeviceHandle_t devHandle_;
   c10::intrusive_ptr<c10::ivalue::Future> future_;
   int deviceId_;
   bool isBarrierOp_;
@@ -280,7 +280,8 @@ protected:
   uint64_t activeGroupCounter_;
   std::unordered_map<int, flagcxStream_t> flagcxStreams_;
   std::unordered_map<int, std::unique_ptr<flagcxEvent>> flagcxEvents_;
-  flagcxHandlerGroup_t handler_ = nullptr;
+  flagcxDeviceHandle_t devHandle_ = nullptr;
+  flagcxComm_t comm_ = nullptr;
 #if (defined(USE_NVIDIA_ADAPTOR) || defined(USE_METAX_ADAPTOR)) &&             \
     defined(TORCH_VER_GE_250)
   const c10::intrusive_ptr<Options> options_;

--- a/plugin/torch/flagcx/src/backend_flagcx.cpp
+++ b/plugin/torch/flagcx/src/backend_flagcx.cpp
@@ -488,7 +488,8 @@ c10::intrusive_ptr<Work> flagcxBackend::endCoalescing() {
   // Sort by peer asc to issue pair sub-comms in canonical (min,max) order,
   // avoiding the ring-of-pairs deadlock from getOrInitPtpuPairComm handshake.
   // No flagcxGroupStart/End: pair-comm send/recv are already async per-stream,
-  // so serial issue still meets batch_isend_irecv's enqueue-then-wait semantics.
+  // so serial issue still meets batch_isend_irecv's enqueue-then-wait
+  // semantics.
   std::stable_sort(
       ptpuCoalesce_.pendingOps.begin(), ptpuCoalesce_.pendingOps.end(),
       [](const auto &a, const auto &b) { return a.first < b.first; });

--- a/plugin/torch/flagcx/src/backend_flagcx.cpp
+++ b/plugin/torch/flagcx/src/backend_flagcx.cpp
@@ -267,7 +267,7 @@ bool flagcxWork::isSuccess() const { return future_->hasValue(); }
 bool flagcxWork::wait(std::chrono::milliseconds /* unused */) {
   event_->block(deviceId_);
   if (isBarrierOp_) {
-    C10D_FLAGCX_CHECK(handler_->streamSynchronize(stream_), std::nullopt);
+    C10D_FLAGCX_CHECK(devHandle_->streamSynchronize(stream_), std::nullopt);
   }
   return true;
 }
@@ -288,8 +288,8 @@ flagcxBackend::flagcxBackend(const c10::intrusive_ptr<::c10d::Store> &store,
   deviceId_ = 0;
   status_ = 0;
   activeGroupCounter_ = 0;
-  C10D_FLAGCX_CHECK(flagcxHandleInit(&handler_), std::nullopt);
-  C10D_FLAGCX_CHECK(handler_->devHandle->getDeviceCount(&nDevs_), std::nullopt);
+  C10D_FLAGCX_CHECK(flagcxDeviceHandleInit(&devHandle_), std::nullopt);
+  C10D_FLAGCX_CHECK(devHandle_->getDeviceCount(&nDevs_), std::nullopt);
 }
 #else
 flagcxBackend::flagcxBackend(const c10::intrusive_ptr<::c10d::Store> &store,
@@ -298,15 +298,15 @@ flagcxBackend::flagcxBackend(const c10::intrusive_ptr<::c10d::Store> &store,
   deviceId_ = 0;
   status_ = 0;
   activeGroupCounter_ = 0;
-  C10D_FLAGCX_CHECK(flagcxHandleInit(&handler_), std::nullopt);
-  C10D_FLAGCX_CHECK(handler_->devHandle->getDeviceCount(&nDevs_), std::nullopt);
+  C10D_FLAGCX_CHECK(flagcxDeviceHandleInit(&devHandle_), std::nullopt);
+  C10D_FLAGCX_CHECK(devHandle_->getDeviceCount(&nDevs_), std::nullopt);
 }
 #endif
 
 flagcxBackend::~flagcxBackend() {
   if (status_ == 1) {
     for (auto &s : flagcxStreams_) {
-      handler_->devHandle->streamDestroy(s.second);
+      devHandle_->streamDestroy(s.second);
     }
 #ifdef USE_SUNRISE_ADAPTOR
     // Tear down the per-pair PCCL sub-comms before the global one.
@@ -315,11 +315,11 @@ flagcxBackend::~flagcxBackend() {
     }
     ptpuPairComms_.clear();
 #endif
-    flagcxCommDestroy(handler_->comm);
+    flagcxCommDestroy(comm_);
     status_ = 0;
   }
   if (status_ == 0) {
-    flagcxHandleFree(handler_);
+    flagcxDeviceHandleFree(devHandle_);
   }
 }
 
@@ -335,9 +335,8 @@ flagcxStream_t flagcxBackend::getStreamByIndex(int streamId) {
     acl_stream = c10_npu::getCurrentNPUStream().stream(false);
     flagcxStreams_[streamId] = reinterpret_cast<flagcxStream_t>(&acl_stream);
 #else
-    C10D_FLAGCX_CHECK(
-        handler_->devHandle->streamCreate(&flagcxStreams_[streamId]),
-        std::nullopt);
+    C10D_FLAGCX_CHECK(devHandle_->streamCreate(&flagcxStreams_[streamId]),
+                      std::nullopt);
 #endif
     return flagcxStreams_[streamId];
   }
@@ -380,22 +379,21 @@ std::unique_ptr<flagcxEvent> &flagcxBackend::getEventByIndex(int eventId) {
 void flagcxBackend::initComm(at::Device dev) {
   if (status_ == 0) {
     deviceId_ = dev.index();
-    C10D_FLAGCX_CHECK(handler_->devHandle->setDevice(deviceId_), std::nullopt);
+    C10D_FLAGCX_CHECK(devHandle_->setDevice(deviceId_), std::nullopt);
     // Get the unique id
-    C10D_FLAGCX_CHECK(flagcxGetUniqueId(&handler_->uniqueId), std::nullopt);
+    flagcxUniqueId uniqueId;
     if (rank_ == 0) {
-      auto vec =
-          std::vector<uint8_t>(reinterpret_cast<uint8_t *>(handler_->uniqueId),
-                               reinterpret_cast<uint8_t *>(handler_->uniqueId) +
-                                   sizeof(flagcxUniqueId));
+      C10D_FLAGCX_CHECK(flagcxGetUniqueId(&uniqueId), std::nullopt);
+      auto vec = std::vector<uint8_t>(reinterpret_cast<uint8_t *>(&uniqueId),
+                                      reinterpret_cast<uint8_t *>(&uniqueId) +
+                                          sizeof(flagcxUniqueId));
       store_->set("flagcx/unique_id", std::string(vec.begin(), vec.end()));
     } else {
       try {
         auto vec = store_->get("flagcx/unique_id");
         TORCH_CHECK_WITH(DistBackendError, vec.size() == sizeof(flagcxUniqueId),
                          "Invalide size for flagcxUniqueId");
-        std::memcpy((uint8_t *)handler_->uniqueId, vec.data(),
-                    sizeof(flagcxUniqueId));
+        std::memcpy((uint8_t *)&uniqueId, vec.data(), sizeof(flagcxUniqueId));
       } catch (const std::exception &e) {
         throw std::runtime_error(
             "Failed to retrieve the unique id from the store: " +
@@ -406,9 +404,8 @@ void flagcxBackend::initComm(at::Device dev) {
       }
     }
     // Initialize the communicator
-    C10D_FLAGCX_CHECK(
-        flagcxCommInitRank(&handler_->comm, size_, handler_->uniqueId, rank_),
-        std::nullopt);
+    C10D_FLAGCX_CHECK(flagcxCommInitRank(&comm_, size_, &uniqueId, rank_),
+                      std::nullopt);
     status_ = 1;
   } else {
     if (dev.is_cuda() || dev.is_privateuseone()) {
@@ -455,13 +452,13 @@ void flagcxBackend::syncStream(at::Device device, int index) {
 
 void flagcxBackend::groupStart() {
   initComm();
-  C10D_FLAGCX_CHECK(flagcxGroupStart(handler_->comm), std::nullopt);
+  C10D_FLAGCX_CHECK(flagcxGroupStart(comm_), std::nullopt);
   ++activeGroupCounter_;
 }
 
 void flagcxBackend::groupEnd() {
   initComm();
-  C10D_FLAGCX_CHECK(flagcxGroupEnd(handler_->comm), std::nullopt);
+  C10D_FLAGCX_CHECK(flagcxGroupEnd(comm_), std::nullopt);
   --activeGroupCounter_;
 }
 
@@ -516,14 +513,14 @@ c10::intrusive_ptr<Work> flagcxBackend::endCoalescing() {
 #else
   groupEnd();
 
-  auto work = c10::make_intrusive<flagcxWork>(
-      OpType::COALESCED, getStreamByIndex(0), handler_->devHandle);
+  auto work = c10::make_intrusive<flagcxWork>(OpType::COALESCED,
+                                              getStreamByIndex(0), devHandle_);
   work->event_->record(getStreamByIndex(0), deviceId_);
   work->deviceId_ = deviceId_;
   // Currently, hetero coalesced ops require a barrier op to avoid hanging issue
   // TODO: remove this barrier op when the hanging issue is resolved
   int isHomo;
-  flagcxIsHomoComm(handler_->comm, &isHomo);
+  flagcxIsHomoComm(comm_, &isHomo);
   if (isHomo) {
     work->isBarrierOp_ = false;
   } else {
@@ -556,14 +553,14 @@ flagcxBackend::collectiveCoalesced(std::vector<at::Tensor> &inputs,
 
   // First let default flagcx stream wait for input tensor allocation stream
   syncStream(device);
-  auto work = c10::make_intrusive<flagcxWork>(opType, getStreamByIndex(0),
-                                              handler_->devHandle);
+  auto work =
+      c10::make_intrusive<flagcxWork>(opType, getStreamByIndex(0), devHandle_);
 
   {
     int isHomo;
-    flagcxIsHomoComm(handler_->comm, &isHomo);
+    flagcxIsHomoComm(comm_, &isHomo);
     if (isHomo) {
-      flagcxGroupGuard guard(handler_->comm);
+      flagcxGroupGuard guard(comm_);
     }
     // multi-stream may lead to queue sync error on mlu,
     // more tests are required to confirm,
@@ -582,7 +579,7 @@ flagcxBackend::collectiveCoalesced(std::vector<at::Tensor> &inputs,
       auto inputTensor = inputs[i];
       auto outputTensor = outputs[i];
       // Perform the collective operation
-      C10D_FLAGCX_CHECK(fn(inputTensor, outputTensor, handler_->comm, stream),
+      C10D_FLAGCX_CHECK(fn(inputTensor, outputTensor, comm_, stream),
                         std::nullopt);
 
       // if (!isHomo) {
@@ -630,8 +627,8 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
       auto &input = (i == rank_) ? inputTensor : output;
       // Perform out-of-place broadcast from rank i
       C10D_FLAGCX_CHECK(flagcxBroadcast(input.data_ptr(), output.data_ptr(),
-                                        input.numel(), flagcxDataType, i,
-                                        handler_->comm, stream),
+                                        input.numel(), flagcxDataType, i, comm_,
+                                        stream),
                         std::nullopt);
     }
   } else {
@@ -647,11 +644,10 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
 
 #endif
     // Perform the allgather operation
-    C10D_FLAGCX_CHECK(flagcxAllGather(inputTensor.data_ptr(),
-                                      outputFlattened.data_ptr(),
-                                      inputTensor.numel(), flagcxDataType,
-                                      handler_->comm, stream),
-                      std::nullopt);
+    C10D_FLAGCX_CHECK(
+        flagcxAllGather(inputTensor.data_ptr(), outputFlattened.data_ptr(),
+                        inputTensor.numel(), flagcxDataType, comm_, stream),
+        std::nullopt);
 
     // Copy the flattened tensor back into a vector of tensors.
     {
@@ -662,8 +658,8 @@ flagcxBackend::allgather(std::vector<std::vector<at::Tensor>> &outputTensors,
     }
   }
 
-  auto work = c10::make_intrusive<flagcxWork>(OpType::ALLGATHER, stream,
-                                              handler_->devHandle);
+  auto work =
+      c10::make_intrusive<flagcxWork>(OpType::ALLGATHER, stream, devHandle_);
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
   // Create a future to track the allgather operation
@@ -681,7 +677,7 @@ flagcxBackend::_allgather_base(at::Tensor &outputTensor,
   auto flagcxDataType = getFlagcxDataType(inputTensor.scalar_type());
   auto stream = getStreamByIndex(0);
   auto work = c10::make_intrusive<flagcxWork>(OpType::_ALLGATHER_BASE, stream,
-                                              handler_->devHandle);
+                                              devHandle_);
   check_device(inputTensor.device(), outputTensor.device());
   initComm(inputTensor.device());
   syncStream(inputTensor.device());
@@ -696,11 +692,10 @@ flagcxBackend::_allgather_base(at::Tensor &outputTensor,
 #endif
 
   // Perform the allgather operation
-  C10D_FLAGCX_CHECK(flagcxAllGather(inputTensor.data_ptr(),
-                                    outputTensor.data_ptr(),
-                                    inputTensor.numel(), flagcxDataType,
-                                    handler_->comm, stream),
-                    std::nullopt);
+  C10D_FLAGCX_CHECK(
+      flagcxAllGather(inputTensor.data_ptr(), outputTensor.data_ptr(),
+                      inputTensor.numel(), flagcxDataType, comm_, stream),
+      std::nullopt);
 
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
@@ -746,8 +741,8 @@ flagcxBackend::allreduce(std::vector<at::Tensor> &tensors,
   auto flagcxReduceOp =
       getFlagcxReduceOp(opts.reduceOp, tensor, flagcxDataType);
   auto stream = getStreamByIndex(0);
-  auto work = c10::make_intrusive<flagcxWork>(OpType::ALLREDUCE, stream,
-                                              handler_->devHandle);
+  auto work =
+      c10::make_intrusive<flagcxWork>(OpType::ALLREDUCE, stream, devHandle_);
   initComm(tensor.device());
   syncStream(tensor.device());
 
@@ -762,7 +757,7 @@ flagcxBackend::allreduce(std::vector<at::Tensor> &tensors,
   // Perform the allreduce operation
   C10D_FLAGCX_CHECK(flagcxAllReduce(tensor.data_ptr(), tensor.data_ptr(),
                                     tensor.numel(), flagcxDataType,
-                                    flagcxReduceOp, handler_->comm, stream),
+                                    flagcxReduceOp, comm_, stream),
                     std::nullopt);
 
   work->event_->record(stream, deviceId_);
@@ -819,8 +814,8 @@ flagcxBackend::alltoall(std::vector<at::Tensor> &outputTensors,
   auto device = outputTensors[0].device();
   auto flagcxDataType = getFlagcxDataType(outputTensors[0].scalar_type());
   auto stream = getStreamByIndex(0);
-  auto work = c10::make_intrusive<flagcxWork>(OpType::ALLTOALL, stream,
-                                              handler_->devHandle);
+  auto work =
+      c10::make_intrusive<flagcxWork>(OpType::ALLTOALL, stream, devHandle_);
 
   for (const auto i : c10::irange(outputTensors.size())) {
     TORCH_CHECK(inputTensors[i].numel() == outputTensors[i].numel(),
@@ -860,7 +855,7 @@ flagcxBackend::alltoall(std::vector<at::Tensor> &outputTensors,
   // Perform the alltoall operation
   C10D_FLAGCX_CHECK(flagcxAlltoAll(inputFlattened.data_ptr(),
                                    outputFlattened.data_ptr(), count,
-                                   flagcxDataType, handler_->comm, stream),
+                                   flagcxDataType, comm_, stream),
                     std::nullopt);
 
   // Copy the flattened tensor back into a vector of tensors.
@@ -891,7 +886,7 @@ flagcxBackend::alltoall_base(at::Tensor &outputTensor, at::Tensor &inputTensor,
   auto flagcxDataType = getFlagcxDataType(outputTensor.scalar_type());
   auto stream = getStreamByIndex(0);
   auto work = c10::make_intrusive<flagcxWork>(OpType::ALLTOALL_BASE, stream,
-                                              handler_->devHandle);
+                                              devHandle_);
 
   TORCH_CHECK(device == outputTensor.device() && device == inputTensor.device(),
               "Tensor must be on the same device");
@@ -928,7 +923,7 @@ flagcxBackend::alltoall_base(at::Tensor &outputTensor, at::Tensor &inputTensor,
     // Perform the alltoall operation
     C10D_FLAGCX_CHECK(flagcxAlltoAll(inputTensor.data_ptr(),
                                      outputTensor.data_ptr(), count,
-                                     flagcxDataType, handler_->comm, stream),
+                                     flagcxDataType, comm_, stream),
                       std::nullopt);
   } else {
     // currently, we do not support recording alltoallv operations for
@@ -936,7 +931,7 @@ flagcxBackend::alltoall_base(at::Tensor &outputTensor, at::Tensor &inputTensor,
     C10D_FLAGCX_CHECK(flagcxAlltoAllv(inputTensor.data_ptr(), inLengths.data(),
                                       inOffsets.data(), outputTensor.data_ptr(),
                                       outLengths.data(), outOffsets.data(),
-                                      flagcxDataType, handler_->comm, stream),
+                                      flagcxDataType, comm_, stream),
                       std::nullopt);
   }
 
@@ -953,10 +948,10 @@ flagcxBackend::alltoall_base(at::Tensor &outputTensor, at::Tensor &inputTensor,
 c10::intrusive_ptr<Work> flagcxBackend::barrier(const BarrierOptions &opts) {
   initComm();
   auto stream = getStreamByIndex(0);
-  auto work = c10::make_intrusive<flagcxWork>(OpType::BARRIER, stream,
-                                              handler_->devHandle);
+  auto work =
+      c10::make_intrusive<flagcxWork>(OpType::BARRIER, stream, devHandle_);
 
-  C10D_FLAGCX_CHECK(flagcxBarrier(handler_->comm, stream), std::nullopt);
+  C10D_FLAGCX_CHECK(flagcxBarrier(comm_, stream), std::nullopt);
 
   work->event_->record(stream, deviceId_);
   work->deviceId_ = deviceId_;
@@ -974,8 +969,8 @@ flagcxBackend::broadcast(std::vector<at::Tensor> &tensors,
   auto &tensor = tensors.back();
   auto flagcxDataType = getFlagcxDataType(tensor.scalar_type());
   auto stream = getStreamByIndex(0);
-  auto work = c10::make_intrusive<flagcxWork>(OpType::BROADCAST, stream,
-                                              handler_->devHandle);
+  auto work =
+      c10::make_intrusive<flagcxWork>(OpType::BROADCAST, stream, devHandle_);
   initComm(tensor.device());
   syncStream(tensor.device());
 
@@ -988,8 +983,8 @@ flagcxBackend::broadcast(std::vector<at::Tensor> &tensors,
 
 #endif
   C10D_FLAGCX_CHECK(flagcxBroadcast(tensor.data_ptr(), tensor.data_ptr(),
-                                    tensor.numel(), flagcxDataType, root,
-                                    handler_->comm, stream),
+                                    tensor.numel(), flagcxDataType, root, comm_,
+                                    stream),
                     std::nullopt);
 
   work->event_->record(stream, deviceId_);
@@ -1010,8 +1005,8 @@ flagcxBackend::gather(std::vector<std::vector<at::Tensor>> &outputTensors,
   auto device = inputTensor.device();
   auto flagcxDataType = getFlagcxDataType(inputTensor.scalar_type());
   auto stream = getStreamByIndex(0);
-  auto work = c10::make_intrusive<flagcxWork>(OpType::GATHER, stream,
-                                              handler_->devHandle);
+  auto work =
+      c10::make_intrusive<flagcxWork>(OpType::GATHER, stream, devHandle_);
   initComm(device);
   syncStream(device);
 
@@ -1036,11 +1031,10 @@ flagcxBackend::gather(std::vector<std::vector<at::Tensor>> &outputTensors,
 
 #endif
   // Perform the gather operation
-  C10D_FLAGCX_CHECK(flagcxGather(inputTensor.data_ptr(),
-                                 outputFlattened.data_ptr(),
-                                 inputTensor.numel(), flagcxDataType, root,
-                                 handler_->comm, stream),
-                    std::nullopt);
+  C10D_FLAGCX_CHECK(
+      flagcxGather(inputTensor.data_ptr(), outputFlattened.data_ptr(),
+                   inputTensor.numel(), flagcxDataType, root, comm_, stream),
+      std::nullopt);
 
   // Unflatten the flattened tensor back into a vector of tensors.
   if (rank_ == root) {
@@ -1067,8 +1061,8 @@ c10::intrusive_ptr<Work> flagcxBackend::reduce(std::vector<at::Tensor> &tensors,
   auto flagcxReduceOp =
       getFlagcxReduceOp(opts.reduceOp, tensor, flagcxDataType);
   auto stream = getStreamByIndex(0);
-  auto work = c10::make_intrusive<flagcxWork>(OpType::REDUCE, stream,
-                                              handler_->devHandle);
+  auto work =
+      c10::make_intrusive<flagcxWork>(OpType::REDUCE, stream, devHandle_);
   initComm(tensor.device());
   syncStream(tensor.device());
 
@@ -1084,7 +1078,7 @@ c10::intrusive_ptr<Work> flagcxBackend::reduce(std::vector<at::Tensor> &tensors,
 
   C10D_FLAGCX_CHECK(flagcxReduce(tensor.data_ptr(), tensor.data_ptr(),
                                  tensor.numel(), flagcxDataType, flagcxReduceOp,
-                                 root, handler_->comm, stream),
+                                 root, comm_, stream),
                     std::nullopt);
 
   work->event_->record(stream, deviceId_);
@@ -1109,7 +1103,7 @@ c10::intrusive_ptr<Work> flagcxBackend::reduce_scatter(
       getFlagcxReduceOp(opts.reduceOp, outputTensor, flagcxDataType);
   auto stream = getStreamByIndex(0);
   auto work = c10::make_intrusive<flagcxWork>(OpType::REDUCE_SCATTER, stream,
-                                              handler_->devHandle);
+                                              devHandle_);
   check_device(outputTensor.device(), inputTensorsTmp[0].device());
   initComm(device);
   syncStream(device);
@@ -1139,11 +1133,11 @@ c10::intrusive_ptr<Work> flagcxBackend::reduce_scatter(
 #endif
 
     // Perform the reducescatter operation
-    C10D_FLAGCX_CHECK(
-        flagcxReduceScatter(inputFlattened.data_ptr(), outputTensor.data_ptr(),
-                            outputTensor.numel(), flagcxDataType,
-                            flagcxReduceOp, handler_->comm, stream),
-        std::nullopt);
+    C10D_FLAGCX_CHECK(flagcxReduceScatter(inputFlattened.data_ptr(),
+                                          outputTensor.data_ptr(),
+                                          outputTensor.numel(), flagcxDataType,
+                                          flagcxReduceOp, comm_, stream),
+                      std::nullopt);
   }
 
   work->event_->record(stream, deviceId_);
@@ -1165,7 +1159,7 @@ flagcxBackend::_reduce_scatter_base(at::Tensor &outputTensor,
       getFlagcxReduceOp(opts.reduceOp, outputTensor, flagcxDataType);
   auto stream = getStreamByIndex(0);
   auto work = c10::make_intrusive<flagcxWork>(OpType::_REDUCE_SCATTER_BASE,
-                                              stream, handler_->devHandle);
+                                              stream, devHandle_);
   check_device(outputTensor.device(), inputTensor.device());
   initComm(outputTensor.device());
   syncStream(outputTensor.device());
@@ -1183,11 +1177,11 @@ flagcxBackend::_reduce_scatter_base(at::Tensor &outputTensor,
 
 #endif
     // Perform the reducescatter operation
-    C10D_FLAGCX_CHECK(
-        flagcxReduceScatter(inputTensor.data_ptr(), outputTensor.data_ptr(),
-                            outputTensor.numel(), flagcxDataType,
-                            flagcxReduceOp, handler_->comm, stream),
-        std::nullopt);
+    C10D_FLAGCX_CHECK(flagcxReduceScatter(inputTensor.data_ptr(),
+                                          outputTensor.data_ptr(),
+                                          outputTensor.numel(), flagcxDataType,
+                                          flagcxReduceOp, comm_, stream),
+                      std::nullopt);
   }
 
   work->event_->record(stream, deviceId_);
@@ -1239,8 +1233,8 @@ flagcxBackend::scatter(std::vector<at::Tensor> &outputTensors,
   auto device = outputTensor.device();
   auto flagcxDataType = getFlagcxDataType(outputTensor.scalar_type());
   auto stream = getStreamByIndex(0);
-  auto work = c10::make_intrusive<flagcxWork>(OpType::SCATTER, stream,
-                                              handler_->devHandle);
+  auto work =
+      c10::make_intrusive<flagcxWork>(OpType::SCATTER, stream, devHandle_);
   initComm(device);
   syncStream(device);
 
@@ -1276,7 +1270,7 @@ flagcxBackend::scatter(std::vector<at::Tensor> &outputTensors,
   // Perform the scatter operation
   C10D_FLAGCX_CHECK(flagcxScatter(inputFlattened.data_ptr(),
                                   outputTensor.data_ptr(), outputTensor.numel(),
-                                  flagcxDataType, root, handler_->comm, stream),
+                                  flagcxDataType, root, comm_, stream),
                     std::nullopt);
 
   work->event_->record(stream, deviceId_);
@@ -1355,8 +1349,7 @@ c10::intrusive_ptr<Work> flagcxBackend::send(std::vector<at::Tensor> &tensors,
   auto &tensor = tensors.back();
   auto flagcxDataType = getFlagcxDataType(tensor.scalar_type());
   auto stream = getStreamByIndex(0);
-  auto work = c10::make_intrusive<flagcxWork>(OpType::SEND, stream,
-                                              handler_->devHandle);
+  auto work = c10::make_intrusive<flagcxWork>(OpType::SEND, stream, devHandle_);
   initComm(tensor.device());
   syncStream(tensor.device());
 
@@ -1389,7 +1382,7 @@ c10::intrusive_ptr<Work> flagcxBackend::send(std::vector<at::Tensor> &tensors,
                     std::nullopt);
 #else
   C10D_FLAGCX_CHECK(flagcxSend(tensor.data_ptr(), tensor.numel(),
-                               flagcxDataType, dstRank, handler_->comm, stream),
+                               flagcxDataType, dstRank, comm_, stream),
                     std::nullopt);
 #endif
 
@@ -1412,8 +1405,7 @@ c10::intrusive_ptr<Work> flagcxBackend::recv(std::vector<at::Tensor> &tensors,
   auto &tensor = tensors.back();
   auto flagcxDataType = getFlagcxDataType(tensor.scalar_type());
   auto stream = getStreamByIndex(0);
-  auto work = c10::make_intrusive<flagcxWork>(OpType::RECV, stream,
-                                              handler_->devHandle);
+  auto work = c10::make_intrusive<flagcxWork>(OpType::RECV, stream, devHandle_);
   initComm(tensor.device());
   syncStream(tensor.device());
 
@@ -1445,7 +1437,7 @@ c10::intrusive_ptr<Work> flagcxBackend::recv(std::vector<at::Tensor> &tensors,
                     std::nullopt);
 #else
   C10D_FLAGCX_CHECK(flagcxRecv(tensor.data_ptr(), tensor.numel(),
-                               flagcxDataType, srcRank, handler_->comm, stream),
+                               flagcxDataType, srcRank, comm_, stream),
                     std::nullopt);
 #endif
 

--- a/test/fixtures/comm_fixture.hpp
+++ b/test/fixtures/comm_fixture.hpp
@@ -17,21 +17,20 @@ protected:
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nranks);
 
-    flagcxHandleInit(&handler);
-    flagcxUniqueId_t &uniqueId = handler->uniqueId;
-    flagcxDeviceHandle_t &devHandle = handler->devHandle;
+    flagcxDeviceHandleInit(&devHandle);
 
     int numDevices;
     devHandle->getDeviceCount(&numDevices);
     devHandle->setDevice(rank % numDevices);
 
+    flagcxUniqueId uniqueId;
     if (rank == 0)
       flagcxGetUniqueId(&uniqueId);
-    MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
+    MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
               MPI_COMM_WORLD);
     MPI_Barrier(MPI_COMM_WORLD);
 
-    flagcxCommInitRank(&handler->comm, nranks, uniqueId, rank);
+    flagcxCommInitRank(&comm, nranks, &uniqueId, rank);
     devHandle->streamCreate(&stream);
 
     size = COMM_FIXTURE_SIZE;
@@ -46,9 +45,7 @@ protected:
   }
 
   void TearDown() override {
-    flagcxDeviceHandle_t &devHandle = handler->devHandle;
-
-    flagcxCommDestroy(handler->comm);
+    flagcxCommDestroy(comm);
     devHandle->streamDestroy(stream);
 
     devHandle->deviceFree(sendbuff, flagcxMemDevice, NULL);
@@ -56,12 +53,13 @@ protected:
     devHandle->deviceFree(hostsendbuff, flagcxMemHost, NULL);
     devHandle->deviceFree(hostrecvbuff, flagcxMemHost, NULL);
 
-    flagcxHandleFree(handler);
+    flagcxDeviceHandleFree(devHandle);
   }
 
   int rank;
   int nranks;
-  flagcxHandlerGroup_t handler;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
   flagcxStream_t stream;
   void *sendbuff;
   void *recvbuff;

--- a/test/include/perf_common.h
+++ b/test/include/perf_common.h
@@ -26,9 +26,8 @@ struct PerfContext {
   int localRegister;
 
   // FlagCX handles
-  flagcxHandlerGroup_t handler;
-  flagcxComm_t comm;              // alias for handler->comm
-  flagcxDeviceHandle_t devHandle; // alias for handler->devHandle
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
 
   // MPI info
   int color;
@@ -72,7 +71,7 @@ using PerfRootPostIterFn = void (*)(PerfContext &ctx, size_t size, size_t count,
 void perfSetup(PerfContext &ctx, int argc, char **argv,
                PerfBufSizeFn bufSizeFn = nullptr);
 
-// Free all buffers, destroy comm/stream, free handler, MPI_Finalize.
+// Free all buffers, destroy comm/stream, free devHandle, MPI_Finalize.
 void perfTeardown(PerfContext &ctx);
 
 // Run warmup iterations for large and small message sizes.

--- a/test/kernel/test_device_api.cpp
+++ b/test/kernel/test_device_api.cpp
@@ -124,11 +124,10 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  flagcxHandlerGroup_t handler;
-  FLAGCXCHECK(flagcxHandleInit(&handler));
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
+  FLAGCXCHECK(flagcxDeviceHandleInit(&devHandle));
+  flagcxUniqueId uniqueId;
 
   int color = 0;
   int worldSize = 1, worldRank = 0;
@@ -143,16 +142,16 @@ int main(int argc, char *argv[]) {
 
   if (proc == 0)
     FLAGCXCHECK(flagcxGetUniqueId(&uniqueId));
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, uniqueId, proc));
+  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, &uniqueId, proc));
 
   if (localRegister == 0) {
     if (proc == 0)
       printf("One-sided ops require -R 1 or -R 2. Skipping.\n");
     FLAGCXCHECK(flagcxCommDestroy(comm));
-    FLAGCXCHECK(flagcxHandleFree(handler));
+    FLAGCXCHECK(flagcxDeviceHandleFree(devHandle));
     MPI_Finalize();
     return 0;
   }
@@ -386,7 +385,7 @@ int main(int argc, char *argv[]) {
   FLAGCXCHECK(flagcxMemFree(sendBuff));
   FLAGCXCHECK(flagcxMemFree(recvBuff));
   free(hostBuff);
-  FLAGCXCHECK(flagcxHandleFree(handler));
+  FLAGCXCHECK(flagcxDeviceHandleFree(devHandle));
 
   MPI_Finalize();
   return 0;

--- a/test/kernel/test_device_ir.cpp
+++ b/test/kernel/test_device_ir.cpp
@@ -32,11 +32,10 @@
 // ===========================================================================
 
 int main(int argc, char *argv[]) {
-  flagcxHandlerGroup_t handler;
-  FLAGCXCHECK(flagcxHandleInit(&handler));
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandle_t devHandle;
+  FLAGCXCHECK(flagcxDeviceHandleInit(&devHandle));
+  flagcxComm_t comm;
+  flagcxUniqueId uniqueId;
 
   int worldSize = 1, worldRank = 0;
   int totalProcs = 1, proc = 0;
@@ -52,10 +51,10 @@ int main(int argc, char *argv[]) {
 
   if (proc == 0)
     FLAGCXCHECK(flagcxGetUniqueId(&uniqueId));
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, uniqueId, proc));
+  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, &uniqueId, proc));
 
   flagcxStream_t stream;
   FLAGCXCHECK(devHandle->streamCreate(&stream));
@@ -358,7 +357,7 @@ int main(int argc, char *argv[]) {
   FLAGCXCHECK(flagcxMemFree(regBuff));
   FLAGCXCHECK(devHandle->streamDestroy(stream));
   FLAGCXCHECK(flagcxCommDestroy(comm));
-  FLAGCXCHECK(flagcxHandleFree(handler));
+  FLAGCXCHECK(flagcxDeviceHandleFree(devHandle));
 
   MPI_Finalize();
   return globalPass ? 0 : 1;

--- a/test/kernel/test_internode_onesided.cpp
+++ b/test/kernel/test_internode_onesided.cpp
@@ -37,11 +37,10 @@ int main(int argc, char *argv[]) {
   uint64_t splitMask = args.getSplitMask();
   int localRegister = args.getLocalRegister();
 
-  flagcxHandlerGroup_t handler;
-  FLAGCXCHECK(flagcxHandleInit(&handler));
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
+  FLAGCXCHECK(flagcxDeviceHandleInit(&devHandle));
+  flagcxUniqueId uniqueId;
 
   int color = 0;
   int worldSize = 1, worldRank = 0;
@@ -56,16 +55,16 @@ int main(int argc, char *argv[]) {
 
   if (proc == 0)
     FLAGCXCHECK(flagcxGetUniqueId(&uniqueId));
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, uniqueId, proc));
+  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, &uniqueId, proc));
 
   if (totalProcs < 2) {
     if (proc == 0)
       printf("test_kernel_internode_onesided requires at least 2 ranks.\n");
     FLAGCXCHECK(flagcxCommDestroy(comm));
-    FLAGCXCHECK(flagcxHandleFree(handler));
+    FLAGCXCHECK(flagcxDeviceHandleFree(devHandle));
     MPI_Finalize();
     return 0;
   }
@@ -74,7 +73,7 @@ int main(int argc, char *argv[]) {
     if (proc == 0)
       printf("One-sided ops require -R 1 or -R 2. Skipping.\n");
     FLAGCXCHECK(flagcxCommDestroy(comm));
-    FLAGCXCHECK(flagcxHandleFree(handler));
+    FLAGCXCHECK(flagcxDeviceHandleFree(devHandle));
     MPI_Finalize();
     return 0;
   }
@@ -270,7 +269,7 @@ int main(int argc, char *argv[]) {
     FLAGCXCHECK(devHandle->deviceFree(recvBuff, flagcxMemDevice, NULL));
   }
   free(hostBuff);
-  FLAGCXCHECK(flagcxHandleFree(handler));
+  FLAGCXCHECK(flagcxDeviceHandleFree(devHandle));
 
   MPI_Finalize();
   return 0;

--- a/test/kernel/test_internode_twosided.cpp
+++ b/test/kernel/test_internode_twosided.cpp
@@ -23,11 +23,10 @@ int main(int argc, char *argv[]) {
   uint64_t splitMask = args.getSplitMask();
   int localRegister = args.getLocalRegister();
 
-  flagcxHandlerGroup_t handler;
-  FLAGCXCHECK(flagcxHandleInit(&handler));
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
+  FLAGCXCHECK(flagcxDeviceHandleInit(&devHandle));
+  flagcxUniqueId uniqueId;
 
   int color = 0;
   int worldSize = 1, worldRank = 0;
@@ -42,10 +41,10 @@ int main(int argc, char *argv[]) {
 
   if (proc == 0)
     FLAGCXCHECK(flagcxGetUniqueId(&uniqueId));
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, uniqueId, proc));
+  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, &uniqueId, proc));
 
   flagcxStream_t stream;
   FLAGCXCHECK(devHandle->streamCreate(&stream));
@@ -327,7 +326,7 @@ int main(int argc, char *argv[]) {
     FLAGCXCHECK(devHandle->deviceFree(recvBuff, flagcxMemDevice, NULL));
   }
   free(hello);
-  FLAGCXCHECK(flagcxHandleFree(handler));
+  FLAGCXCHECK(flagcxDeviceHandleFree(devHandle));
 
   MPI_Finalize();
   return 0;

--- a/test/kernel/test_intranode.cpp
+++ b/test/kernel/test_intranode.cpp
@@ -38,11 +38,10 @@ int main(int argc, char *argv[]) {
   assert(stepFactor > 1 && "Step factor must be > 1 to avoid infinite loop "
                            "when increasing message size");
 
-  flagcxHandlerGroup_t handler;
-  FLAGCXCHECK(flagcxHandleInit(&handler));
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
+  FLAGCXCHECK(flagcxDeviceHandleInit(&devHandle));
+  flagcxUniqueId uniqueId;
 
   int color = 0;
   int worldSize = 1, worldRank = 0;
@@ -57,10 +56,10 @@ int main(int argc, char *argv[]) {
 
   if (proc == 0)
     FLAGCXCHECK(flagcxGetUniqueId(&uniqueId));
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, uniqueId, proc));
+  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, &uniqueId, proc));
 
   // Create device communicator for custom kernel usage
   flagcxDevComm_t devComm = nullptr;
@@ -227,7 +226,7 @@ int main(int argc, char *argv[]) {
   FLAGCXCHECK(devHandle->deviceFree(sendbuff, flagcxMemDevice, NULL));
   FLAGCXCHECK(devHandle->deviceFree(recvbuff, flagcxMemDevice, NULL));
   free(hostbuff);
-  FLAGCXCHECK(flagcxHandleFree(handler));
+  FLAGCXCHECK(flagcxDeviceHandleFree(devHandle));
 
   MPI_Finalize();
   return 0;

--- a/test/kernel/test_multi_fifo.cpp
+++ b/test/kernel/test_multi_fifo.cpp
@@ -133,11 +133,10 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  flagcxHandlerGroup_t handler;
-  FLAGCXCHECK(flagcxHandleInit(&handler));
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
+  FLAGCXCHECK(flagcxDeviceHandleInit(&devHandle));
+  flagcxUniqueId uniqueId;
 
   int color = 0;
   int worldSize = 1, worldRank = 0;
@@ -149,7 +148,7 @@ int main(int argc, char *argv[]) {
   if (localRegister == 0) {
     if (proc == 0)
       printf("One-sided ops require -R 1 or -R 2. Skipping.\n");
-    FLAGCXCHECK(flagcxHandleFree(handler));
+    FLAGCXCHECK(flagcxDeviceHandleFree(devHandle));
     MPI_Finalize();
     return 0;
   }
@@ -167,10 +166,10 @@ int main(int argc, char *argv[]) {
 
   if (proc == 0)
     FLAGCXCHECK(flagcxGetUniqueId(&uniqueId));
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, uniqueId, proc));
+  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, &uniqueId, proc));
 
   flagcxStream_t stream;
   FLAGCXCHECK(devHandle->streamCreate(&stream));
@@ -251,7 +250,7 @@ int main(int argc, char *argv[]) {
   FLAGCXCHECK(flagcxMemFree(recvBuff));
   free(hello);
   FLAGCXCHECK(flagcxCommDestroy(comm));
-  FLAGCXCHECK(flagcxHandleFree(handler));
+  FLAGCXCHECK(flagcxDeviceHandleFree(devHandle));
 
   MPI_Finalize();
   return anyFail ? 1 : 0;

--- a/test/perf/device_api/test_device_api_allreduce.cpp
+++ b/test/perf/device_api/test_device_api_allreduce.cpp
@@ -36,11 +36,10 @@ int main(int argc, char *argv[]) {
   assert(stepFactor > 1 && "Step factor must be > 1 to avoid infinite loop "
                            "when increasing message size");
 
-  flagcxHandlerGroup_t handler;
-  FLAGCXCHECK(flagcxHandleInit(&handler));
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
+  FLAGCXCHECK(flagcxDeviceHandleInit(&devHandle));
+  flagcxUniqueId uniqueId;
 
   int color = 0;
   int worldSize = 1, worldRank = 0;
@@ -55,10 +54,10 @@ int main(int argc, char *argv[]) {
 
   if (proc == 0)
     FLAGCXCHECK(flagcxGetUniqueId(&uniqueId));
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, uniqueId, proc));
+  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, &uniqueId, proc));
 
   // Create device communicator for custom kernel usage
   flagcxDevComm_t devComm = nullptr;
@@ -219,7 +218,7 @@ int main(int argc, char *argv[]) {
   free(hostbuff);
 
   FLAGCXCHECK(flagcxCommDestroy(comm));
-  FLAGCXCHECK(flagcxHandleFree(handler));
+  FLAGCXCHECK(flagcxDeviceHandleFree(devHandle));
 
   MPI_Finalize();
   return 0;

--- a/test/perf/device_api/test_internode_kernel.cpp
+++ b/test/perf/device_api/test_internode_kernel.cpp
@@ -19,11 +19,10 @@ int main(int argc, char *argv[]) {
   uint64_t splitMask = args.getSplitMask();
   int localRegister = args.getLocalRegister();
 
-  flagcxHandlerGroup_t handler;
-  FLAGCXCHECK(flagcxHandleInit(&handler));
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
+  FLAGCXCHECK(flagcxDeviceHandleInit(&devHandle));
+  flagcxUniqueId uniqueId;
 
   int color = 0;
   int worldSize = 1, worldRank = 0;
@@ -38,10 +37,10 @@ int main(int argc, char *argv[]) {
 
   if (proc == 0)
     FLAGCXCHECK(flagcxGetUniqueId(&uniqueId));
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, uniqueId, proc));
+  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, &uniqueId, proc));
 
   flagcxStream_t stream;
   FLAGCXCHECK(devHandle->streamCreate(&stream));
@@ -323,7 +322,7 @@ int main(int argc, char *argv[]) {
     FLAGCXCHECK(devHandle->deviceFree(recvBuff, flagcxMemDevice, NULL));
   }
   free(hello);
-  FLAGCXCHECK(flagcxHandleFree(handler));
+  FLAGCXCHECK(flagcxDeviceHandleFree(devHandle));
 
   MPI_Finalize();
   return 0;

--- a/test/perf/device_api/test_intranode_kernel.cpp
+++ b/test/perf/device_api/test_intranode_kernel.cpp
@@ -36,11 +36,10 @@ int main(int argc, char *argv[]) {
   assert(stepFactor > 1 && "Step factor must be > 1 to avoid infinite loop "
                            "when increasing message size");
 
-  flagcxHandlerGroup_t handler;
-  FLAGCXCHECK(flagcxHandleInit(&handler));
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
+  FLAGCXCHECK(flagcxDeviceHandleInit(&devHandle));
+  flagcxUniqueId uniqueId;
 
   int color = 0;
   int worldSize = 1, worldRank = 0;
@@ -55,10 +54,10 @@ int main(int argc, char *argv[]) {
 
   if (proc == 0)
     FLAGCXCHECK(flagcxGetUniqueId(&uniqueId));
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, uniqueId, proc));
+  FLAGCXCHECK(flagcxCommInitRank(&comm, totalProcs, &uniqueId, proc));
 
   // Create device communicator for custom kernel usage
   flagcxDevComm_t devComm = nullptr;
@@ -225,7 +224,7 @@ int main(int argc, char *argv[]) {
   FLAGCXCHECK(devHandle->deviceFree(sendbuff, flagcxMemDevice, NULL));
   FLAGCXCHECK(devHandle->deviceFree(recvbuff, flagcxMemDevice, NULL));
   free(hostbuff);
-  FLAGCXCHECK(flagcxHandleFree(handler));
+  FLAGCXCHECK(flagcxDeviceHandleFree(devHandle));
 
   MPI_Finalize();
   return 0;

--- a/test/perf/host_api/test_core_sendrecv.cpp
+++ b/test/perf/host_api/test_core_sendrecv.cpp
@@ -16,10 +16,9 @@ int main(int argc, char *argv[]) {
   int printBuffer = args.isPrintBuffer();
   uint64_t splitMask = args.getSplitMask();
 
-  flagcxHandlerGroup_t handler;
-  flagcxHandleInit(&handler);
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandle_t devHandle;
+  flagcxDeviceHandleInit(&devHandle);
+  flagcxUniqueId uniqueId;
 
   int color = 0;
   int worldSize = 1, worldRank = 0;
@@ -33,12 +32,12 @@ int main(int argc, char *argv[]) {
   devHandle->setDevice(worldRank % nGpu);
 
   if (proc == 0)
-    flagcxHeteroGetUniqueId(uniqueId);
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+    flagcxHeteroGetUniqueId(&uniqueId);
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
   flagcxHeteroComm_t comm;
-  flagcxHeteroCommInitRank(&comm, totalProcs, *uniqueId, proc);
+  flagcxHeteroCommInitRank(&comm, totalProcs, uniqueId, proc);
 
   flagcxStream_t stream;
   devHandle->streamCreate(&stream);
@@ -213,7 +212,7 @@ int main(int argc, char *argv[]) {
   free(testdata2);
   flagcxHeteroCommDestroy(comm);
   devHandle->streamDestroy(stream);
-  flagcxHandleFree(handler);
+  flagcxDeviceHandleFree(devHandle);
 
   MPI_Finalize();
   return 0;

--- a/test/perf/host_api/test_get.cpp
+++ b/test/perf/host_api/test_get.cpp
@@ -54,11 +54,10 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  flagcxHandlerGroup_t handler;
-  flagcxHandleInit(&handler);
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
+  flagcxDeviceHandleInit(&devHandle);
+  flagcxUniqueId uniqueId;
 
   int color = 0;
   int worldSize = 1, worldRank = 0;
@@ -73,10 +72,10 @@ int main(int argc, char *argv[]) {
 
   if (proc == 0)
     flagcxGetUniqueId(&uniqueId);
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  flagcxCommInitRank(&comm, totalProcs, uniqueId, proc);
+  flagcxCommInitRank(&comm, totalProcs, &uniqueId, proc);
 
   int isHomo = 0;
   flagcxIsHomoComm(comm, &isHomo);
@@ -86,7 +85,7 @@ int main(int argc, char *argv[]) {
              "(isHomo=%d).\n",
              isHomo);
     flagcxCommDestroy(comm);
-    flagcxHandleFree(handler);
+    flagcxDeviceHandleFree(devHandle);
     MPI_Finalize();
     return 0;
   }
@@ -95,7 +94,7 @@ int main(int argc, char *argv[]) {
     if (proc == 0)
       printf("test_get requires exactly 2 ranks (producer=0, getter=1).\n");
     flagcxCommDestroy(comm);
-    flagcxHandleFree(handler);
+    flagcxDeviceHandleFree(devHandle);
     MPI_Finalize();
     return 0;
   }
@@ -152,7 +151,7 @@ int main(int argc, char *argv[]) {
     flagcxMemFree(dataWindow);
     flagcxMemFree(signalWindow);
     flagcxCommDestroy(comm);
-    flagcxHandleFree(handler);
+    flagcxDeviceHandleFree(devHandle);
     MPI_Finalize();
     return 0;
   }
@@ -353,7 +352,8 @@ int main(int argc, char *argv[]) {
   }
 
   fatal(flagcxCommDestroy(comm), "flagcxCommDestroy failed", proc);
-  fatal(flagcxHandleFree(handler), "flagcxHandleFree failed", proc);
+  fatal(flagcxDeviceHandleFree(devHandle), "flagcxDeviceHandleFree failed",
+        proc);
 
   MPI_Finalize();
   return 0;

--- a/test/perf/host_api/test_ipc_sendrecv.cpp
+++ b/test/perf/host_api/test_ipc_sendrecv.cpp
@@ -19,9 +19,8 @@ int main(int argc, char *argv[]) {
   uint64_t splitMask = args.getSplitMask();
   // int localRegister = args.getLocalRegister();
 
-  flagcxHandlerGroup_t handler;
-  flagcxHandleInit(&handler);
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandle_t devHandle;
+  flagcxDeviceHandleInit(&devHandle);
 
   int color = 0;
   int worldSize = 1, worldRank = 0;
@@ -184,7 +183,7 @@ int main(int argc, char *argv[]) {
   // }
   free(hello);
   devHandle->streamDestroy(stream);
-  flagcxHandleFree(handler);
+  flagcxDeviceHandleFree(devHandle);
 
   MPI_Finalize();
   return 0;

--- a/test/perf/host_api/test_one_side_register.cpp
+++ b/test/perf/host_api/test_one_side_register.cpp
@@ -92,9 +92,8 @@ int main(int argc, char *argv[]) {
   uint64_t splitMask = args.getSplitMask();
   MPI_Comm splitComm;
 
-  flagcxHandlerGroup_t handler;
-  flagcxHandleInit(&handler);
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandle_t devHandle;
+  flagcxDeviceHandleInit(&devHandle);
 
   initMpiEnv(argc, argv, worldRank, worldSize, proc, totalProcs, color,
              splitComm, splitMask);
@@ -102,7 +101,7 @@ int main(int argc, char *argv[]) {
   if (totalProcs != 2) {
     if (proc == 0)
       printf("test_multi_comm_put requires exactly 2 MPI processes.\n");
-    flagcxHandleFree(handler);
+    flagcxDeviceHandleFree(devHandle);
     MPI_Finalize();
     return 0;
   }
@@ -114,30 +113,25 @@ int main(int argc, char *argv[]) {
   const int senderRank = 0;
   const int receiverRank = 1;
 
-  flagcxUniqueId_t uid1 = NULL;
-  flagcxCalloc(&uid1, 1);
+  flagcxUniqueId uid1;
   if (proc == 0)
     flagcxGetUniqueId(&uid1);
-  MPI_Bcast((void *)uid1, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+  MPI_Bcast((void *)&uid1, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
   flagcxComm_t comm1 = NULL;
-  fatal(flagcxCommInitRank(&comm1, totalProcs, uid1, proc),
+  fatal(flagcxCommInitRank(&comm1, totalProcs, &uid1, proc),
         "flagcxCommInitRank (comm1) failed", proc);
 
-  flagcxUniqueId_t uid2 = NULL;
-  flagcxCalloc(&uid2, 1);
+  flagcxUniqueId uid2;
   if (proc == 0)
     flagcxGetUniqueId(&uid2);
-  MPI_Bcast((void *)uid2, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+  MPI_Bcast((void *)&uid2, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
   flagcxComm_t comm2 = NULL;
-  fatal(flagcxCommInitRank(&comm2, totalProcs, uid2, proc),
+  fatal(flagcxCommInitRank(&comm2, totalProcs, &uid2, proc),
         "flagcxCommInitRank (comm2) failed", proc);
-
-  free(uid1);
-  free(uid2);
 
   if (proc == 0)
     printf("[test] comm1=%p  comm2=%p\n", (void *)comm1, (void *)comm2);
@@ -320,7 +314,7 @@ cleanup_no_onesided:
 
   flagcxCommDestroy(comm1);
   flagcxCommDestroy(comm2);
-  flagcxHandleFree(handler);
+  flagcxDeviceHandleFree(devHandle);
 
   MPI_Finalize();
   return 0;

--- a/test/perf/host_api/test_put.cpp
+++ b/test/perf/host_api/test_put.cpp
@@ -42,11 +42,10 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  flagcxHandlerGroup_t handler;
-  flagcxHandleInit(&handler);
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
+  flagcxDeviceHandleInit(&devHandle);
+  flagcxUniqueId uniqueId;
 
   int color = 0;
   int worldSize = 1, worldRank = 0;
@@ -61,10 +60,10 @@ int main(int argc, char *argv[]) {
 
   if (proc == 0)
     flagcxGetUniqueId(&uniqueId);
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0, splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  flagcxCommInitRank(&comm, totalProcs, uniqueId, proc);
+  flagcxCommInitRank(&comm, totalProcs, &uniqueId, proc);
 
   int isHomo = 0;
   flagcxIsHomoComm(comm, &isHomo);
@@ -74,7 +73,7 @@ int main(int argc, char *argv[]) {
              "(isHomo=%d).\n",
              isHomo);
     flagcxCommDestroy(comm);
-    flagcxHandleFree(handler);
+    flagcxDeviceHandleFree(devHandle);
     MPI_Finalize();
     return 0;
   }
@@ -141,7 +140,7 @@ int main(int argc, char *argv[]) {
     flagcxMemFree(dataWindow);
     flagcxMemFree(signalWindow);
     flagcxCommDestroy(comm);
-    flagcxHandleFree(handler);
+    flagcxDeviceHandleFree(devHandle);
     MPI_Finalize();
     return 0;
   }
@@ -301,7 +300,8 @@ int main(int argc, char *argv[]) {
   }
 
   fatal(flagcxCommDestroy(comm), "flagcxCommDestroy failed", proc);
-  fatal(flagcxHandleFree(handler), "flagcxHandleFree failed", proc);
+  fatal(flagcxDeviceHandleFree(devHandle), "flagcxDeviceHandleFree failed",
+        proc);
 
   MPI_Finalize();
   return 0;

--- a/test/perf_common.cc
+++ b/test/perf_common.cc
@@ -15,10 +15,8 @@ void perfSetup(PerfContext &ctx, int argc, char **argv,
   ctx.splitMask = ctx.args->getSplitMask();
   ctx.localRegister = ctx.args->getLocalRegister();
 
-  // Initialize FlagCX handles
-  flagcxHandleInit(&ctx.handler);
-  ctx.comm = ctx.handler->comm;
-  ctx.devHandle = ctx.handler->devHandle;
+  // Initialize FlagCX device handle
+  flagcxDeviceHandleInit(&ctx.devHandle);
 
   // Initialize MPI environment
   ctx.color = 0;
@@ -39,16 +37,15 @@ void perfSetup(PerfContext &ctx, int argc, char **argv,
   ctx.devHandle->setDevice(ctx.worldRank % nGpu);
 
   // Create and broadcast uniqueId
-  flagcxUniqueId_t &uniqueId = ctx.handler->uniqueId;
+  flagcxUniqueId uniqueId;
   if (ctx.proc == 0)
     flagcxGetUniqueId(&uniqueId);
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
             ctx.splitComm);
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Initialize communicator
-  flagcxCommInitRank(&ctx.handler->comm, ctx.totalProcs, uniqueId, ctx.proc);
-  ctx.comm = ctx.handler->comm;
+  flagcxCommInitRank(&ctx.comm, ctx.totalProcs, &uniqueId, ctx.proc);
 
   // Create stream
   ctx.devHandle->streamCreate(&ctx.stream);
@@ -95,7 +92,7 @@ void perfTeardown(PerfContext &ctx) {
   free(ctx.hello);
   ctx.devHandle->streamDestroy(ctx.stream);
   flagcxCommDestroy(ctx.comm);
-  flagcxHandleFree(ctx.handler);
+  flagcxDeviceHandleFree(ctx.devHandle);
   delete ctx.args;
 
   MPI_Finalize();

--- a/test/unittest/adaptor/test_device_adaptor.cpp
+++ b/test/unittest/adaptor/test_device_adaptor.cpp
@@ -15,8 +15,7 @@ class DeviceAdaptorTest : public ::testing::Test {
 protected:
   void SetUp() override {
     // Initialize flagcx handle
-    flagcxHandleInit(&handler);
-    devHandle = handler->devHandle;
+    flagcxDeviceHandleInit(&devHandle);
 
     // Get device count and set device 0
     int numDevices = 0;
@@ -35,11 +34,11 @@ protected:
     if (stream) {
       devHandle->streamDestroy(stream);
     }
-    flagcxHandleFree(handler);
+    flagcxDeviceHandleFree(devHandle);
   }
 
-  flagcxHandlerGroup_t handler = nullptr;
   flagcxDeviceHandle_t devHandle = nullptr;
+  flagcxComm_t comm = nullptr;
   flagcxStream_t stream = nullptr;
 
   static constexpr size_t TEST_SIZE = 1024 * sizeof(float); // 1K floats

--- a/test/unittest/coll/flagcx_coll_test.cpp
+++ b/test/unittest/coll/flagcx_coll_test.cpp
@@ -6,10 +6,8 @@ void FlagCXCollTest::SetUp() {
   std::cout << "rank = " << rank << "; nranks = " << nranks << std::endl;
 
   // initialize flagcx handles
-  flagcxHandleInit(&handler);
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandleInit(&devHandle);
+  flagcxUniqueId uniqueId;
   sendbuff = nullptr;
   recvbuff = nullptr;
   hostsendbuff = nullptr;
@@ -24,12 +22,12 @@ void FlagCXCollTest::SetUp() {
   // Create and broadcast uniqueId
   if (rank == 0)
     flagcxGetUniqueId(&uniqueId);
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
             MPI_COMM_WORLD);
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Create comm and stream
-  flagcxCommInitRank(&comm, nranks, uniqueId, rank);
+  flagcxCommInitRank(&comm, nranks, &uniqueId, rank);
   devHandle->streamCreate(&stream);
 
   // allocate data and set inital value
@@ -43,11 +41,9 @@ void FlagCXCollTest::SetUp() {
 
 void FlagCXCollTest::TearDown() {
   // destroy comm
-  flagcxComm_t &comm = handler->comm;
   flagcxCommDestroy(comm);
 
   // destroy stream
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
   devHandle->streamDestroy(stream);
 
   // free data
@@ -57,7 +53,7 @@ void FlagCXCollTest::TearDown() {
   devHandle->deviceFree(hostrecvbuff, flagcxMemHost, NULL);
 
   // free handles
-  flagcxHandleFree(handler);
+  flagcxDeviceHandleFree(devHandle);
 
   FlagCXTest::TearDown();
 }

--- a/test/unittest/coll/include/flagcx_coll_test.hpp
+++ b/test/unittest/coll/include/flagcx_coll_test.hpp
@@ -13,7 +13,8 @@ protected:
 
   void Run();
 
-  flagcxHandlerGroup_t handler;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
   flagcxStream_t stream;
   void *sendbuff;
   void *recvbuff;

--- a/test/unittest/core/include/core_fixtures.hpp
+++ b/test/unittest/core/include/core_fixtures.hpp
@@ -8,5 +8,6 @@ protected:
   void SetUp() override;
   void TearDown() override;
 
-  flagcxHandlerGroup_t handler;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
 };

--- a/test/unittest/core/include/core_fixtures.hpp
+++ b/test/unittest/core/include/core_fixtures.hpp
@@ -8,6 +8,7 @@ protected:
   void SetUp() override;
   void TearDown() override;
 
-  flagcxDeviceHandle_t devHandle;
-  flagcxComm_t comm;
+  flagcxDeviceHandle_t devHandle = nullptr;
+  flagcxComm_t comm = nullptr;
+  flagcxUniqueId uniqueId;
 };

--- a/test/unittest/core/main_mpi.cpp
+++ b/test/unittest/core/main_mpi.cpp
@@ -15,9 +15,8 @@ void FlagCXTest::SetUp() {
 void FlagCXTopoTest::SetUp() {
   FlagCXTest::SetUp();
 
-  flagcxHandleInit(&handler);
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandleInit(&devHandle);
+  flagcxUniqueId uniqueId;
 
   int numDevices;
   devHandle->getDeviceCount(&numDevices);
@@ -25,16 +24,16 @@ void FlagCXTopoTest::SetUp() {
 
   if (rank == 0)
     flagcxGetUniqueId(&uniqueId);
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
             MPI_COMM_WORLD);
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
 void FlagCXTopoTest::TearDown() {
-  if (handler->comm) {
-    flagcxCommDestroy(handler->comm);
+  if (comm) {
+    flagcxCommDestroy(comm);
   }
-  flagcxHandleFree(handler);
+  flagcxDeviceHandleFree(devHandle);
 }
 
 // ---------- main ----------

--- a/test/unittest/core/main_mpi.cpp
+++ b/test/unittest/core/main_mpi.cpp
@@ -16,7 +16,6 @@ void FlagCXTopoTest::SetUp() {
   FlagCXTest::SetUp();
 
   flagcxDeviceHandleInit(&devHandle);
-  flagcxUniqueId uniqueId;
 
   int numDevices;
   devHandle->getDeviceCount(&numDevices);

--- a/test/unittest/device/device_adaptor_test.cpp
+++ b/test/unittest/device/device_adaptor_test.cpp
@@ -14,8 +14,7 @@ class DeviceAdaptorTest : public ::testing::Test {
 protected:
   void SetUp() override {
     // Initialize flagcx handle
-    flagcxHandleInit(&handler);
-    devHandle = handler->devHandle;
+    flagcxDeviceHandleInit(&devHandle);
 
     // Get device count and set device 0
     int numDevices = 0;
@@ -34,11 +33,11 @@ protected:
     if (stream) {
       devHandle->streamDestroy(stream);
     }
-    flagcxHandleFree(handler);
+    flagcxDeviceHandleFree(devHandle);
   }
 
-  flagcxHandlerGroup_t handler = nullptr;
   flagcxDeviceHandle_t devHandle = nullptr;
+  flagcxComm_t comm = nullptr;
   flagcxStream_t stream = nullptr;
 
   static constexpr size_t TEST_SIZE = 1024 * sizeof(float); // 1K floats

--- a/test/unittest/kernel/coll_deviceptr_allreduce.cpp
+++ b/test/unittest/kernel/coll_deviceptr_allreduce.cpp
@@ -54,8 +54,8 @@ TEST_F(DeviceApiTest, IntraAllReduceViaDevicePtr) {
     hostInit[i] = (float)(worldRank + 1);
   }
 
-  ASSERT_EQ(handler->devHandle->deviceMemcpy(regBuff, hostInit, size,
-                                             flagcxMemcpyHostToDevice, nullptr),
+  ASSERT_EQ(devHandle->deviceMemcpy(regBuff, hostInit, size,
+                                    flagcxMemcpyHostToDevice, nullptr),
             flagcxSuccess);
   delete[] hostInit;
 
@@ -65,15 +65,15 @@ TEST_F(DeviceApiTest, IntraAllReduceViaDevicePtr) {
   EXPECT_EQ(
       flagcxIntraAllReduce(devMem, floatCount, flagcxFloat, devComm, stream),
       flagcxSuccess);
-  ASSERT_EQ(handler->devHandle->streamSynchronize(stream), flagcxSuccess);
+  ASSERT_EQ(devHandle->streamSynchronize(stream), flagcxSuccess);
 
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Verify: expected value = sum(1..nRanks) = nRanks*(nRanks+1)/2
   float expected = (float)(worldSize * (worldSize + 1)) / 2.0f;
   float *hostResult = new float[floatCount];
-  ASSERT_EQ(handler->devHandle->deviceMemcpy(hostResult, regBuff, size,
-                                             flagcxMemcpyDeviceToHost, nullptr),
+  ASSERT_EQ(devHandle->deviceMemcpy(hostResult, regBuff, size,
+                                    flagcxMemcpyDeviceToHost, nullptr),
             flagcxSuccess);
 
   for (size_t i = 0; i < floatCount; i++) {

--- a/test/unittest/kernel/coll_kernel_p2p.cpp
+++ b/test/unittest/kernel/coll_kernel_p2p.cpp
@@ -13,8 +13,6 @@
 #include <iostream>
 
 TEST_F(FlagCXKernelTest, DISABLED_TwoSidedAlltoAll) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   size_t countPerPeer = count / nranks;
 
@@ -76,8 +74,6 @@ TEST_F(FlagCXKernelTest, DISABLED_TwoSidedAlltoAll) {
 }
 
 TEST_F(FlagCXKernelTest, DISABLED_OneSidedAlltoAll) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   size_t countPerPeer = count / nranks;
 

--- a/test/unittest/kernel/deviceapi_test.cpp
+++ b/test/unittest/kernel/deviceapi_test.cpp
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 
 // Static member definitions
-flagcxHandlerGroup_t DeviceApiTest::handler = nullptr;
+flagcxDeviceHandle_t DeviceApiTest::devHandle = nullptr;
 flagcxComm_t DeviceApiTest::comm = nullptr;
 flagcxStream_t DeviceApiTest::stream = nullptr;
 void *DeviceApiTest::devBuff = nullptr;
@@ -15,45 +15,40 @@ void DeviceApiTest::SetUpTestSuite() {
 
   size = DEVICEAPI_TEST_SIZE;
 
-  ASSERT_EQ(flagcxHandleInit(&handler), flagcxSuccess);
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  ASSERT_EQ(flagcxDeviceHandleInit(&devHandle), flagcxSuccess);
 
   int numDevices;
   ASSERT_EQ(devHandle->getDeviceCount(&numDevices), flagcxSuccess);
   ASSERT_EQ(devHandle->setDevice(rank % numDevices), flagcxSuccess);
 
-  flagcxUniqueId_t uniqueId = nullptr;
+  flagcxUniqueId uniqueId;
   if (rank == 0) {
     ASSERT_EQ(flagcxGetUniqueId(&uniqueId), flagcxSuccess);
-  } else {
-    uniqueId = (flagcxUniqueId_t)calloc(1, sizeof(flagcxUniqueId));
-    ASSERT_NE(uniqueId, nullptr);
   }
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
             MPI_COMM_WORLD);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  ASSERT_EQ(flagcxCommInitRank(&comm, nranks, uniqueId, rank), flagcxSuccess);
-  free(uniqueId);
+  ASSERT_EQ(flagcxCommInitRank(&comm, nranks, &uniqueId, rank), flagcxSuccess);
 
   ASSERT_EQ(devHandle->streamCreate(&stream), flagcxSuccess);
   ASSERT_EQ(flagcxMemAlloc(&devBuff, size), flagcxSuccess);
 }
 
 void DeviceApiTest::TearDownTestSuite() {
-  if (handler == nullptr)
+  if (devHandle == nullptr)
     return;
 
-  handler->devHandle->streamDestroy(stream);
+  devHandle->streamDestroy(stream);
 
   if (comm)
     flagcxCommDestroy(comm);
 
   flagcxMemFree(devBuff);
 
-  flagcxHandleFree(handler);
+  flagcxDeviceHandleFree(devHandle);
 
-  handler = nullptr;
+  devHandle = nullptr;
   comm = nullptr;
   stream = nullptr;
   devBuff = nullptr;

--- a/test/unittest/kernel/flagcx_kernel_test.cpp
+++ b/test/unittest/kernel/flagcx_kernel_test.cpp
@@ -6,10 +6,8 @@ void FlagCXKernelTest::SetUp() {
   FlagCXTest::SetUp();
 
   // initialize flagcx handles
-  flagcxHandleInit(&handler);
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandleInit(&devHandle);
+  flagcxUniqueId uniqueId;
   sendbuff = nullptr;
   recvbuff = nullptr;
   hostsendbuff = nullptr;
@@ -24,12 +22,12 @@ void FlagCXKernelTest::SetUp() {
   // Create and broadcast uniqueId
   if (rank == 0)
     flagcxGetUniqueId(&uniqueId);
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
             MPI_COMM_WORLD);
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Create comm and stream
-  flagcxCommInitRank(&comm, nranks, uniqueId, rank);
+  flagcxCommInitRank(&comm, nranks, &uniqueId, rank);
   devHandle->streamCreate(&stream);
 
   // allocate device buffers
@@ -44,8 +42,6 @@ void FlagCXKernelTest::SetUp() {
 }
 
 void FlagCXKernelTest::TearDown() {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   // Destroy stream first (sync any pending work)
   devHandle->streamDestroy(stream);
@@ -62,7 +58,7 @@ void FlagCXKernelTest::TearDown() {
   free(hostrecvbuff);
 
   // free handles
-  flagcxHandleFree(handler);
+  flagcxDeviceHandleFree(devHandle);
 
   FlagCXTest::TearDown();
 }

--- a/test/unittest/kernel/include/deviceapi_test.hpp
+++ b/test/unittest/kernel/include/deviceapi_test.hpp
@@ -13,7 +13,7 @@ protected:
   void SetUp() override;
   void TearDown() override {}
 
-  static flagcxHandlerGroup_t handler;
+  static flagcxDeviceHandle_t devHandle;
   static flagcxComm_t comm;
   static flagcxStream_t stream;
   static void *devBuff;

--- a/test/unittest/kernel/include/flagcx_kernel_test.hpp
+++ b/test/unittest/kernel/include/flagcx_kernel_test.hpp
@@ -14,8 +14,8 @@ protected:
 
   void Run();
 
-  flagcxDeviceHandle_t devHandle;
-  flagcxComm_t comm;
+  flagcxDeviceHandle_t devHandle = nullptr;
+  flagcxComm_t comm = nullptr;
   flagcxStream_t stream;
   void *sendbuff;
   void *recvbuff;

--- a/test/unittest/kernel/include/flagcx_kernel_test.hpp
+++ b/test/unittest/kernel/include/flagcx_kernel_test.hpp
@@ -14,7 +14,8 @@ protected:
 
   void Run();
 
-  flagcxHandlerGroup_t handler;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
   flagcxStream_t stream;
   void *sendbuff;
   void *recvbuff;

--- a/test/unittest/main.cpp
+++ b/test/unittest/main.cpp
@@ -13,8 +13,6 @@
 #define NUM_BASELINE_ENTRIES 1000
 
 TEST_F(FlagCXCollTest, AllReduce) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   for (size_t i = 0; i < count; i++) {
     ((float *)hostsendbuff)[i] = i % 10;
@@ -61,8 +59,6 @@ TEST_F(FlagCXCollTest, AllReduce) {
 }
 
 TEST_F(FlagCXCollTest, AllGather) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   for (size_t i = 0; i < count; i++) {
     ((float *)hostsendbuff)[i] = i % 10;
@@ -107,8 +103,6 @@ TEST_F(FlagCXCollTest, AllGather) {
 }
 
 TEST_F(FlagCXCollTest, ReduceScatter) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   for (size_t i = 0; i < count; i++) {
     ((float *)hostsendbuff)[i] = i % 10;
@@ -151,8 +145,6 @@ TEST_F(FlagCXCollTest, ReduceScatter) {
 }
 
 TEST_F(FlagCXCollTest, Reduce) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   for (size_t i = 0; i < count; i++) {
     ((float *)hostsendbuff)[i] = i % 10;
@@ -195,8 +187,6 @@ TEST_F(FlagCXCollTest, Reduce) {
 }
 
 TEST_F(FlagCXCollTest, Gather) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   for (size_t i = 0; i < count; i++) {
     ((float *)hostsendbuff)[i] = i % 10;
@@ -241,8 +231,6 @@ TEST_F(FlagCXCollTest, Gather) {
 }
 
 TEST_F(FlagCXCollTest, Scatter) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   if (rank == 0) {
     for (size_t i = 0; i < count; i++) {
@@ -285,8 +273,6 @@ TEST_F(FlagCXCollTest, Scatter) {
 }
 
 TEST_F(FlagCXCollTest, Broadcast) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   for (size_t i = 0; i < count; i++) {
     ((float *)hostsendbuff)[i] = i % 10;
@@ -327,11 +313,10 @@ TEST_F(FlagCXCollTest, Broadcast) {
 }
 
 TEST_F(FlagCXTopoTest, TopoDetection) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
+  flagcxUniqueId uniqueId;
 
   std::cout << "executing flagcxCommInitRank" << std::endl;
-  auto result = flagcxCommInitRank(&comm, nranks, uniqueId, rank);
+  auto result = flagcxCommInitRank(&comm, nranks, &uniqueId, rank);
   EXPECT_EQ(result, flagcxSuccess);
 }
 
@@ -339,8 +324,6 @@ TEST_F(FlagCXTopoTest, TopoDetection) {
 // Intra-node AllReduce: each rank fills with (rank+1), verify sum
 // ---------------------------------------------------------------------------
 TEST_F(FlagCXKernelTest, IntraAllReduce) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   // Allocate a separate buffer for the kernel (aligned with
   // test_kernel_intranode -R 0)
@@ -402,8 +385,6 @@ TEST_F(FlagCXKernelTest, IntraAllReduce) {
 // Inter-node AlltoAll: two-sided send/recv via FIFO
 // ---------------------------------------------------------------------------
 TEST_F(FlagCXKernelTest, InterTwoSidedAlltoAll) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   // count per peer
   size_t countPerPeer = count / nranks;
@@ -472,8 +453,6 @@ TEST_F(FlagCXKernelTest, InterTwoSidedAlltoAll) {
 // Inter-node one-sided AlltoAll: put + waitSignal + flush
 // ---------------------------------------------------------------------------
 TEST_F(FlagCXKernelTest, InterOneSidedAlltoAll) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   size_t countPerPeer = count / nranks;
 

--- a/test/unittest/main.cpp
+++ b/test/unittest/main.cpp
@@ -313,8 +313,6 @@ TEST_F(FlagCXCollTest, Broadcast) {
 }
 
 TEST_F(FlagCXTopoTest, TopoDetection) {
-  flagcxUniqueId uniqueId;
-
   std::cout << "executing flagcxCommInitRank" << std::endl;
   auto result = flagcxCommInitRank(&comm, nranks, &uniqueId, rank);
   EXPECT_EQ(result, flagcxSuccess);

--- a/test/unittest/p2p/test_p2p_engine_read.cpp
+++ b/test/unittest/p2p/test_p2p_engine_read.cpp
@@ -234,15 +234,13 @@ protected:
   static constexpr int kServerGpuIdx = 1;
 
   void SetUp() override {
-    ASSERT_EQ(flagcxHandleInit(&handler), flagcxSuccess);
-    devHandle = handler->devHandle;
+    ASSERT_EQ(flagcxDeviceHandleInit(&devHandle), flagcxSuccess);
     ASSERT_NE(devHandle, nullptr);
 
     int numDevices = 0;
     ASSERT_EQ(devHandle->getDeviceCount(&numDevices), flagcxSuccess);
     if (numDevices <= kServerGpuIdx) {
-      flagcxHandleFree(handler);
-      handler = nullptr;
+      flagcxDeviceHandleFree(devHandle);
       devHandle = nullptr;
       GTEST_SKIP() << "At least 2 GPU devices are required";
     }
@@ -273,8 +271,7 @@ protected:
         devHandle->streamDestroy(clientStream);
         clientStream = nullptr;
       }
-      flagcxHandleFree(handler);
-      handler = nullptr;
+      flagcxDeviceHandleFree(devHandle);
       devHandle = nullptr;
       GTEST_SKIP()
           << "Unable to create FlagCX P2P engines; likely no IB-capable device";
@@ -308,9 +305,8 @@ protected:
       devHandle->streamDestroy(clientStream);
       clientStream = nullptr;
     }
-    if (handler != nullptr) {
-      flagcxHandleFree(handler);
-      handler = nullptr;
+    if (devHandle != nullptr) {
+      flagcxDeviceHandleFree(devHandle);
       devHandle = nullptr;
     }
   }
@@ -398,8 +394,8 @@ protected:
     ASSERT_EQ(devHandle->streamSynchronize(stream), flagcxSuccess);
   }
 
-  flagcxHandlerGroup_t handler = nullptr;
   flagcxDeviceHandle_t devHandle = nullptr;
+  flagcxComm_t comm = nullptr;
   flagcxStream_t clientStream = nullptr;
   flagcxStream_t serverStream = nullptr;
   FlagcxP2pEngine *serverEngine = nullptr;

--- a/test/unittest/runner/coll_allgather.cpp
+++ b/test/unittest/runner/coll_allgather.cpp
@@ -5,8 +5,6 @@
 #include <vector>
 
 TEST_F(FlagCXCollTest, AllGather) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   for (size_t i = 0; i < count; i++) {
     ((float *)hostsendbuff)[i] = rank * 1000.0f + (i % 10);

--- a/test/unittest/runner/coll_allreduce.cpp
+++ b/test/unittest/runner/coll_allreduce.cpp
@@ -5,8 +5,6 @@
 #include <vector>
 
 TEST_F(FlagCXCollTest, AllReduce) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   for (size_t i = 0; i < count; i++) {
     ((float *)hostsendbuff)[i] = rank * 1000.0f + (i % 10);

--- a/test/unittest/runner/coll_alltoall.cpp
+++ b/test/unittest/runner/coll_alltoall.cpp
@@ -9,8 +9,6 @@
 #include <iostream>
 
 TEST_F(FlagCXCollTest, AlltoAll) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   size_t countPerRank = count / nranks;
 

--- a/test/unittest/runner/coll_broadcast.cpp
+++ b/test/unittest/runner/coll_broadcast.cpp
@@ -5,8 +5,6 @@
 #include <vector>
 
 TEST_F(FlagCXCollTest, Broadcast) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   // Only root (rank 0) initializes sendbuff; other ranks leave it zeroed
   // so stale data would be detected if broadcast fails.

--- a/test/unittest/runner/coll_gather.cpp
+++ b/test/unittest/runner/coll_gather.cpp
@@ -5,8 +5,6 @@
 #include <vector>
 
 TEST_F(FlagCXCollTest, Gather) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   for (size_t i = 0; i < count; i++) {
     ((float *)hostsendbuff)[i] = rank * 1000.0f + (i % 10);

--- a/test/unittest/runner/coll_reduce.cpp
+++ b/test/unittest/runner/coll_reduce.cpp
@@ -5,8 +5,6 @@
 #include <vector>
 
 TEST_F(FlagCXCollTest, Reduce) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   for (size_t i = 0; i < count; i++) {
     ((float *)hostsendbuff)[i] = rank * 1000.0f + (i % 10);

--- a/test/unittest/runner/coll_reducescatter.cpp
+++ b/test/unittest/runner/coll_reducescatter.cpp
@@ -5,8 +5,6 @@
 #include <vector>
 
 TEST_F(FlagCXCollTest, ReduceScatter) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   for (size_t i = 0; i < count; i++) {
     ((float *)hostsendbuff)[i] = rank * 1000.0f + (i % 10);

--- a/test/unittest/runner/coll_scatter.cpp
+++ b/test/unittest/runner/coll_scatter.cpp
@@ -6,8 +6,6 @@
 #include <vector>
 
 TEST_F(FlagCXCollTest, Scatter) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   if (rank == 0) {
     for (size_t i = 0; i < count; i++) {

--- a/test/unittest/runner/coll_sendrecv.cpp
+++ b/test/unittest/runner/coll_sendrecv.cpp
@@ -9,8 +9,6 @@
 #include <iostream>
 
 TEST_F(FlagCXCollTest, SendRecv) {
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
 
   int sendPeer = (rank + 1) % nranks;
   int recvPeer = (rank - 1 + nranks) % nranks;

--- a/test/unittest/runner/include/runner_fixtures.hpp
+++ b/test/unittest/runner/include/runner_fixtures.hpp
@@ -23,8 +23,8 @@ protected:
   void SetUp() override;
   void TearDown() override;
 
-  flagcxDeviceHandle_t devHandle;
-  flagcxComm_t comm;
+  flagcxDeviceHandle_t devHandle = nullptr;
+  flagcxComm_t comm = nullptr;
   flagcxStream_t stream;
   void *sendbuff;
   void *recvbuff;

--- a/test/unittest/runner/include/runner_fixtures.hpp
+++ b/test/unittest/runner/include/runner_fixtures.hpp
@@ -23,7 +23,8 @@ protected:
   void SetUp() override;
   void TearDown() override;
 
-  flagcxHandlerGroup_t handler;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
   flagcxStream_t stream;
   void *sendbuff;
   void *recvbuff;

--- a/test/unittest/runner/main_mpi.cpp
+++ b/test/unittest/runner/main_mpi.cpp
@@ -33,10 +33,7 @@ void FlagCXTest::SetUp() {
 void FlagCXCollTest::SetUp() {
   FlagCXTest::SetUp();
 
-  flagcxHandleInit(&handler);
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxComm_t &comm = handler->comm;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandleInit(&devHandle);
   sendbuff = nullptr;
   recvbuff = nullptr;
   hostsendbuff = nullptr;
@@ -48,13 +45,14 @@ void FlagCXCollTest::SetUp() {
   devHandle->getDeviceCount(&numDevices);
   devHandle->setDevice(rank % numDevices);
 
+  flagcxUniqueId uniqueId;
   if (rank == 0)
     flagcxGetUniqueId(&uniqueId);
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
             MPI_COMM_WORLD);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  flagcxCommInitRank(&comm, nranks, uniqueId, rank);
+  flagcxCommInitRank(&comm, nranks, &uniqueId, rank);
   devHandle->streamCreate(&stream);
 
   devHandle->deviceMalloc(&sendbuff, size, flagcxMemDevice, NULL);
@@ -66,16 +64,15 @@ void FlagCXCollTest::SetUp() {
 }
 
 void FlagCXCollTest::TearDown() {
-  flagcxCommDestroy(handler->comm);
+  flagcxCommDestroy(comm);
 
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
   devHandle->streamDestroy(stream);
   devHandle->deviceFree(sendbuff, flagcxMemDevice, NULL);
   devHandle->deviceFree(recvbuff, flagcxMemDevice, NULL);
   devHandle->deviceFree(hostsendbuff, flagcxMemHost, NULL);
   devHandle->deviceFree(hostrecvbuff, flagcxMemHost, NULL);
 
-  flagcxHandleFree(handler);
+  flagcxDeviceHandleFree(devHandle);
   FlagCXTest::TearDown();
 
   // Synchronize all ranks before the next test to prevent bootstrap hangs

--- a/test/unittest/symmem/coll_sym_access.cpp
+++ b/test/unittest/symmem/coll_sym_access.cpp
@@ -38,9 +38,9 @@ TEST_F(SymMemTest, CrossGpuReadViaPeerPtr) {
   // Each rank fills its own region with (localRank + 1) as a float pattern
   float fillValue = (float)(localRank + 1);
   std::vector<float> pattern(count, fillValue);
-  handler->devHandle->deviceMemcpy(devBuff, pattern.data(), size,
-                                   flagcxMemcpyHostToDevice, stream);
-  handler->devHandle->streamSynchronize(stream);
+  devHandle->deviceMemcpy(devBuff, pattern.data(), size,
+                          flagcxMemcpyHostToDevice, stream);
+  devHandle->streamSynchronize(stream);
 
   MPI_Barrier(MPI_COMM_WORLD);
 
@@ -50,11 +50,11 @@ TEST_F(SymMemTest, CrossGpuReadViaPeerPtr) {
 
   // Stage through local device memory: peer VMM -> devBuff2 -> host
   std::vector<float> readBack(count, 0.0f);
-  handler->devHandle->deviceMemcpy(devBuff2, peerRegion, size,
-                                   flagcxMemcpyDeviceToDevice, stream);
-  handler->devHandle->deviceMemcpy(readBack.data(), devBuff2, size,
-                                   flagcxMemcpyDeviceToHost, stream);
-  handler->devHandle->streamSynchronize(stream);
+  devHandle->deviceMemcpy(devBuff2, peerRegion, size,
+                          flagcxMemcpyDeviceToDevice, stream);
+  devHandle->deviceMemcpy(readBack.data(), devBuff2, size,
+                          flagcxMemcpyDeviceToHost, stream);
+  devHandle->streamSynchronize(stream);
 
   // Verify: peer's region should contain (peerLocalRank + 1)
   float expected = (float)(peerLocalRank + 1);
@@ -106,8 +106,8 @@ TEST_F(SymMemTest, CrossGpuWriteViaPeerPtr) {
   size_t allocSize = d->allocSize;
 
   // Zero out own region first
-  handler->devHandle->deviceMemset(devBuff, 0, size, flagcxMemDevice, stream);
-  handler->devHandle->streamSynchronize(stream);
+  devHandle->deviceMemset(devBuff, 0, size, flagcxMemDevice, stream);
+  devHandle->streamSynchronize(stream);
 
   MPI_Barrier(MPI_COMM_WORLD);
 
@@ -120,11 +120,11 @@ TEST_F(SymMemTest, CrossGpuWriteViaPeerPtr) {
 
   float writeValue = (float)(localRank + 100);
   std::vector<float> pattern(count, writeValue);
-  handler->devHandle->deviceMemcpy(devBuff2, pattern.data(), size,
-                                   flagcxMemcpyHostToDevice, stream);
-  handler->devHandle->deviceMemcpy(targetRegion, devBuff2, size,
-                                   flagcxMemcpyDeviceToDevice, stream);
-  handler->devHandle->streamSynchronize(stream);
+  devHandle->deviceMemcpy(devBuff2, pattern.data(), size,
+                          flagcxMemcpyHostToDevice, stream);
+  devHandle->deviceMemcpy(targetRegion, devBuff2, size,
+                          flagcxMemcpyDeviceToDevice, stream);
+  devHandle->streamSynchronize(stream);
 
   MPI_Barrier(MPI_COMM_WORLD);
 
@@ -133,9 +133,9 @@ TEST_F(SymMemTest, CrossGpuWriteViaPeerPtr) {
   float expected = (float)(writerLocalRank + 100);
 
   std::vector<float> readBack(count, 0.0f);
-  handler->devHandle->deviceMemcpy(readBack.data(), devBuff, size,
-                                   flagcxMemcpyDeviceToHost, stream);
-  handler->devHandle->streamSynchronize(stream);
+  devHandle->deviceMemcpy(readBack.data(), devBuff, size,
+                          flagcxMemcpyDeviceToHost, stream);
+  devHandle->streamSynchronize(stream);
 
   int mismatches = 0;
   for (size_t i = 0; i < count && mismatches < 10; i++) {

--- a/test/unittest/symmem/include/symmem_test.hpp
+++ b/test/unittest/symmem/include/symmem_test.hpp
@@ -19,7 +19,7 @@ protected:
 
   bool hasHeteroComm() const;
 
-  static flagcxHandlerGroup_t handler;
+  static flagcxDeviceHandle_t devHandle;
   static flagcxComm_t comm;
   static flagcxStream_t stream;
   static void *devBuff;

--- a/test/unittest/symmem/symmem_test.cpp
+++ b/test/unittest/symmem/symmem_test.cpp
@@ -2,7 +2,7 @@
 #include <cstring>
 
 // Static member definitions
-flagcxHandlerGroup_t SymMemTest::handler = nullptr;
+flagcxDeviceHandle_t SymMemTest::devHandle = nullptr;
 flagcxComm_t SymMemTest::comm = nullptr;
 flagcxStream_t SymMemTest::stream = nullptr;
 void *SymMemTest::devBuff = nullptr;
@@ -19,24 +19,20 @@ void SymMemTest::SetUpTestSuite() {
   size = SYMMEM_TEST_SIZE;
   count = size / sizeof(float);
 
-  flagcxHandleInit(&handler);
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandleInit(&devHandle);
 
   int numDevices;
   devHandle->getDeviceCount(&numDevices);
   devHandle->setDevice(rank % numDevices);
 
-  flagcxUniqueId_t uniqueId = nullptr;
+  flagcxUniqueId uniqueId;
   if (rank == 0)
     flagcxGetUniqueId(&uniqueId);
-  else
-    uniqueId = (flagcxUniqueId_t)calloc(1, sizeof(flagcxUniqueId));
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
             MPI_COMM_WORLD);
   MPI_Barrier(MPI_COMM_WORLD);
 
-  flagcxCommInitRank(&comm, nranks, uniqueId, rank);
-  free(uniqueId);
+  flagcxCommInitRank(&comm, nranks, &uniqueId, rank);
 
   devHandle->streamCreate(&stream);
 
@@ -48,10 +44,10 @@ void SymMemTest::SetUpTestSuite() {
 }
 
 void SymMemTest::TearDownTestSuite() {
-  if (handler == nullptr)
+  if (devHandle == nullptr)
     return;
 
-  handler->devHandle->streamDestroy(stream);
+  devHandle->streamDestroy(stream);
 
   if (comm)
     flagcxCommDestroy(comm);
@@ -60,9 +56,9 @@ void SymMemTest::TearDownTestSuite() {
   flagcxMemFree(devBuff2);
   free(hostBuff);
 
-  flagcxHandleFree(handler);
+  flagcxDeviceHandleFree(devHandle);
 
-  handler = nullptr;
+  devHandle = nullptr;
   comm = nullptr;
   stream = nullptr;
   devBuff = nullptr;

--- a/test/unittest/topo/flagcx_topo_test.cpp
+++ b/test/unittest/topo/flagcx_topo_test.cpp
@@ -7,7 +7,6 @@ void FlagCXTopoTest::SetUp() {
 
   // initialize flagcx handles
   flagcxDeviceHandleInit(&devHandle);
-  flagcxUniqueId uniqueId;
 
   int numDevices;
   devHandle->getDeviceCount(&numDevices);
@@ -27,7 +26,8 @@ void FlagCXTopoTest::SetUp() {
 }
 
 void FlagCXTopoTest::TearDown() {
-  flagcxCommDestroy(comm);
-
+  if (comm) {
+    flagcxCommDestroy(comm);
+  }
   flagcxDeviceHandleFree(devHandle);
 }

--- a/test/unittest/topo/flagcx_topo_test.cpp
+++ b/test/unittest/topo/flagcx_topo_test.cpp
@@ -6,9 +6,8 @@ void FlagCXTopoTest::SetUp() {
   std::cout << "rank = " << rank << "; nranks = " << nranks << std::endl;
 
   // initialize flagcx handles
-  flagcxHandleInit(&handler);
-  flagcxUniqueId_t &uniqueId = handler->uniqueId;
-  flagcxDeviceHandle_t &devHandle = handler->devHandle;
+  flagcxDeviceHandleInit(&devHandle);
+  flagcxUniqueId uniqueId;
 
   int numDevices;
   devHandle->getDeviceCount(&numDevices);
@@ -17,7 +16,7 @@ void FlagCXTopoTest::SetUp() {
   if (rank == 0)
     flagcxGetUniqueId(&uniqueId);
   std::cout << "finished getting uniqueId" << std::endl;
-  MPI_Bcast((void *)uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
+  MPI_Bcast((void *)&uniqueId, sizeof(flagcxUniqueId), MPI_BYTE, 0,
             MPI_COMM_WORLD);
   MPI_Barrier(MPI_COMM_WORLD);
 
@@ -28,8 +27,7 @@ void FlagCXTopoTest::SetUp() {
 }
 
 void FlagCXTopoTest::TearDown() {
-  flagcxComm_t &comm = handler->comm;
   flagcxCommDestroy(comm);
 
-  flagcxHandleFree(handler);
+  flagcxDeviceHandleFree(devHandle);
 }

--- a/test/unittest/topo/include/flagcx_topo_test.hpp
+++ b/test/unittest/topo/include/flagcx_topo_test.hpp
@@ -13,8 +13,9 @@ protected:
 
   void Run();
 
-  flagcxDeviceHandle_t devHandle;
-  flagcxComm_t comm;
+  flagcxDeviceHandle_t devHandle = nullptr;
+  flagcxComm_t comm = nullptr;
+  flagcxUniqueId uniqueId;
   flagcxStream_t stream;
   void *sendbuff;
   void *recvbuff;

--- a/test/unittest/topo/include/flagcx_topo_test.hpp
+++ b/test/unittest/topo/include/flagcx_topo_test.hpp
@@ -13,7 +13,8 @@ protected:
 
   void Run();
 
-  flagcxHandlerGroup_t handler;
+  flagcxDeviceHandle_t devHandle;
+  flagcxComm_t comm;
   flagcxStream_t stream;
   void *sendbuff;
   void *recvbuff;

--- a/test/unittest/topo/test_p2p_topo.cpp
+++ b/test/unittest/topo/test_p2p_topo.cpp
@@ -19,7 +19,7 @@ class P2pTopoTest : public ::testing::Test {
 protected:
   void SetUp() override {
     // Initialize device adaptor (sets global deviceAdaptor)
-    flagcxHandleInit(&handler);
+    flagcxDeviceHandleInit(&devHandle);
 
     netAdaptor = &flagcxNetIbP2p;
     ASSERT_EQ(netAdaptor->init(), flagcxSuccess)
@@ -32,9 +32,10 @@ protected:
               << " devices)" << std::endl;
   }
 
-  void TearDown() override { flagcxHandleFree(handler); }
+  void TearDown() override { flagcxDeviceHandleFree(devHandle); }
 
-  flagcxHandlerGroup_t handler = nullptr;
+  flagcxDeviceHandle_t devHandle = nullptr;
+  flagcxComm_t comm = nullptr;
   struct flagcxNetAdaptor *netAdaptor = nullptr;
 };
 


### PR DESCRIPTION
### PR Category
CRL

### PR Types
Deprecations

### PR Description
This PR deprecates flagcxHandlerGroup and refactors call sites to manage the device handle (flagcxDeviceHandle_t), unique ID (flagcxUniqueId), and communicator (flagcxComm_t) lifecycles separately. It also updates the public API so flagcxGetUniqueId writes into caller-provided storage instead of allocating.