### PR TITLE
[CRL] Bootstrap extension

### DIFF
--- a/adaptor_plugin/ccl/example/plugin.cc
+++ b/adaptor_plugin/ccl/example/plugin.cc
@@ -32,9 +32,9 @@ static flagcxResult_t pluginGetStagedBuffer(const flagcxInnerComm_t comm,
   return flagcxInternalError;
 }
 
-static flagcxResult_t
-pluginCommInitRank(flagcxInnerComm_t *comm, int nranks, flagcxUniqueId *commId,
-                   int rank, struct flagcxBootstrapState *bootstrap) {
+static flagcxResult_t pluginCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                                         flagcxUniqueId *commId, int rank,
+                                         struct bootstrapState *bootstrap) {
   return flagcxInternalError;
 }
 

--- a/adaptor_plugin/ccl/example/plugin.cc
+++ b/adaptor_plugin/ccl/example/plugin.cc
@@ -32,9 +32,9 @@ static flagcxResult_t pluginGetStagedBuffer(const flagcxInnerComm_t comm,
   return flagcxInternalError;
 }
 
-static flagcxResult_t pluginCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                         flagcxUniqueId *commId, int rank,
-                                         struct bootstrapState *bootstrap) {
+static flagcxResult_t
+pluginCommInitRank(flagcxInnerComm_t *comm, int nranks, flagcxUniqueId *commId,
+                   int rank, struct flagcxBootstrapState *bootstrap) {
   return flagcxInternalError;
 }
 

--- a/flagcx/adaptor/ccl/bootstrap_adaptor.cc
+++ b/flagcx/adaptor/ccl/bootstrap_adaptor.cc
@@ -70,10 +70,10 @@ const char *bootstrapAdaptorGetLastError(flagcxInnerComm_t comm) {
   return "Not Implemented";
 }
 
-flagcxResult_t
-bootstrapAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                             flagcxUniqueId_t /*commId*/, int rank,
-                             struct flagcxBootstrapState *bootstrap) {
+flagcxResult_t bootstrapAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                                            flagcxUniqueId_t /*commId*/,
+                                            int rank,
+                                            struct bootstrapState *bootstrap) {
   if (*comm == NULL) {
     FLAGCXCHECK(flagcxCalloc(comm, 1));
   }

--- a/flagcx/adaptor/ccl/bootstrap_adaptor.cc
+++ b/flagcx/adaptor/ccl/bootstrap_adaptor.cc
@@ -70,10 +70,10 @@ const char *bootstrapAdaptorGetLastError(flagcxInnerComm_t comm) {
   return "Not Implemented";
 }
 
-flagcxResult_t bootstrapAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                            flagcxUniqueId_t /*commId*/,
-                                            int rank,
-                                            bootstrapState *bootstrap) {
+flagcxResult_t
+bootstrapAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                             flagcxUniqueId_t /*commId*/, int rank,
+                             struct flagcxBootstrapState *bootstrap) {
   if (*comm == NULL) {
     FLAGCXCHECK(flagcxCalloc(comm, 1));
   }
@@ -142,7 +142,7 @@ flagcxResult_t bootstrapAdaptorCommSuspend(flagcxInnerComm_t comm) {
 
 flagcxResult_t bootstrapAdaptorCommCount(const flagcxInnerComm_t comm,
                                          int *count) {
-  *count = comm->base->nranks;
+  *count = comm->base->coll->nranks;
   return flagcxSuccess;
 }
 
@@ -154,7 +154,7 @@ flagcxResult_t bootstrapAdaptorCommCuDevice(const flagcxInnerComm_t comm,
 
 flagcxResult_t bootstrapAdaptorCommUserRank(const flagcxInnerComm_t comm,
                                             int *rank) {
-  *rank = comm->base->rank;
+  *rank = comm->base->coll->rank;
   return flagcxSuccess;
 }
 

--- a/flagcx/adaptor/ccl/bootstrap_adaptor.cc
+++ b/flagcx/adaptor/ccl/bootstrap_adaptor.cc
@@ -142,7 +142,7 @@ flagcxResult_t bootstrapAdaptorCommSuspend(flagcxInnerComm_t comm) {
 
 flagcxResult_t bootstrapAdaptorCommCount(const flagcxInnerComm_t comm,
                                          int *count) {
-  *count = comm->base->coll->nranks;
+  *count = bootstrapGetNranks(comm->base);
   return flagcxSuccess;
 }
 
@@ -154,7 +154,7 @@ flagcxResult_t bootstrapAdaptorCommCuDevice(const flagcxInnerComm_t comm,
 
 flagcxResult_t bootstrapAdaptorCommUserRank(const flagcxInnerComm_t comm,
                                             int *rank) {
-  *rank = comm->base->coll->rank;
+  *rank = bootstrapGetRank(comm->base);
   return flagcxSuccess;
 }
 

--- a/flagcx/adaptor/ccl/cncl_adaptor.cc
+++ b/flagcx/adaptor/ccl/cncl_adaptor.cc
@@ -62,10 +62,9 @@ const char *cnclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return "Not Implemented";
 }
 
-flagcxResult_t
-cnclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                        flagcxUniqueId_t commId, int rank,
-                        struct flagcxBootstrapState * /*bootstrap*/) {
+flagcxResult_t cnclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                                       flagcxUniqueId_t commId, int rank,
+                                       struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/cncl_adaptor.cc
+++ b/flagcx/adaptor/ccl/cncl_adaptor.cc
@@ -62,9 +62,10 @@ const char *cnclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return "Not Implemented";
 }
 
-flagcxResult_t cnclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
-                                       bootstrapState * /*bootstrap*/) {
+flagcxResult_t
+cnclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                        flagcxUniqueId_t commId, int rank,
+                        struct flagcxBootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/dunccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/dunccl_adaptor.cc
@@ -34,7 +34,7 @@ const char *duncclAdaptorGetLastError(flagcxInnerComm_t comm) {
 flagcxResult_t
 duncclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
                           flagcxUniqueId_t commId, int rank,
-                          struct flagcxBootstrapState * /*bootstrap*/) {
+                          struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/dunccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/dunccl_adaptor.cc
@@ -31,9 +31,10 @@ const char *duncclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return ncclGetLastError(comm->base);
 }
 
-flagcxResult_t duncclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                         flagcxUniqueId_t commId, int rank,
-                                         bootstrapState * /*bootstrap*/) {
+flagcxResult_t
+duncclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                          flagcxUniqueId_t commId, int rank,
+                          struct flagcxBootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/eccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/eccl_adaptor.cc
@@ -35,9 +35,10 @@ flagcxResult_t ecclAdaptorGetStagedBuffer(const flagcxInnerComm_t comm,
   return flagcxNotSupported;
 }
 
-flagcxResult_t ecclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
-                                       bootstrapState * /*bootstrap*/) {
+flagcxResult_t
+ecclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                        flagcxUniqueId_t commId, int rank,
+                        struct flagcxBootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/eccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/eccl_adaptor.cc
@@ -35,10 +35,9 @@ flagcxResult_t ecclAdaptorGetStagedBuffer(const flagcxInnerComm_t comm,
   return flagcxNotSupported;
 }
 
-flagcxResult_t
-ecclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                        flagcxUniqueId_t commId, int rank,
-                        struct flagcxBootstrapState * /*bootstrap*/) {
+flagcxResult_t ecclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                                       flagcxUniqueId_t commId, int rank,
+                                       struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/gloo_adaptor.cc
+++ b/flagcx/adaptor/ccl/gloo_adaptor.cc
@@ -85,7 +85,7 @@ const char *glooAdaptorGetLastError(flagcxInnerComm_t comm) {
 
 flagcxResult_t glooAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
                                        flagcxUniqueId_t /*commId*/, int rank,
-                                       struct flagcxBootstrapState *bootstrap) {
+                                       struct bootstrapState *bootstrap) {
   // Create gloo transport device
   std::shared_ptr<::gloo::transport::Device> dev;
   flagcxNetProperties_t *properties =

--- a/flagcx/adaptor/ccl/gloo_adaptor.cc
+++ b/flagcx/adaptor/ccl/gloo_adaptor.cc
@@ -85,7 +85,7 @@ const char *glooAdaptorGetLastError(flagcxInnerComm_t comm) {
 
 flagcxResult_t glooAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
                                        flagcxUniqueId_t /*commId*/, int rank,
-                                       bootstrapState *bootstrap) {
+                                       struct flagcxBootstrapState *bootstrap) {
   // Create gloo transport device
   std::shared_ptr<::gloo::transport::Device> dev;
   flagcxNetProperties_t *properties =

--- a/flagcx/adaptor/ccl/gloo_adaptor.cc
+++ b/flagcx/adaptor/ccl/gloo_adaptor.cc
@@ -88,12 +88,11 @@ flagcxResult_t glooAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
                                        struct bootstrapState *bootstrap) {
   // Create gloo transport device
   std::shared_ptr<::gloo::transport::Device> dev;
-  flagcxNetProperties_t *properties =
-      (flagcxNetProperties_t *)bootstrap->properties;
+  flagcxNetProperties_t *properties = bootstrapGetNetProperties();
   if (flagcxParamGlooIbDisable() || flagcxParamTopoDetectionDisable()) {
     // Use transport tcp
     ::gloo::transport::tcp::attr attr;
-    attr.iface = std::string(bootstrap->bootstrapNetIfName);
+    attr.iface = std::string(bootstrapGetNetIfName());
     dev = ::gloo::transport::tcp::CreateDevice(attr);
   } else {
     // Use transport ibverbs

--- a/flagcx/adaptor/ccl/hccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/hccl_adaptor.cc
@@ -94,10 +94,9 @@ const char *hcclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return "Not Implemented";
 }
 
-flagcxResult_t
-hcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                        flagcxUniqueId_t commId, int rank,
-                        struct flagcxBootstrapState * /*bootstrap*/) {
+flagcxResult_t hcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                                       flagcxUniqueId_t commId, int rank,
+                                       struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/hccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/hccl_adaptor.cc
@@ -94,9 +94,10 @@ const char *hcclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return "Not Implemented";
 }
 
-flagcxResult_t hcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
-                                       bootstrapState * /*bootstrap*/) {
+flagcxResult_t
+hcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                        flagcxUniqueId_t commId, int rank,
+                        struct flagcxBootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/ixnccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/ixnccl_adaptor.cc
@@ -34,7 +34,7 @@ const char *ixncclAdaptorGetLastError(flagcxInnerComm_t comm) {
 flagcxResult_t
 ixncclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
                           flagcxUniqueId_t commId, int rank,
-                          struct flagcxBootstrapState * /*bootstrap*/) {
+                          struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/ixnccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/ixnccl_adaptor.cc
@@ -31,9 +31,10 @@ const char *ixncclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return ncclGetLastError(comm->base);
 }
 
-flagcxResult_t ixncclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                         flagcxUniqueId_t commId, int rank,
-                                         bootstrapState * /*bootstrap*/) {
+flagcxResult_t
+ixncclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                          flagcxUniqueId_t commId, int rank,
+                          struct flagcxBootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/mccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/mccl_adaptor.cc
@@ -36,9 +36,10 @@ const char *mcclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return mcclGetLastError(comm->base);
 }
 
-flagcxResult_t mcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
-                                       bootstrapState * /*bootstrap*/) {
+flagcxResult_t
+mcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                        flagcxUniqueId_t commId, int rank,
+                        struct flagcxBootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/mccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/mccl_adaptor.cc
@@ -36,10 +36,9 @@ const char *mcclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return mcclGetLastError(comm->base);
 }
 
-flagcxResult_t
-mcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                        flagcxUniqueId_t commId, int rank,
-                        struct flagcxBootstrapState * /*bootstrap*/) {
+flagcxResult_t mcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                                       flagcxUniqueId_t commId, int rank,
+                                       struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/mpi_adaptor.cc
+++ b/flagcx/adaptor/ccl/mpi_adaptor.cc
@@ -91,7 +91,7 @@ const char *mpiAdaptorGetLastError(flagcxInnerComm_t comm) {
 
 flagcxResult_t mpiAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
                                       flagcxUniqueId_t /*commId*/, int rank,
-                                      struct flagcxBootstrapState *bootstrap) {
+                                      struct bootstrapState *bootstrap) {
   int initialized;
   MPI_Initialized(&initialized);
 

--- a/flagcx/adaptor/ccl/mpi_adaptor.cc
+++ b/flagcx/adaptor/ccl/mpi_adaptor.cc
@@ -91,7 +91,7 @@ const char *mpiAdaptorGetLastError(flagcxInnerComm_t comm) {
 
 flagcxResult_t mpiAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
                                       flagcxUniqueId_t /*commId*/, int rank,
-                                      bootstrapState *bootstrap) {
+                                      struct flagcxBootstrapState *bootstrap) {
   int initialized;
   MPI_Initialized(&initialized);
 

--- a/flagcx/adaptor/ccl/musa_mccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/musa_mccl_adaptor.cc
@@ -32,9 +32,10 @@ const char *mcclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return "flagcxNotSupported";
 }
 
-flagcxResult_t mcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
-                                       bootstrapState * /*bootstrap*/) {
+flagcxResult_t
+mcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                        flagcxUniqueId_t commId, int rank,
+                        struct flagcxBootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/musa_mccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/musa_mccl_adaptor.cc
@@ -32,10 +32,9 @@ const char *mcclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return "flagcxNotSupported";
 }
 
-flagcxResult_t
-mcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                        flagcxUniqueId_t commId, int rank,
-                        struct flagcxBootstrapState * /*bootstrap*/) {
+flagcxResult_t mcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                                       flagcxUniqueId_t commId, int rank,
+                                       struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/nccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/nccl_adaptor.cc
@@ -104,10 +104,9 @@ const char *ncclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return ncclGetLastError(comm->base);
 }
 
-flagcxResult_t
-ncclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                        flagcxUniqueId_t commId, int rank,
-                        struct flagcxBootstrapState * /*bootstrap*/) {
+flagcxResult_t ncclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                                       flagcxUniqueId_t commId, int rank,
+                                       struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     void *p = malloc(sizeof(struct flagcxInnerComm));
     memset(p, 0, sizeof(struct flagcxInnerComm));

--- a/flagcx/adaptor/ccl/nccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/nccl_adaptor.cc
@@ -104,9 +104,10 @@ const char *ncclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return ncclGetLastError(comm->base);
 }
 
-flagcxResult_t ncclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
-                                       bootstrapState * /*bootstrap*/) {
+flagcxResult_t
+ncclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                        flagcxUniqueId_t commId, int rank,
+                        struct flagcxBootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     void *p = malloc(sizeof(struct flagcxInnerComm));
     memset(p, 0, sizeof(struct flagcxInnerComm));

--- a/flagcx/adaptor/ccl/pccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/pccl_adaptor.cc
@@ -72,10 +72,9 @@ flagcxResult_t pcclAdaptorGetStagedBuffer(const flagcxInnerComm_t comm,
 }
 
 // Communicator functions
-flagcxResult_t
-pcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                        flagcxUniqueId_t commId, int rank,
-                        struct flagcxBootstrapState * /*bootstrap*/) {
+flagcxResult_t pcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                                       flagcxUniqueId_t commId, int rank,
+                                       struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/pccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/pccl_adaptor.cc
@@ -72,9 +72,10 @@ flagcxResult_t pcclAdaptorGetStagedBuffer(const flagcxInnerComm_t comm,
 }
 
 // Communicator functions
-flagcxResult_t pcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
-                                       bootstrapState * /*bootstrap*/) {
+flagcxResult_t
+pcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                        flagcxUniqueId_t commId, int rank,
+                        struct flagcxBootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/rccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/rccl_adaptor.cc
@@ -31,9 +31,10 @@ const char *rcclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return ncclGetLastError(comm->base);
 }
 
-flagcxResult_t rcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
-                                       bootstrapState * /*bootstrap*/) {
+flagcxResult_t
+rcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                        flagcxUniqueId_t commId, int rank,
+                        struct flagcxBootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/rccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/rccl_adaptor.cc
@@ -31,10 +31,9 @@ const char *rcclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return ncclGetLastError(comm->base);
 }
 
-flagcxResult_t
-rcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                        flagcxUniqueId_t commId, int rank,
-                        struct flagcxBootstrapState * /*bootstrap*/) {
+flagcxResult_t rcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                                       flagcxUniqueId_t commId, int rank,
+                                       struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/tccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/tccl_adaptor.cc
@@ -97,9 +97,10 @@ const char *tcclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return tcclGetLastError(comm->base);
 }
 
-flagcxResult_t tcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
-                                       bootstrapState * /*bootstrap*/) {
+flagcxResult_t
+tcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                        flagcxUniqueId_t commId, int rank,
+                        struct flagcxBootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/tccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/tccl_adaptor.cc
@@ -97,10 +97,9 @@ const char *tcclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return tcclGetLastError(comm->base);
 }
 
-flagcxResult_t
-tcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                        flagcxUniqueId_t commId, int rank,
-                        struct flagcxBootstrapState * /*bootstrap*/) {
+flagcxResult_t tcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                                       flagcxUniqueId_t commId, int rank,
+                                       struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/xccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/xccl_adaptor.cc
@@ -82,9 +82,10 @@ const char *xcclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return "flagcxNotSupported";
 }
 
-flagcxResult_t xcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                                       flagcxUniqueId_t commId, int rank,
-                                       bootstrapState * /*bootstrap*/) {
+flagcxResult_t
+xcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                        flagcxUniqueId_t commId, int rank,
+                        struct flagcxBootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/ccl/xccl_adaptor.cc
+++ b/flagcx/adaptor/ccl/xccl_adaptor.cc
@@ -82,10 +82,9 @@ const char *xcclAdaptorGetLastError(flagcxInnerComm_t comm) {
   return "flagcxNotSupported";
 }
 
-flagcxResult_t
-xcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
-                        flagcxUniqueId_t commId, int rank,
-                        struct flagcxBootstrapState * /*bootstrap*/) {
+flagcxResult_t xcclAdaptorCommInitRank(flagcxInnerComm_t *comm, int nranks,
+                                       flagcxUniqueId_t commId, int rank,
+                                       struct bootstrapState * /*bootstrap*/) {
   if (*comm == NULL) {
     flagcxCalloc(comm, 1);
   }

--- a/flagcx/adaptor/flagcx_device.cc
+++ b/flagcx/adaptor/flagcx_device.cc
@@ -114,8 +114,8 @@ static int buildIpcPeerPointers(flagcxComm_t comm, void *buff, size_t size) {
     goto fail;
   }
   memcpy(&allDescs[myRank], &myIpcDesc, sizeof(struct flagcxP2pIpcDesc));
-  FLAGCXCHECKGOTO(bootstrapAllGather(comm->bootstrap, allDescs,
-                                     sizeof(struct flagcxP2pIpcDesc)),
+  FLAGCXCHECKGOTO(bootstrapCollAllGather(comm->bootstrap, allDescs,
+                                         sizeof(struct flagcxP2pIpcDesc)),
                   res, fail);
 
   // Step 3: Open intra-node peer IPC handles
@@ -288,7 +288,7 @@ static flagcxResult_t setupInterNodeSignalRelay(flagcxComm_t comm,
     }
 
     {
-      struct bootstrapState *bootstrap = comm->bootstrap;
+      struct flagcxBootstrapState *bootstrap = comm->bootstrap;
       int netDev = hetero->netDev;
       struct flagcxNetAdaptor *net = hetero->netAdaptor;
       const int signalTagBase = 2001;
@@ -513,7 +513,7 @@ static flagcxResult_t setupIpcBarriers(flagcxComm_t comm,
 
     // Step 2: Bootstrap barrier — all ranks have created their shm.
     FLAGCXCHECKGOTO(
-        bootstrapBarrier(comm->bootstrap, comm->rank, comm->nranks, 0xBA01),
+        bootstrapCollBarrier(comm->bootstrap, comm->rank, comm->nranks, 0xBA01),
         res, fail_own_shm);
 
     // Step 3: Open and map each peer's shm segment.
@@ -541,7 +541,7 @@ static flagcxResult_t setupIpcBarriers(flagcxComm_t comm,
     // Step 4: Bootstrap barrier — all ranks have opened peer shm.
     // Then unlink own shm: safe because peers already have it mapped.
     FLAGCXCHECKGOTO(
-        bootstrapBarrier(comm->bootstrap, comm->rank, comm->nranks, 0xBA02),
+        bootstrapCollBarrier(comm->bootstrap, comm->rank, comm->nranks, 0xBA02),
         res, fail_peer_shms);
     flagcxShmUnlink(myShmHandle);
 
@@ -1493,7 +1493,7 @@ flagcxResult_t flagcxCommRelayDestroy(flagcxComm_t comm) {
   }
 
   // Cross-rank barrier: all ranks drain before any rank closes connections
-  bootstrapBarrier(comm->bootstrap, comm->rank, comm->nranks, 0x7f01);
+  bootstrapCollBarrier(comm->bootstrap, comm->rank, comm->nranks, 0x7f01);
 
   free(hetero->interPeerRanks);
   hetero->interPeerRanks = nullptr;

--- a/flagcx/adaptor/flagcx_device.cc
+++ b/flagcx/adaptor/flagcx_device.cc
@@ -288,7 +288,7 @@ static flagcxResult_t setupInterNodeSignalRelay(flagcxComm_t comm,
     }
 
     {
-      struct flagcxBootstrapState *bootstrap = comm->bootstrap;
+      struct bootstrapState *bootstrap = comm->bootstrap;
       int netDev = hetero->netDev;
       struct flagcxNetAdaptor *net = hetero->netAdaptor;
       const int signalTagBase = 2001;

--- a/flagcx/adaptor/include/bootstrap_adaptor.h
+++ b/flagcx/adaptor/include/bootstrap_adaptor.h
@@ -19,7 +19,7 @@ typedef struct stagedBuffer *stagedBuffer_t;
 struct flagcxInnerDevComm {};
 
 struct flagcxInnerComm {
-  struct flagcxBootstrapState *base;
+  struct bootstrapState *base;
 };
 
 #endif // USE_BOOTSTRAP_ADAPTOR

--- a/flagcx/adaptor/include/bootstrap_adaptor.h
+++ b/flagcx/adaptor/include/bootstrap_adaptor.h
@@ -19,7 +19,7 @@ typedef struct stagedBuffer *stagedBuffer_t;
 struct flagcxInnerDevComm {};
 
 struct flagcxInnerComm {
-  bootstrapState *base;
+  struct flagcxBootstrapState *base;
 };
 
 #endif // USE_BOOTSTRAP_ADAPTOR

--- a/flagcx/adaptor/include/flagcx_ccl_adaptor.h
+++ b/flagcx/adaptor/include/flagcx_ccl_adaptor.h
@@ -16,7 +16,7 @@ extern "C" {
 typedef struct flagcxInnerComm *flagcxInnerComm_t;
 typedef struct flagcxInnerDevComm *flagcxInnerDevComm_t;
 struct flagcxDevCommRequirements;
-struct flagcxBootstrapState;
+struct bootstrapState;
 
 // Version history:
 //   v1 — 34 function pointers: getVersion, getUniqueId, getErrorString,
@@ -42,7 +42,7 @@ struct flagcxCCLAdaptor_v1 {
   // Communicator functions
   flagcxResult_t (*commInitRank)(flagcxInnerComm_t *comm, int nranks,
                                  flagcxUniqueId *commId, int rank,
-                                 struct flagcxBootstrapState *bootstrap);
+                                 struct bootstrapState *bootstrap);
   flagcxResult_t (*commFinalize)(flagcxInnerComm_t comm);
   flagcxResult_t (*commDestroy)(flagcxInnerComm_t comm);
   flagcxResult_t (*commAbort)(flagcxInnerComm_t comm);
@@ -126,7 +126,7 @@ struct flagcxCCLAdaptor_latest {
   // Communicator functions
   flagcxResult_t (*commInitRank)(flagcxInnerComm_t *comm, int nranks,
                                  flagcxUniqueId *commId, int rank,
-                                 struct flagcxBootstrapState *bootstrap);
+                                 struct bootstrapState *bootstrap);
   flagcxResult_t (*commFinalize)(flagcxInnerComm_t comm);
   flagcxResult_t (*commDestroy)(flagcxInnerComm_t comm);
   flagcxResult_t (*commAbort)(flagcxInnerComm_t comm);

--- a/flagcx/adaptor/include/flagcx_ccl_adaptor.h
+++ b/flagcx/adaptor/include/flagcx_ccl_adaptor.h
@@ -16,7 +16,7 @@ extern "C" {
 typedef struct flagcxInnerComm *flagcxInnerComm_t;
 typedef struct flagcxInnerDevComm *flagcxInnerDevComm_t;
 struct flagcxDevCommRequirements;
-struct bootstrapState;
+struct flagcxBootstrapState;
 
 // Version history:
 //   v1 — 34 function pointers: getVersion, getUniqueId, getErrorString,
@@ -42,7 +42,7 @@ struct flagcxCCLAdaptor_v1 {
   // Communicator functions
   flagcxResult_t (*commInitRank)(flagcxInnerComm_t *comm, int nranks,
                                  flagcxUniqueId *commId, int rank,
-                                 bootstrapState *bootstrap);
+                                 struct flagcxBootstrapState *bootstrap);
   flagcxResult_t (*commFinalize)(flagcxInnerComm_t comm);
   flagcxResult_t (*commDestroy)(flagcxInnerComm_t comm);
   flagcxResult_t (*commAbort)(flagcxInnerComm_t comm);
@@ -126,7 +126,7 @@ struct flagcxCCLAdaptor_latest {
   // Communicator functions
   flagcxResult_t (*commInitRank)(flagcxInnerComm_t *comm, int nranks,
                                  flagcxUniqueId *commId, int rank,
-                                 bootstrapState *bootstrap);
+                                 struct flagcxBootstrapState *bootstrap);
   flagcxResult_t (*commFinalize)(flagcxInnerComm_t comm);
   flagcxResult_t (*commDestroy)(flagcxInnerComm_t comm);
   flagcxResult_t (*commAbort)(flagcxInnerComm_t comm);

--- a/flagcx/adaptor/include/gloo_adaptor.h
+++ b/flagcx/adaptor/include/gloo_adaptor.h
@@ -147,8 +147,7 @@ struct MaxLengthData {
 
 class flagcxGlooContext : public ::gloo::Context {
 public:
-  flagcxGlooContext(int rank, int nranks,
-                    struct flagcxBootstrapState *bootstrap)
+  flagcxGlooContext(int rank, int nranks, struct bootstrapState *bootstrap)
       : ::gloo::Context(rank, nranks) {
     bootstrap_ = bootstrap;
   }
@@ -218,7 +217,7 @@ public:
   }
 
 public:
-  struct flagcxBootstrapState *bootstrap_;
+  struct bootstrapState *bootstrap_;
 };
 
 struct flagcxInnerDevComm {};

--- a/flagcx/adaptor/include/gloo_adaptor.h
+++ b/flagcx/adaptor/include/gloo_adaptor.h
@@ -147,7 +147,8 @@ struct MaxLengthData {
 
 class flagcxGlooContext : public ::gloo::Context {
 public:
-  flagcxGlooContext(int rank, int nranks, bootstrapState *bootstrap)
+  flagcxGlooContext(int rank, int nranks,
+                    struct flagcxBootstrapState *bootstrap)
       : ::gloo::Context(rank, nranks) {
     bootstrap_ = bootstrap;
   }
@@ -176,9 +177,9 @@ public:
     MaxLengthData *maxLengthData;
     flagcxCalloc(&maxLengthData, size);
     maxLengthData[rank].maxLength = maxLength;
-    bootstrapAllGather(bootstrap_, (void *)maxLengthData,
-                       sizeof(MaxLengthData));
-    bootstrapBarrier(bootstrap_, rank, size, 0);
+    bootstrapCollAllGather(bootstrap_, (void *)maxLengthData,
+                           sizeof(MaxLengthData));
+    bootstrapCollBarrier(bootstrap_, rank, size, 0);
     for (int i = 0; i < size; ++i) {
       maxLength = std::max(maxLength, maxLengthData[i].maxLength);
     }
@@ -196,9 +197,9 @@ public:
     }
 
     // bootstrap allgather to get all addresses
-    bootstrapAllGather(bootstrap_, (void *)addressData.data(),
-                       size * maxLength);
-    bootstrapBarrier(bootstrap_, rank, size, 0);
+    bootstrapCollAllGather(bootstrap_, (void *)addressData.data(),
+                           size * maxLength);
+    bootstrapCollBarrier(bootstrap_, rank, size, 0);
 
     // Connect every pair
     for (int i = 0; i < size; ++i) {
@@ -217,7 +218,7 @@ public:
   }
 
 public:
-  bootstrapState *bootstrap_;
+  struct flagcxBootstrapState *bootstrap_;
 };
 
 struct flagcxInnerDevComm {};

--- a/flagcx/adaptor/include/mpi_adaptor.h
+++ b/flagcx/adaptor/include/mpi_adaptor.h
@@ -177,15 +177,14 @@ void callMpi(int func_type, flagcxDataType_t datatype, Args... args) {
 
 class flagcxMpiContext {
 public:
-  flagcxMpiContext(int rank, int nranks,
-                   struct flagcxBootstrapState *bootstrap);
+  flagcxMpiContext(int rank, int nranks, struct bootstrapState *bootstrap);
   ~flagcxMpiContext();
 
   // Getters
   MPI_Comm getMpiComm() const { return mpiComm_; }
   int getRank() const { return rank_; }
   int getSize() const { return size_; }
-  struct flagcxBootstrapState *getBootstrap() const {
+  struct bootstrapState *getBootstrap() const {
     return bootstrap_;
   }
   bool isValidContext() const { return isValid_; }
@@ -199,7 +198,7 @@ private:
   MPI_Comm mpiComm_;
   int rank_;
   int size_;
-  struct flagcxBootstrapState *bootstrap_;
+  struct bootstrapState *bootstrap_;
   bool isValid_;
   bool ownsComm_;
   std::string lastError_;
@@ -212,8 +211,8 @@ private:
   bool validateMpiEnvironment();
 };
 
-inline flagcxMpiContext::flagcxMpiContext(
-    int rank, int nranks, struct flagcxBootstrapState *bootstrap)
+inline flagcxMpiContext::flagcxMpiContext(int rank, int nranks,
+                                          struct bootstrapState *bootstrap)
     : mpiComm_(MPI_COMM_NULL), rank_(rank), size_(nranks),
       bootstrap_(bootstrap), isValid_(false), ownsComm_(false) {
 

--- a/flagcx/adaptor/include/mpi_adaptor.h
+++ b/flagcx/adaptor/include/mpi_adaptor.h
@@ -177,14 +177,17 @@ void callMpi(int func_type, flagcxDataType_t datatype, Args... args) {
 
 class flagcxMpiContext {
 public:
-  flagcxMpiContext(int rank, int nranks, bootstrapState *bootstrap);
+  flagcxMpiContext(int rank, int nranks,
+                   struct flagcxBootstrapState *bootstrap);
   ~flagcxMpiContext();
 
   // Getters
   MPI_Comm getMpiComm() const { return mpiComm_; }
   int getRank() const { return rank_; }
   int getSize() const { return size_; }
-  bootstrapState *getBootstrap() const { return bootstrap_; }
+  struct flagcxBootstrapState *getBootstrap() const {
+    return bootstrap_;
+  }
   bool isValidContext() const { return isValid_; }
   const std::string &getLastError() const { return lastError_; }
 
@@ -196,7 +199,7 @@ private:
   MPI_Comm mpiComm_;
   int rank_;
   int size_;
-  bootstrapState *bootstrap_;
+  struct flagcxBootstrapState *bootstrap_;
   bool isValid_;
   bool ownsComm_;
   std::string lastError_;
@@ -209,8 +212,8 @@ private:
   bool validateMpiEnvironment();
 };
 
-inline flagcxMpiContext::flagcxMpiContext(int rank, int nranks,
-                                          bootstrapState *bootstrap)
+inline flagcxMpiContext::flagcxMpiContext(
+    int rank, int nranks, struct flagcxBootstrapState *bootstrap)
     : mpiComm_(MPI_COMM_NULL), rank_(rank), size_(nranks),
       bootstrap_(bootstrap), isValid_(false), ownsComm_(false) {
 

--- a/flagcx/core/flagcx_p2p.cc
+++ b/flagcx/core/flagcx_p2p.cc
@@ -12,6 +12,7 @@
 #include "flagcx_p2p.h"
 
 #include "adaptor.h"
+#include "bootstrap.h"
 #include "debug.h"
 #include "flagcx_net.h"
 #include "flagcx_net_adaptor.h"
@@ -267,6 +268,11 @@ struct FlagcxP2pEngine {
   std::atomic<bool> stopNotif;
   std::unordered_map<int, FlagcxP2pNotifConn> notifPeers;
   std::mutex notifPeerMutex;
+
+  /* Bootstrap P2P listen state — used for ctrl meta + desc table exchange
+     during connect/accept handshake. */
+  struct bootstrapState *bsListenState;
+  int bsListenPort;
 
   /* Control-plane RPC service: accept daemon + per-session connection
      cache (initiator side) + kept-alive accepted connections (server
@@ -1593,6 +1599,70 @@ static int startLocalTransfer(FlagcxP2pConn *conn,
   return 0;
 }
 
+// ============================================================================
+// Bootstrap P2P helpers for ctrl meta + desc table exchange
+// ============================================================================
+
+static flagcxResult_t bootstrapExchangeCtrlMeta(struct bootstrapState *bsState,
+                                                FlagcxP2pCtrlMeta *localMeta,
+                                                FlagcxP2pCtrlMeta *remoteMeta) {
+  FLAGCXCHECK(bootstrapExchange(bsState, 0, 1, localMeta, sizeof(*localMeta),
+                                remoteMeta, sizeof(*remoteMeta)));
+  return flagcxSuccess;
+}
+
+static int bootstrapExchangeDescTable(struct bootstrapState *bsState,
+                                      FlagcxP2pConn *conn) {
+  if (bsState == NULL || conn == NULL || conn->sendComm == NULL)
+    return -1;
+
+  std::vector<FlagcxP2pMemRegWire> localTable;
+  {
+    std::lock_guard<std::mutex> lock(gMemMutex);
+    localTable.reserve(gMemRegInfo.size());
+    for (std::unordered_map<uintptr_t, FlagcxP2pMemRegEntry>::iterator it =
+             gMemRegInfo.begin();
+         it != gMemRegInfo.end(); ++it) {
+      FlagcxP2pMrHandleView *mrView =
+          reinterpret_cast<FlagcxP2pMrHandleView *>(it->second.mhandle);
+      if (mrView == NULL)
+        continue;
+      FlagcxP2pMemRegWire w;
+      w.baseAddr = it->second.baseAddr;
+      w.size = it->second.size;
+      w.rkey = mrView->rkey;
+      w.reserved = 0;
+      localTable.push_back(w);
+    }
+  }
+
+  uint32_t localCount = static_cast<uint32_t>(localTable.size());
+  uint32_t remoteCount = 0;
+  if (bootstrapExchange(bsState, 0, 2, &localCount, sizeof(localCount),
+                        &remoteCount, sizeof(remoteCount)) != flagcxSuccess)
+    return -1;
+
+  std::vector<FlagcxP2pMemRegWire> remoteTable(remoteCount);
+  if (bootstrapExchange(
+          bsState, 0, 3, localTable.data(),
+          static_cast<int>(localCount * sizeof(FlagcxP2pMemRegWire)),
+          remoteTable.data(),
+          static_cast<int>(remoteCount * sizeof(FlagcxP2pMemRegWire))) !=
+      flagcxSuccess)
+    return -1;
+
+  conn->remoteRegions.clear();
+  conn->remoteRegions.reserve(remoteCount);
+  for (uint32_t i = 0; i < remoteCount; i++) {
+    FlagcxP2pRemoteRegion r;
+    r.baseAddr = remoteTable[i].baseAddr;
+    r.size = remoteTable[i].size;
+    r.rkey = remoteTable[i].rkey;
+    conn->remoteRegions.push_back(r);
+  }
+  return 0;
+}
+
 FlagcxP2pEngine *flagcxP2pEngineCreate() {
   FlagcxP2pEngine *engine = new FlagcxP2pEngine;
   engine->adaptor = &flagcxNetIbP2p;
@@ -1607,6 +1677,8 @@ FlagcxP2pEngine *flagcxP2pEngineCreate() {
   engine->stopNotif = false;
   engine->rpcServerActive = false;
   engine->stopRpcServer = false;
+  engine->bsListenState = NULL;
+  engine->bsListenPort = 0;
   memset(engine->listeners, 0, sizeof(engine->listeners));
   memset(&engine->notifListenSock, 0, sizeof(engine->notifListenSock));
 
@@ -1614,6 +1686,9 @@ FlagcxP2pEngine *flagcxP2pEngineCreate() {
     delete engine;
     return NULL;
   }
+
+  // Initialize bootstrap network context (discovers local NIC)
+  bootstrapNetInit();
 
   engine->adaptor->devices(&engine->nDevs);
   if (flagcxP2pTopoInit(engine->adaptor, &engine->topoMgr) != flagcxSuccess) {
@@ -1665,6 +1740,21 @@ FlagcxP2pEngine *flagcxP2pEngineCreate() {
   if (engine->notifListenActive && flagcxNIbDevs > 0) {
     flagcxP2pPoolStartNotif(0, flagcxIbDevs[0].context, engine);
   }
+
+  // Set up bootstrap P2P listen for ctrl meta + desc table exchange
+  struct bootstrapState *bsState = NULL;
+  char bsListenHandle[FLAGCX_NET_HANDLE_MAXSIZE];
+  memset(bsListenHandle, 0, sizeof(bsListenHandle));
+  if (bootstrapP2pListen(FLAGCX_SOCKET_MAGIC, NULL, bsListenHandle, &bsState) ==
+      flagcxSuccess) {
+    engine->bsListenState = bsState;
+    union flagcxSocketAddress bsAddr;
+    flagcxSocketGetAddr(&bsState->p2p->sock, &bsAddr);
+    engine->bsListenPort = socketAddrPort(&bsAddr);
+    INFO(FLAGCX_INIT, "NET/IB_P2P : bootstrap P2P listen on port %d",
+         engine->bsListenPort);
+  }
+
   return engine;
 }
 
@@ -1679,6 +1769,11 @@ void flagcxP2pEngineDestroy(FlagcxP2pEngine *engine) {
     engine->notifListenActive = false;
   }
   flagcxP2pPoolStopNotif();
+
+  if (engine->bsListenState) {
+    bootstrapClose(engine->bsListenState);
+    engine->bsListenState = NULL;
+  }
 
   {
     std::lock_guard<std::mutex> lock(engine->notifPeerMutex);
@@ -1764,6 +1859,12 @@ void flagcxP2pEngineStopAccept(FlagcxP2pEngine *engine) {
     engine->notifListenActive = false;
   }
 
+  if (engine->bsListenState) {
+    bootstrapClose(engine->bsListenState);
+    engine->bsListenState = NULL;
+    engine->bsListenPort = 0;
+  }
+
   for (int d = 0; d < engine->nDevs; d++) {
     if (engine->listeners[d].listenComm) {
       engine->adaptor->closeListen(engine->listeners[d].listenComm);
@@ -1833,30 +1934,57 @@ FlagcxP2pConn *flagcxP2pEngineConnect(FlagcxP2pEngine *engine,
 
   const int netDev = chooseEngineNetDev(engine);
 
-  char remoteHandleBuf[FLAGCX_NET_HANDLE_MAXSIZE];
-  memset(remoteHandleBuf, 0, sizeof(remoteHandleBuf));
-  FlagcxP2pListenHandleView *remoteHandle =
-      reinterpret_cast<FlagcxP2pListenHandleView *>(remoteHandleBuf);
+  // Step 1: Establish bootstrap P2P connection to remote's bootstrap listen
+  // port
+  char bsPeerHandle[FLAGCX_NET_HANDLE_MAXSIZE];
+  memset(bsPeerHandle, 0, sizeof(bsPeerHandle));
+  FlagcxP2pListenHandleView *bsHandleView =
+      reinterpret_cast<FlagcxP2pListenHandleView *>(bsPeerHandle);
 
   char ipPortStr[256];
   snprintf(ipPortStr, sizeof(ipPortStr), "%s:%d", ipAddr, remotePort);
-  if (flagcxSocketGetAddrFromString(&remoteHandle->connectAddr, ipPortStr) !=
+  if (flagcxSocketGetAddrFromString(&bsHandleView->connectAddr, ipPortStr) !=
       flagcxSuccess) {
     return NULL;
   }
-  remoteHandle->magic = FLAGCX_SOCKET_MAGIC;
+  bsHandleView->magic = FLAGCX_SOCKET_MAGIC;
 
+  struct bootstrapState *bsConn = NULL;
+  if (bootstrapP2pConnect(bsPeerHandle, FLAGCX_SOCKET_MAGIC, NULL, &bsConn) !=
+      flagcxSuccess) {
+    return NULL;
+  }
+
+  // Step 2: Exchange IB listen handles over bootstrap
+  char localIbHandle[FLAGCX_NET_HANDLE_MAXSIZE];
+  memcpy(localIbHandle, engine->listeners[netDev].handle,
+         FLAGCX_NET_HANDLE_MAXSIZE);
+
+  char remoteIbHandle[FLAGCX_NET_HANDLE_MAXSIZE];
+  memset(remoteIbHandle, 0, sizeof(remoteIbHandle));
+  if (bootstrapExchange(bsConn, 0, 4, localIbHandle, FLAGCX_NET_HANDLE_MAXSIZE,
+                        remoteIbHandle,
+                        FLAGCX_NET_HANDLE_MAXSIZE) != flagcxSuccess) {
+    bootstrapClose(bsConn);
+    return NULL;
+  }
+
+  // Step 3: Connect IB adaptor using remote's handle
   void *sendComm = NULL;
-  if (engine->adaptor->connect(netDev, remoteHandleBuf, &sendComm) !=
+  if (engine->adaptor->connect(netDev, remoteIbHandle, &sendComm) !=
       flagcxSuccess) {
+    bootstrapClose(bsConn);
     return NULL;
   }
 
+  FlagcxP2pListenHandleView *remoteHandle =
+      reinterpret_cast<FlagcxP2pListenHandleView *>(remoteIbHandle);
   const bool sameHost =
       socketAddrSameHost(&remoteHandle->connectAddr, &flagcxIbIfAddr);
   const bool isLocal = sameHost;
   const bool isSameProcess = sameHost && sameProcess;
 
+  // Step 4: Exchange ctrl meta over bootstrap
   FlagcxP2pCtrlMeta localMeta;
   memset(&localMeta, 0, sizeof(localMeta));
   localMeta.gpuIdx = engine->localGpuIdx;
@@ -1869,11 +1997,10 @@ FlagcxP2pConn *flagcxP2pEngineConnect(FlagcxP2pEngine *engine,
 
   FlagcxP2pCtrlMeta remoteMeta;
   memset(&remoteMeta, 0, sizeof(remoteMeta));
-  FlagcxP2pCommView *sendView = getCommView(sendComm);
-  if (flagcxSocketSendRecv(&sendView->sock, &localMeta, sizeof(localMeta),
-                           &sendView->sock, &remoteMeta,
-                           sizeof(remoteMeta)) != flagcxSuccess) {
+  if (bootstrapExchangeCtrlMeta(bsConn, &localMeta, &remoteMeta) !=
+      flagcxSuccess) {
     engine->adaptor->closeSend(sendComm);
+    bootstrapClose(bsConn);
     return NULL;
   }
 
@@ -1897,12 +2024,16 @@ FlagcxP2pConn *flagcxP2pEngineConnect(FlagcxP2pEngine *engine,
     connectNotifSocket(conn, &remoteHandle->connectAddr, remoteMeta.notifPort);
   }
 
-  if (exchangeMemRegTable(conn) != 0) {
+  // Step 5: Exchange desc table over bootstrap
+  if (bootstrapExchangeDescTable(bsConn, conn) != 0) {
     WARN("NET/IB_P2P : connect desc-table exchange failed");
     flagcxP2pEngineConnDestroy(conn);
+    bootstrapClose(bsConn);
     return NULL;
   }
 
+  // Step 6: Close transient bootstrap connection
+  bootstrapClose(bsConn);
   return conn;
 }
 
@@ -1912,15 +2043,38 @@ FlagcxP2pConn *flagcxP2pEngineAccept(FlagcxP2pEngine *engine, char *ipAddrBuf,
     return NULL;
 
   const int dev = chooseEngineNetDev(engine);
-  if (engine->listeners[dev].listenComm == NULL)
+  if (engine->bsListenState == NULL)
     return NULL;
 
-  void *recvComm = NULL;
-  if (engine->adaptor->accept(engine->listeners[dev].listenComm, &recvComm) !=
-      flagcxSuccess) {
+  // Step 1: Accept bootstrap P2P connection from connector
+  struct bootstrapState *bsConn = NULL;
+  if (bootstrapP2pAccept(engine->bsListenState, &bsConn) != flagcxSuccess) {
     return NULL;
   }
 
+  // Step 2: Exchange IB listen handles over bootstrap
+  char localIbHandle[FLAGCX_NET_HANDLE_MAXSIZE];
+  memcpy(localIbHandle, engine->listeners[dev].handle,
+         FLAGCX_NET_HANDLE_MAXSIZE);
+
+  char remoteIbHandle[FLAGCX_NET_HANDLE_MAXSIZE];
+  memset(remoteIbHandle, 0, sizeof(remoteIbHandle));
+  if (bootstrapExchange(bsConn, 0, 4, localIbHandle, FLAGCX_NET_HANDLE_MAXSIZE,
+                        remoteIbHandle,
+                        FLAGCX_NET_HANDLE_MAXSIZE) != flagcxSuccess) {
+    bootstrapClose(bsConn);
+    return NULL;
+  }
+
+  // Step 3: Accept IB connection using the adaptor
+  void *recvComm = NULL;
+  if (engine->adaptor->accept(engine->listeners[dev].listenComm, &recvComm) !=
+      flagcxSuccess) {
+    bootstrapClose(bsConn);
+    return NULL;
+  }
+
+  // Step 4: Exchange ctrl meta over bootstrap
   FlagcxP2pCtrlMeta localMeta;
   memset(&localMeta, 0, sizeof(localMeta));
   localMeta.gpuIdx = engine->localGpuIdx;
@@ -1932,10 +2086,10 @@ FlagcxP2pConn *flagcxP2pEngineAccept(FlagcxP2pEngine *engine, char *ipAddrBuf,
 
   FlagcxP2pCtrlMeta remoteMeta;
   memset(&remoteMeta, 0, sizeof(remoteMeta));
-  if (flagcxSocketSendRecv(&recvView->sock, &localMeta, sizeof(localMeta),
-                           &recvView->sock, &remoteMeta,
-                           sizeof(remoteMeta)) != flagcxSuccess) {
+  if (bootstrapExchangeCtrlMeta(bsConn, &localMeta, &remoteMeta) !=
+      flagcxSuccess) {
     engine->adaptor->closeRecv(recvComm);
+    bootstrapClose(bsConn);
     return NULL;
   }
 
@@ -1960,12 +2114,16 @@ FlagcxP2pConn *flagcxP2pEngineAccept(FlagcxP2pEngine *engine, char *ipAddrBuf,
     connectNotifSocket(conn, &recvView->sock.addr, remoteMeta.notifPort);
   }
 
-  if (exchangeMemRegTable(conn) != 0) {
+  // Step 5: Exchange desc table over bootstrap
+  if (bootstrapExchangeDescTable(bsConn, conn) != 0) {
     WARN("NET/IB_P2P : accept desc-table exchange failed");
     flagcxP2pEngineConnDestroy(conn);
+    bootstrapClose(bsConn);
     return NULL;
   }
 
+  // Step 6: Close transient bootstrap connection
+  bootstrapClose(bsConn);
   return conn;
 }
 
@@ -2516,6 +2674,10 @@ int flagcxP2pEngineGetMetadata(FlagcxP2pEngine *engine, char **metadataStr) {
 int flagcxP2pEngineGetRpcPort(FlagcxP2pEngine *engine) {
   if (engine == NULL)
     return -1;
+  // Return bootstrap P2P listen port for RPC metadata exchange
+  if (engine->bsListenState != NULL && engine->bsListenPort > 0)
+    return engine->bsListenPort;
+  // Fallback to IB listen port if bootstrap not available
   const int netDev = chooseEngineNetDev(engine);
   if (engine->listeners[netDev].listenComm == NULL)
     return -1;

--- a/flagcx/core/flagcx_p2p.cc
+++ b/flagcx/core/flagcx_p2p.cc
@@ -1642,6 +1642,14 @@ static int bootstrapExchangeDescTable(struct bootstrapState *bsState,
                         &remoteCount, sizeof(remoteCount)) != flagcxSuccess)
     return -1;
 
+  // Sanity check: reject absurdly large counts to prevent OOM or overflow
+  const uint32_t MAX_REMOTE_REGIONS = 65536;
+  if (remoteCount > MAX_REMOTE_REGIONS) {
+    WARN("bootstrapExchangeDescTable: remote count %u exceeds limit %u",
+         remoteCount, MAX_REMOTE_REGIONS);
+    return -1;
+  }
+
   std::vector<FlagcxP2pMemRegWire> remoteTable(remoteCount);
   if (bootstrapExchange(
           bsState, 0, 3, localTable.data(),
@@ -1936,21 +1944,19 @@ FlagcxP2pConn *flagcxP2pEngineConnect(FlagcxP2pEngine *engine,
 
   // Step 1: Establish bootstrap P2P connection to remote's bootstrap listen
   // port
-  char bsPeerHandle[FLAGCX_NET_HANDLE_MAXSIZE];
-  memset(bsPeerHandle, 0, sizeof(bsPeerHandle));
-  FlagcxP2pListenHandleView *bsHandleView =
-      reinterpret_cast<FlagcxP2pListenHandleView *>(bsPeerHandle);
+  struct flagcxBootstrapHandle bsHandle;
+  memset(&bsHandle, 0, sizeof(bsHandle));
+  bsHandle.magic = FLAGCX_SOCKET_MAGIC;
 
   char ipPortStr[256];
   snprintf(ipPortStr, sizeof(ipPortStr), "%s:%d", ipAddr, remotePort);
-  if (flagcxSocketGetAddrFromString(&bsHandleView->connectAddr, ipPortStr) !=
+  if (flagcxSocketGetAddrFromString(&bsHandle.addr, ipPortStr) !=
       flagcxSuccess) {
     return NULL;
   }
-  bsHandleView->magic = FLAGCX_SOCKET_MAGIC;
 
   struct bootstrapState *bsConn = NULL;
-  if (bootstrapP2pConnect(bsPeerHandle, FLAGCX_SOCKET_MAGIC, NULL, &bsConn) !=
+  if (bootstrapP2pConnect(&bsHandle, FLAGCX_SOCKET_MAGIC, NULL, &bsConn) !=
       flagcxSuccess) {
     return NULL;
   }
@@ -2647,15 +2653,15 @@ int flagcxP2pEngineGetMetadata(FlagcxP2pEngine *engine, char **metadataStr) {
   if (engine == NULL || metadataStr == NULL)
     return -1;
 
-  const int netDev = chooseEngineNetDev(engine);
-  if (engine->listeners[netDev].listenComm == NULL)
+  // After bootstrap P2P integration, metadata must expose the bootstrap listen
+  // port (used by flagcxP2pEngineConnect for the initial handshake), not the
+  // RDMA listen port (which is now exchanged during the bootstrap handshake).
+  if (engine->bsListenState == NULL || engine->bsListenPort <= 0)
     return -1;
 
-  FlagcxP2pListenHandleView *listenHandle =
-      reinterpret_cast<FlagcxP2pListenHandleView *>(
-          engine->listeners[netDev].handle);
-  const std::string rdmaAddr =
-      socketAddrToHostPortString(&listenHandle->connectAddr);
+  union flagcxSocketAddress bsAddr;
+  flagcxSocketGetAddr(&engine->bsListenState->p2p->sock, &bsAddr);
+  const std::string rdmaAddr = socketAddrToHostPortString(&bsAddr);
   if (rdmaAddr.empty())
     return -1;
 

--- a/flagcx/core/flagcx_p2p.cc
+++ b/flagcx/core/flagcx_p2p.cc
@@ -2051,6 +2051,9 @@ FlagcxP2pConn *flagcxP2pEngineAccept(FlagcxP2pEngine *engine, char *ipAddrBuf,
   const int dev = chooseEngineNetDev(engine);
   if (engine->bsListenState == NULL)
     return NULL;
+  if (dev < 0 || dev >= engine->nDevs ||
+      engine->listeners[dev].listenComm == NULL)
+    return NULL;
 
   // Step 1: Accept bootstrap P2P connection from connector
   struct bootstrapState *bsConn = NULL;

--- a/flagcx/core/flagcx_tuner.cc
+++ b/flagcx/core/flagcx_tuner.cc
@@ -111,7 +111,7 @@ static bool operator<(const struct TunerCommTagCounterKey &lhs,
 
 // customized context structure for internal use
 struct flagcxTunerContext {
-  struct flagcxBootstrapState *bootstrap;
+  struct bootstrapState *bootstrap;
 
   int rank;
   int nranks;
@@ -186,7 +186,7 @@ flagcxResult_t flagcxTunerInit(size_t nRanks, size_t rank,
                                flagcxDebugLogger_t logFunction, void **context,
                                void *commState) {
   struct flagcxTunerContext *ctx = new struct flagcxTunerContext;
-  ctx->bootstrap = (struct flagcxBootstrapState *)commState;
+  ctx->bootstrap = (struct bootstrapState *)commState;
   ctx->rank = rank;
   ctx->nranks = nRanks;
   FLAGCXCHECK(generateCandidate(ctx->configList));
@@ -407,9 +407,9 @@ flagcxCreateOrReplaceHomoComm(flagcxComm_t *comm,
   }
 
   flagcxInnerComm_t innerComm = NULL;
-  FLAGCXCHECK(flagcxHomoCommInit(
-      (*comm)->commId, (*comm)->uniqueIdData,
-      (struct flagcxBootstrapState *)(ctx->bootstrap), *comm, &innerComm));
+  FLAGCXCHECK(flagcxHomoCommInit((*comm)->commId, (*comm)->uniqueIdData,
+                                 (struct bootstrapState *)(ctx->bootstrap),
+                                 *comm, &innerComm));
   // Store new communicator of collCat into homoCommMap
   (*comm)->homoCommMap[collCat] = innerComm;
   // For backward compatible, also assign homoComm field.
@@ -666,9 +666,9 @@ flagcxResult_t flagcxTunerSwitchCommConfig(void *context, flagcxComm_t *comm,
       FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->commDestroy(inner));
       FLAGCXCHECK(setEnvConfig(cfg, FLAGCX_ENV_TYPE_CREATION));
       flagcxInnerComm_t newInner = NULL;
-      FLAGCXCHECK(flagcxHomoCommInit(
-          (*comm)->commId, (*comm)->uniqueIdData,
-          (struct flagcxBootstrapState *)(ctx->bootstrap), *comm, &newInner));
+      FLAGCXCHECK(flagcxHomoCommInit((*comm)->commId, (*comm)->uniqueIdData,
+                                     (struct bootstrapState *)(ctx->bootstrap),
+                                     *comm, &newInner));
       (*comm)->tunerInnerComm = newInner;
       (*comm)->homoComm = newInner;
     } else {
@@ -709,9 +709,9 @@ flagcxResult_t flagcxTunerSwitchCommConfig(void *context, flagcxComm_t *comm,
       FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->commDestroy(inner));
       FLAGCXCHECK(setEnvConfig(cfg, FLAGCX_ENV_TYPE_CREATION));
       flagcxInnerComm_t newInner = NULL;
-      FLAGCXCHECK(flagcxHomoCommInit(
-          (*comm)->commId, (*comm)->uniqueIdData,
-          (struct flagcxBootstrapState *)(ctx->bootstrap), *comm, &newInner));
+      FLAGCXCHECK(flagcxHomoCommInit((*comm)->commId, (*comm)->uniqueIdData,
+                                     (struct bootstrapState *)(ctx->bootstrap),
+                                     *comm, &newInner));
       (*comm)->tunerInnerComm = newInner;
       (*comm)->homoComm = newInner;
     } else {

--- a/flagcx/core/flagcx_tuner.cc
+++ b/flagcx/core/flagcx_tuner.cc
@@ -111,7 +111,7 @@ static bool operator<(const struct TunerCommTagCounterKey &lhs,
 
 // customized context structure for internal use
 struct flagcxTunerContext {
-  void *bootstrap;
+  struct flagcxBootstrapState *bootstrap;
 
   int rank;
   int nranks;
@@ -186,7 +186,7 @@ flagcxResult_t flagcxTunerInit(size_t nRanks, size_t rank,
                                flagcxDebugLogger_t logFunction, void **context,
                                void *commState) {
   struct flagcxTunerContext *ctx = new struct flagcxTunerContext;
-  ctx->bootstrap = commState;
+  ctx->bootstrap = (struct flagcxBootstrapState *)commState;
   ctx->rank = rank;
   ctx->nranks = nRanks;
   FLAGCXCHECK(generateCandidate(ctx->configList));
@@ -329,9 +329,10 @@ static flagcxResult_t findBestComm(struct flagcxTunerContext *ctx,
 
     memcpy(ctx->profilingResults + ctx->rank, &duration, sizeof(float));
     // get average duration across all ranks
-    FLAGCXCHECK(bootstrapAllGather(
+    FLAGCXCHECK(bootstrapCollAllGather(
         ctx->bootstrap, (void *)ctx->profilingResults, sizeof(float)));
-    FLAGCXCHECK(bootstrapBarrier(ctx->bootstrap, ctx->rank, ctx->nranks, 0));
+    FLAGCXCHECK(
+        bootstrapCollBarrier(ctx->bootstrap, ctx->rank, ctx->nranks, 0));
     duration = 0.0f;
     for (int i = 0; i < ctx->nranks; ++i) {
       duration += ctx->profilingResults[i];
@@ -406,9 +407,9 @@ flagcxCreateOrReplaceHomoComm(flagcxComm_t *comm,
   }
 
   flagcxInnerComm_t innerComm = NULL;
-  FLAGCXCHECK(flagcxHomoCommInit((*comm)->commId, (*comm)->uniqueIdData,
-                                 (struct bootstrapState *)(ctx->bootstrap),
-                                 *comm, &innerComm));
+  FLAGCXCHECK(flagcxHomoCommInit(
+      (*comm)->commId, (*comm)->uniqueIdData,
+      (struct flagcxBootstrapState *)(ctx->bootstrap), *comm, &innerComm));
   // Store new communicator of collCat into homoCommMap
   (*comm)->homoCommMap[collCat] = innerComm;
   // For backward compatible, also assign homoComm field.
@@ -665,9 +666,9 @@ flagcxResult_t flagcxTunerSwitchCommConfig(void *context, flagcxComm_t *comm,
       FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->commDestroy(inner));
       FLAGCXCHECK(setEnvConfig(cfg, FLAGCX_ENV_TYPE_CREATION));
       flagcxInnerComm_t newInner = NULL;
-      FLAGCXCHECK(flagcxHomoCommInit((*comm)->commId, (*comm)->uniqueIdData,
-                                     (struct bootstrapState *)(ctx->bootstrap),
-                                     *comm, &newInner));
+      FLAGCXCHECK(flagcxHomoCommInit(
+          (*comm)->commId, (*comm)->uniqueIdData,
+          (struct flagcxBootstrapState *)(ctx->bootstrap), *comm, &newInner));
       (*comm)->tunerInnerComm = newInner;
       (*comm)->homoComm = newInner;
     } else {
@@ -708,9 +709,9 @@ flagcxResult_t flagcxTunerSwitchCommConfig(void *context, flagcxComm_t *comm,
       FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorDevice]->commDestroy(inner));
       FLAGCXCHECK(setEnvConfig(cfg, FLAGCX_ENV_TYPE_CREATION));
       flagcxInnerComm_t newInner = NULL;
-      FLAGCXCHECK(flagcxHomoCommInit((*comm)->commId, (*comm)->uniqueIdData,
-                                     (struct bootstrapState *)(ctx->bootstrap),
-                                     *comm, &newInner));
+      FLAGCXCHECK(flagcxHomoCommInit(
+          (*comm)->commId, (*comm)->uniqueIdData,
+          (struct flagcxBootstrapState *)(ctx->bootstrap), *comm, &newInner));
       (*comm)->tunerInnerComm = newInner;
       (*comm)->homoComm = newInner;
     } else {

--- a/flagcx/core/include/comm.h
+++ b/flagcx/core/include/comm.h
@@ -182,7 +182,7 @@ struct flagcxHeteroComm {
   struct flagcxInterServerTopo *interServerTopo;
 
   struct flagcxNetAdaptor *netAdaptor;
-  struct bootstrapState *bootstrap;
+  struct flagcxBootstrapState *bootstrap;
   // Bitmasks for flagcxTransportP2pSetup
   uint64_t *connectSend;
   uint64_t *connectRecv;

--- a/flagcx/core/include/comm.h
+++ b/flagcx/core/include/comm.h
@@ -182,7 +182,7 @@ struct flagcxHeteroComm {
   struct flagcxInterServerTopo *interServerTopo;
 
   struct flagcxNetAdaptor *netAdaptor;
-  struct flagcxBootstrapState *bootstrap;
+  struct bootstrapState *bootstrap;
   // Bitmasks for flagcxTransportP2pSetup
   uint64_t *connectSend;
   uint64_t *connectRecv;

--- a/flagcx/core/include/global_comm.h
+++ b/flagcx/core/include/global_comm.h
@@ -76,7 +76,7 @@ struct flagcxComm {
   int *clusterIds;
   int *globalRank2HomoRank;
   int *clusterInterRanks;
-  struct flagcxBootstrapState *bootstrap;
+  struct bootstrapState *bootstrap;
   int localRank;        // intra-node rank index (computed from hostHash)
   int localRanks;       // number of ranks on this node
   int *localRankToRank; // mapping: local index -> global rank
@@ -129,7 +129,7 @@ struct flagcxComm {
 // return homoComm via homoComm parameter.
 flagcxResult_t flagcxHomoCommInit(flagcxUniqueId_t commId,
                                   flagcxUniqueId *uniqueIdData,
-                                  struct flagcxBootstrapState *state,
+                                  struct bootstrapState *state,
                                   flagcxComm_t comm,
                                   flagcxInnerComm_t *homoComm /*out*/);
 

--- a/flagcx/core/include/global_comm.h
+++ b/flagcx/core/include/global_comm.h
@@ -76,7 +76,7 @@ struct flagcxComm {
   int *clusterIds;
   int *globalRank2HomoRank;
   int *clusterInterRanks;
-  bootstrapState *bootstrap;
+  struct flagcxBootstrapState *bootstrap;
   int localRank;        // intra-node rank index (computed from hostHash)
   int localRanks;       // number of ranks on this node
   int *localRankToRank; // mapping: local index -> global rank
@@ -129,7 +129,7 @@ struct flagcxComm {
 // return homoComm via homoComm parameter.
 flagcxResult_t flagcxHomoCommInit(flagcxUniqueId_t commId,
                                   flagcxUniqueId *uniqueIdData,
-                                  struct bootstrapState *state,
+                                  struct flagcxBootstrapState *state,
                                   flagcxComm_t comm,
                                   flagcxInnerComm_t *homoComm /*out*/);
 

--- a/flagcx/core/include/topo.h
+++ b/flagcx/core/include/topo.h
@@ -209,7 +209,7 @@ struct topoArgs {
   int rank;
   int nranks;
   flagcxUniqueId uniqueId;
-  void *bootstrap;
+  struct flagcxBootstrapState *bootstrap;
 };
 
 struct flatTopoLink {

--- a/flagcx/core/include/topo.h
+++ b/flagcx/core/include/topo.h
@@ -209,7 +209,7 @@ struct topoArgs {
   int rank;
   int nranks;
   flagcxUniqueId uniqueId;
-  struct flagcxBootstrapState *bootstrap;
+  struct bootstrapState *bootstrap;
 };
 
 struct flatTopoLink {

--- a/flagcx/core/init.cc
+++ b/flagcx/core/init.cc
@@ -102,10 +102,11 @@ static flagcxResult_t initTransportsRank(flagcxHeteroComm_t comm,
                   ret, fail);
   // Question: where did we initialize comm->bootstrap?
   INFO(FLAGCX_INIT, "start bootstrapAllGather for peerInfo");
-  FLAGCXCHECKGOTO(bootstrapAllGather(comm->bootstrap, (void *)comm->peerInfo,
-                                     sizeof(struct flagcxPeerInfo)),
+  FLAGCXCHECKGOTO(bootstrapCollAllGather(comm->bootstrap,
+                                         (void *)comm->peerInfo,
+                                         sizeof(struct flagcxPeerInfo)),
                   ret, fail);
-  FLAGCXCHECKGOTO(bootstrapBarrier(comm->bootstrap, rank, nranks, 0), ret,
+  FLAGCXCHECKGOTO(bootstrapCollBarrier(comm->bootstrap, rank, nranks, 0), ret,
                   fail);
 
   // check for duplicate GPUs
@@ -277,17 +278,13 @@ static flagcxResult_t flagcxCommInitRankFunc(struct flagcxAsyncJob *job_) {
 
   if (!job->parent) {
     // New version of calling bootstrapInit
-    struct bootstrapState *state;
-    FLAGCXCHECK(flagcxCalloc(&state, 1));
-    state->rank = comm->rank;
-    state->nranks = comm->nRanks;
-    state->abortFlag = comm->abortFlag;
-    comm->bootstrap = state;
-    state->magic = ((struct flagcxBootstrapHandle *)&job->commId)->magic;
-    comm->magic = ((struct flagcxBootstrapHandle *)&job->commId)->magic;
+    uint64_t magic = ((struct flagcxBootstrapHandle *)&job->commId)->magic;
+    comm->magic = magic;
     FLAGCXCHECKGOTO(
-        bootstrapInit((struct flagcxBootstrapHandle *)&job->commId, state), res,
-        fail);
+        bootstrapCollInit((struct flagcxBootstrapHandle *)&job->commId,
+                          comm->rank, comm->nRanks, magic, comm->abortFlag,
+                          &comm->bootstrap),
+        res, fail);
   }
 
   if (!job->parent) {
@@ -388,8 +385,8 @@ static flagcxResult_t flagcxCommInitRankDev(flagcxHeteroComm_t *newcomm,
   if (env && myrank == 0) {
     INFO(FLAGCX_ENV, "FLAGCX_COMM_ID set by environment to %s", env);
     FLAGCXCHECKGOTO(
-        bootstrapCreateRoot((struct flagcxBootstrapHandle *)&commId, true), res,
-        fail);
+        bootstrapCollCreateRoot((struct flagcxBootstrapHandle *)&commId, true),
+        res, fail);
   }
 
   if (nranks < 1 || myrank < 0 || myrank >= nranks) {

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -1121,9 +1121,9 @@ flagcxResult_t flagcxProxyInit(struct flagcxHeteroComm *comm) {
   FLAGCXCHECK(flagcxCalloc(&comm->proxyState->peerAddresses, comm->nRanks));
   comm->proxyState->peerAddresses[comm->rank] =
       comm->proxyState->listenSock.addr;
-  FLAGCXCHECK(bootstrapAllGather(comm->bootstrap,
-                                 comm->proxyState->peerAddresses,
-                                 sizeof(union flagcxSocketAddress)));
+  FLAGCXCHECK(bootstrapCollAllGather(comm->bootstrap,
+                                     comm->proxyState->peerAddresses,
+                                     sizeof(union flagcxSocketAddress)));
 
   comm->proxyState->cudaDev = comm->cudaDev;
   comm->proxyState->nRanks = comm->nRanks;

--- a/flagcx/core/sym_heap.cc
+++ b/flagcx/core/sym_heap.cc
@@ -79,7 +79,7 @@ flagcxResult_t flagcxSymWindowRegister(flagcxHeteroComm_t comm, void *buff,
       // to avoid hanging at the intra-node barrier.
       int allAllocOk = localAllocOk;
       {
-        struct flagcxBootstrapState *bState = comm->bootstrap;
+        struct bootstrapState *bState = comm->bootstrap;
         for (int i = 0; i < localRanks; i++) {
           if (i == localRank)
             continue;
@@ -112,7 +112,7 @@ flagcxResult_t flagcxSymWindowRegister(flagcxHeteroComm_t comm, void *buff,
         ipcSockOpen = true;
 
         // Barrier to ensure all sockets are created before sending
-        struct flagcxBootstrapState *state = comm->bootstrap;
+        struct bootstrapState *state = comm->bootstrap;
         FLAGCXCHECKGOTO(bootstrapCollIntraNodeBarrier(
                             state, comm->localRankToRank, localRank, localRanks,
                             /*tag=*/0x5932),
@@ -194,7 +194,7 @@ flagcxResult_t flagcxSymWindowRegister(flagcxHeteroComm_t comm, void *buff,
             localDevices = nullptr;
 
             // Broadcast success/failure from rank 0
-            struct flagcxBootstrapState *mcState = comm->bootstrap;
+            struct bootstrapState *mcState = comm->bootstrap;
             if (localRank == 0) {
               for (int i = 1; i < localRanks; i++) {
                 int peerGlobalRank = comm->localRankToRank[i];

--- a/flagcx/core/sym_heap.cc
+++ b/flagcx/core/sym_heap.cc
@@ -79,7 +79,7 @@ flagcxResult_t flagcxSymWindowRegister(flagcxHeteroComm_t comm, void *buff,
       // to avoid hanging at the intra-node barrier.
       int allAllocOk = localAllocOk;
       {
-        struct bootstrapState *bState = comm->bootstrap;
+        struct flagcxBootstrapState *bState = comm->bootstrap;
         for (int i = 0; i < localRanks; i++) {
           if (i == localRank)
             continue;
@@ -112,10 +112,10 @@ flagcxResult_t flagcxSymWindowRegister(flagcxHeteroComm_t comm, void *buff,
         ipcSockOpen = true;
 
         // Barrier to ensure all sockets are created before sending
-        struct bootstrapState *state = comm->bootstrap;
-        FLAGCXCHECKGOTO(bootstrapIntraNodeBarrier(state, comm->localRankToRank,
-                                                  localRank, localRanks,
-                                                  /*tag=*/0x5932),
+        struct flagcxBootstrapState *state = comm->bootstrap;
+        FLAGCXCHECKGOTO(bootstrapCollIntraNodeBarrier(
+                            state, comm->localRankToRank, localRank, localRanks,
+                            /*tag=*/0x5932),
                         res, fail);
 
         // Send our FD to each peer
@@ -194,7 +194,7 @@ flagcxResult_t flagcxSymWindowRegister(flagcxHeteroComm_t comm, void *buff,
             localDevices = nullptr;
 
             // Broadcast success/failure from rank 0
-            struct bootstrapState *mcState = comm->bootstrap;
+            struct flagcxBootstrapState *mcState = comm->bootstrap;
             if (localRank == 0) {
               for (int i = 1; i < localRanks; i++) {
                 int peerGlobalRank = comm->localRankToRank[i];
@@ -220,7 +220,7 @@ flagcxResult_t flagcxSymWindowRegister(flagcxHeteroComm_t comm, void *buff,
               mcIpcSockOpen = true;
 
               // Barrier: ensure all peers have created their IPC sockets
-              FLAGCXCHECKGOTO(bootstrapIntraNodeBarrier(
+              FLAGCXCHECKGOTO(bootstrapCollIntraNodeBarrier(
                                   state, comm->localRankToRank, localRank,
                                   localRanks, /*tag=*/0x5934),
                               res, fail);

--- a/flagcx/core/topo.cc
+++ b/flagcx/core/topo.cc
@@ -1476,9 +1476,9 @@ flagcxGetInterServerTopo(struct flagcxHeteroComm *comm,
   // we need to flatten topoServer first to remove all pointer types in the
   // structure before copying and trasferring it to other ranks
   FLAGCXCHECK(flattenTopoServer(topoServer, flatServerData + rank));
-  FLAGCXCHECK(bootstrapAllGather(comm->bootstrap, (void *)flatServerData,
-                                 sizeof(flatTopoServer)));
-  FLAGCXCHECK(bootstrapBarrier(comm->bootstrap, rank, nRanks, 0));
+  FLAGCXCHECK(bootstrapCollAllGather(comm->bootstrap, (void *)flatServerData,
+                                     sizeof(flatTopoServer)));
+  FLAGCXCHECK(bootstrapCollBarrier(comm->bootstrap, rank, nRanks, 0));
 
   // reorder serverId
   FLAGCXCHECK(flagcxTopoReorderServerId(flatServerData, nRanks));

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -255,9 +255,8 @@ flagcxResult_t flagcxMemFree(void *ptr) {
 static flagcxResult_t
 flagcxOneSideBuildFullMesh(struct flagcxHeteroComm *heteroComm,
                            struct flagcxOneSideHandleInfo *info) {
-  struct bootstrapState *state = heteroComm->bootstrap;
-  int nranks = state->nranks;
-  int rank = state->rank;
+  int nranks = heteroComm->nRanks;
+  int rank = heteroComm->rank;
   flagcxResult_t res = flagcxSuccess;
 
   void *listenComm = NULL;
@@ -278,8 +277,9 @@ flagcxOneSideBuildFullMesh(struct flagcxHeteroComm *heteroComm,
     // Allgather listen handles from all ranks
     FLAGCXCHECKGOTO(flagcxCalloc(&allHandles, nranks), res, fail_listen);
     memcpy(&allHandles[rank], &myListenHandle, sizeof(flagcxNetHandle_t));
-    FLAGCXCHECKGOTO(bootstrapAllGather(state, (void *)allHandles,
-                                       sizeof(flagcxNetHandle_t)),
+    FLAGCXCHECKGOTO(bootstrapCollAllGather(heteroComm->bootstrap,
+                                           (void *)allHandles,
+                                           sizeof(flagcxNetHandle_t)),
                     res, fail_handles);
 
     // 2. Deadlock-free full-mesh connection (NCCL GIN pattern)
@@ -371,9 +371,8 @@ flagcxResult_t flagcxOneSideRegisterInternal(flagcxHeteroComm_t heteroComm,
     }
   }
 
-  struct bootstrapState *state = heteroComm->bootstrap;
-  if (state == NULL) {
-    INFO(FLAGCX_REG, "flagcxOneSideRegister: state is NULL");
+  if (heteroComm->bootstrap == NULL) {
+    INFO(FLAGCX_REG, "flagcxOneSideRegister: bootstrap is NULL");
     return flagcxNotSupported;
   }
 
@@ -417,8 +416,8 @@ flagcxResult_t flagcxOneSideRegisterInternal(flagcxHeteroComm_t heteroComm,
   {
     void *selfRecvComm =
         isFirstHandle
-            ? info->fullRecvComms[state->rank]
-            : heteroComm->oneSideHandles[0]->fullRecvComms[state->rank];
+            ? info->fullRecvComms[heteroComm->rank]
+            : heteroComm->oneSideHandles[0]->fullRecvComms[heteroComm->rank];
     info->localRecvComm = selfRecvComm;
     regComm = selfRecvComm;
     if (heteroComm->netAdaptor->name &&
@@ -448,25 +447,28 @@ flagcxResult_t flagcxOneSideRegisterInternal(flagcxHeteroComm_t heteroComm,
 
   // Allgather MR info
   {
-    int nranks = state->nranks;
+    int nranks = heteroComm->nRanks;
     FLAGCXCHECKGOTO(flagcxCalloc(&info->baseVas, nranks), res, fail_mr);
     FLAGCXCHECKGOTO(flagcxCalloc(&info->rkeys, nranks), res, fail_mr);
     FLAGCXCHECKGOTO(flagcxCalloc(&info->lkeys, nranks), res, fail_mr);
 
-    info->baseVas[state->rank] = (uintptr_t)buff;
-    info->rkeys[state->rank] = mr->rkey;
-    info->lkeys[state->rank] = mr->lkey;
+    info->baseVas[heteroComm->rank] = (uintptr_t)buff;
+    info->rkeys[heteroComm->rank] = mr->rkey;
+    info->lkeys[heteroComm->rank] = mr->lkey;
     info->localMrHandle = mrHandle;
 
-    FLAGCXCHECKGOTO(
-        bootstrapAllGather(state, (void *)info->baseVas, sizeof(uintptr_t)),
-        res, fail_mr);
-    FLAGCXCHECKGOTO(
-        bootstrapAllGather(state, (void *)info->rkeys, sizeof(uint32_t)), res,
-        fail_mr);
-    FLAGCXCHECKGOTO(
-        bootstrapAllGather(state, (void *)info->lkeys, sizeof(uint32_t)), res,
-        fail_mr);
+    FLAGCXCHECKGOTO(bootstrapCollAllGather(heteroComm->bootstrap,
+                                           (void *)info->baseVas,
+                                           sizeof(uintptr_t)),
+                    res, fail_mr);
+    FLAGCXCHECKGOTO(bootstrapCollAllGather(heteroComm->bootstrap,
+                                           (void *)info->rkeys,
+                                           sizeof(uint32_t)),
+                    res, fail_mr);
+    FLAGCXCHECKGOTO(bootstrapCollAllGather(heteroComm->bootstrap,
+                                           (void *)info->lkeys,
+                                           sizeof(uint32_t)),
+                    res, fail_mr);
 
     int slot = heteroComm->oneSideHandleCount;
     heteroComm->oneSideHandles[slot] = info;
@@ -481,7 +483,7 @@ flagcxResult_t flagcxOneSideRegisterInternal(flagcxHeteroComm_t heteroComm,
 
     INFO(FLAGCX_REG,
          "One-sided register index %d allgather results (rank %d, nranks %d):",
-         slot, state->rank, nranks);
+         slot, heteroComm->rank, nranks);
     for (int i = 0; i < nranks; i++) {
       INFO(FLAGCX_REG, "  Rank %d: base_va=0x%lx, rkey=0x%x, lkey=0x%x", i,
            info->baseVas[i], info->rkeys[i], info->lkeys[i]);
@@ -501,7 +503,7 @@ fail_mr:
 fail_mesh:
   if (isFirstHandle) {
     // Clean up full-mesh connections on first-handle failure
-    for (int i = 0; i < state->nranks; i++) {
+    for (int i = 0; i < heteroComm->nRanks; i++) {
       if (info->fullSendComms && info->fullSendComms[i])
         heteroComm->netAdaptor->closeSend(info->fullSendComms[i]);
       if (info->fullRecvComms && info->fullRecvComms[i])
@@ -606,9 +608,8 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
     return flagcxSuccess;
   }
 
-  struct bootstrapState *state = heteroComm->bootstrap;
-  if (state == NULL) {
-    INFO(FLAGCX_REG, "flagcxOneSideSignalRegister: state is NULL");
+  if (heteroComm->bootstrap == NULL) {
+    INFO(FLAGCX_REG, "flagcxOneSideSignalRegister: bootstrap is NULL");
     return flagcxNotSupported;
   }
 
@@ -635,7 +636,7 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
 
   // Use self recvComm from this comm's first data handle for MR registration
   // (PD match)
-  void *selfRecvComm = firstDataHandle->fullRecvComms[state->rank];
+  void *selfRecvComm = firstDataHandle->fullRecvComms[heteroComm->rank];
   regComm = selfRecvComm;
   if (heteroComm->netAdaptor->name &&
       strcmp(heteroComm->netAdaptor->name, "IB") == 0) {
@@ -659,31 +660,33 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
   }
 
   {
-    int nranks = state->nranks;
+    int nranks = heteroComm->nRanks;
     FLAGCXCHECKGOTO(flagcxCalloc(&info, 1), res, fail_mr);
     FLAGCXCHECKGOTO(flagcxCalloc(&info->baseVas, nranks), res, fail_mr);
     FLAGCXCHECKGOTO(flagcxCalloc(&info->rkeys, nranks), res, fail_mr);
     FLAGCXCHECKGOTO(flagcxCalloc(&info->lkeys, nranks), res, fail_mr);
 
-    info->baseVas[state->rank] = (uintptr_t)buff;
-    info->rkeys[state->rank] = mr->rkey;
-    info->lkeys[state->rank] = mr->lkey;
+    info->baseVas[heteroComm->rank] = (uintptr_t)buff;
+    info->rkeys[heteroComm->rank] = mr->rkey;
+    info->lkeys[heteroComm->rank] = mr->lkey;
     info->localMrHandle = mrHandle;
     info->localRecvComm = selfRecvComm;
 
-    FLAGCXCHECKGOTO(
-        bootstrapAllGather(state, (void *)info->baseVas, sizeof(uintptr_t)),
-        res, fail_mr);
-    FLAGCXCHECKGOTO(
-        bootstrapAllGather(state, (void *)info->rkeys, sizeof(uint32_t)), res,
-        fail_mr);
-    FLAGCXCHECKGOTO(
-        bootstrapAllGather(state, (void *)info->lkeys, sizeof(uint32_t)), res,
-        fail_mr);
+    FLAGCXCHECKGOTO(bootstrapCollAllGather(heteroComm->bootstrap,
+                                           (void *)info->baseVas,
+                                           sizeof(uintptr_t)),
+                    res, fail_mr);
+    FLAGCXCHECKGOTO(bootstrapCollAllGather(heteroComm->bootstrap,
+                                           (void *)info->rkeys,
+                                           sizeof(uint32_t)),
+                    res, fail_mr);
+    FLAGCXCHECKGOTO(bootstrapCollAllGather(heteroComm->bootstrap,
+                                           (void *)info->lkeys,
+                                           sizeof(uint32_t)),
+                    res, fail_mr);
     heteroComm->signalHandle = info;
-    INFO(FLAGCX_REG,
-         "Signal register allgather results (rank %d, nranks %d):", state->rank,
-         nranks);
+    INFO(FLAGCX_REG, "Signal register allgather results (rank %d, nranks %d):",
+         heteroComm->rank, nranks);
     for (int i = 0; i < nranks; i++) {
       INFO(FLAGCX_REG, "  Rank %d: base_va=0x%lx, rkey=0x%x, lkey=0x%x", i,
            info->baseVas[i], info->rkeys[i], info->lkeys[i]);
@@ -758,9 +761,8 @@ flagcxResult_t flagcxOneSideStagingRegister(const flagcxComm_t comm, void *buff,
     return flagcxSuccess;
   }
 
-  struct bootstrapState *state = heteroComm->bootstrap;
-  if (state == NULL) {
-    INFO(FLAGCX_REG, "flagcxOneSideStagingRegister: state is NULL");
+  if (heteroComm->bootstrap == NULL) {
+    INFO(FLAGCX_REG, "flagcxOneSideStagingRegister: bootstrap is NULL");
     return flagcxNotSupported;
   }
 
@@ -787,7 +789,7 @@ flagcxResult_t flagcxOneSideStagingRegister(const flagcxComm_t comm, void *buff,
 
   // Use self recvComm from this comm's first data handle for MR registration
   // (PD match)
-  void *selfRecvComm = firstDataHandleStg->fullRecvComms[state->rank];
+  void *selfRecvComm = firstDataHandleStg->fullRecvComms[heteroComm->rank];
   regComm = selfRecvComm;
   if (heteroComm->netAdaptor->name &&
       strcmp(heteroComm->netAdaptor->name, "IB") == 0) {
@@ -812,30 +814,33 @@ flagcxResult_t flagcxOneSideStagingRegister(const flagcxComm_t comm, void *buff,
   }
 
   {
-    int nranks = state->nranks;
+    int nranks = heteroComm->nRanks;
     FLAGCXCHECKGOTO(flagcxCalloc(&info, 1), res, fail_mr);
     FLAGCXCHECKGOTO(flagcxCalloc(&info->baseVas, nranks), res, fail_mr);
     FLAGCXCHECKGOTO(flagcxCalloc(&info->rkeys, nranks), res, fail_mr);
     FLAGCXCHECKGOTO(flagcxCalloc(&info->lkeys, nranks), res, fail_mr);
 
-    info->baseVas[state->rank] = (uintptr_t)buff;
-    info->rkeys[state->rank] = mr->rkey;
-    info->lkeys[state->rank] = mr->lkey;
+    info->baseVas[heteroComm->rank] = (uintptr_t)buff;
+    info->rkeys[heteroComm->rank] = mr->rkey;
+    info->lkeys[heteroComm->rank] = mr->lkey;
     info->localMrHandle = mrHandle;
     info->localRecvComm = selfRecvComm;
 
-    FLAGCXCHECKGOTO(
-        bootstrapAllGather(state, (void *)info->baseVas, sizeof(uintptr_t)),
-        res, fail_mr);
-    FLAGCXCHECKGOTO(
-        bootstrapAllGather(state, (void *)info->rkeys, sizeof(uint32_t)), res,
-        fail_mr);
-    FLAGCXCHECKGOTO(
-        bootstrapAllGather(state, (void *)info->lkeys, sizeof(uint32_t)), res,
-        fail_mr);
+    FLAGCXCHECKGOTO(bootstrapCollAllGather(heteroComm->bootstrap,
+                                           (void *)info->baseVas,
+                                           sizeof(uintptr_t)),
+                    res, fail_mr);
+    FLAGCXCHECKGOTO(bootstrapCollAllGather(heteroComm->bootstrap,
+                                           (void *)info->rkeys,
+                                           sizeof(uint32_t)),
+                    res, fail_mr);
+    FLAGCXCHECKGOTO(bootstrapCollAllGather(heteroComm->bootstrap,
+                                           (void *)info->lkeys,
+                                           sizeof(uint32_t)),
+                    res, fail_mr);
     heteroComm->stagingHandle = info;
     INFO(FLAGCX_REG, "Staging register allgather results (rank %d, nranks %d):",
-         state->rank, nranks);
+         heteroComm->rank, nranks);
     for (int i = 0; i < nranks; i++) {
       INFO(FLAGCX_REG, "  Rank %d: base_va=0x%lx, rkey=0x%x, lkey=0x%x", i,
            info->baseVas[i], info->rkeys[i], info->lkeys[i]);
@@ -897,8 +902,7 @@ flagcxOneSideBarrierRegister(const flagcxComm_t comm, void *recvComm,
       heteroComm->netAdaptor->regMr == NULL)
     return flagcxNotSupported;
 
-  struct bootstrapState *state = comm->bootstrap;
-  if (state == NULL)
+  if (comm->bootstrap == NULL)
     return flagcxNotSupported;
 
   struct flagcxNetAdaptor *net = heteroComm->netAdaptor;
@@ -931,8 +935,8 @@ flagcxOneSideBarrierRegister(const flagcxComm_t comm, void *recvComm,
 
   // ALL ranks: allocate info, populate own entry, AllGather
   {
-    int nranks = state->nranks;
-    int myRank = state->rank;
+    int nranks = comm->nranks;
+    int myRank = comm->rank;
     FLAGCXCHECKGOTO(flagcxCalloc(&info, 1), res, fail_mr);
     FLAGCXCHECKGOTO(flagcxCalloc(&info->baseVas, nranks), res, fail_mr);
     FLAGCXCHECKGOTO(flagcxCalloc(&info->rkeys, nranks), res, fail_mr);
@@ -944,15 +948,16 @@ flagcxOneSideBarrierRegister(const flagcxComm_t comm, void *recvComm,
     info->localMrHandle = mrHandle;
     info->localRecvComm = recvComm;
 
-    FLAGCXCHECKGOTO(
-        bootstrapAllGather(state, (void *)info->baseVas, sizeof(uintptr_t)),
-        res, fail_mr);
-    FLAGCXCHECKGOTO(
-        bootstrapAllGather(state, (void *)info->rkeys, sizeof(uint32_t)), res,
-        fail_mr);
-    FLAGCXCHECKGOTO(
-        bootstrapAllGather(state, (void *)info->lkeys, sizeof(uint32_t)), res,
-        fail_mr);
+    FLAGCXCHECKGOTO(bootstrapCollAllGather(comm->bootstrap,
+                                           (void *)info->baseVas,
+                                           sizeof(uintptr_t)),
+                    res, fail_mr);
+    FLAGCXCHECKGOTO(bootstrapCollAllGather(comm->bootstrap, (void *)info->rkeys,
+                                           sizeof(uint32_t)),
+                    res, fail_mr);
+    FLAGCXCHECKGOTO(bootstrapCollAllGather(comm->bootstrap, (void *)info->lkeys,
+                                           sizeof(uint32_t)),
+                    res, fail_mr);
 
     INFO(FLAGCX_REG,
          "Barrier register allgather results (rank %d, nranks %d):", myRank,
@@ -1567,7 +1572,7 @@ static flagcxResult_t flagcxDevCommStateDestroy(flagcxComm_t comm) {
 
 flagcxResult_t flagcxHomoCommInit(flagcxUniqueId_t commId,
                                   flagcxUniqueId *uniqueIdData,
-                                  struct bootstrapState *state,
+                                  struct flagcxBootstrapState *state,
                                   flagcxComm_t comm,
                                   flagcxInnerComm_t *homoComm /*out*/) {
   int rank = comm->rank;
@@ -1580,9 +1585,9 @@ flagcxResult_t flagcxHomoCommInit(flagcxUniqueId_t commId,
   if (comm->homoRank == 0) {
     memcpy((void *)&uniqueIdData[rank], (void *)commId, sizeof(flagcxUniqueId));
   }
-  FLAGCXCHECK(
-      bootstrapAllGather(state, (void *)uniqueIdData, sizeof(flagcxUniqueId)));
-  FLAGCXCHECK(bootstrapBarrier(state, rank, nranks, 0));
+  FLAGCXCHECK(bootstrapCollAllGather(state, (void *)uniqueIdData,
+                                     sizeof(flagcxUniqueId)));
+  FLAGCXCHECK(bootstrapCollBarrier(state, rank, nranks, 0));
 
   memcpy((void *)commId, (void *)&uniqueIdData[comm->homoRootRank],
          sizeof(flagcxUniqueId));
@@ -1638,20 +1643,17 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
   flagcxIntruQueueConstruct(&(*comm)->deferredBufferQueue);
   (*comm)->deferredBufferCount = 0;
 
-  struct bootstrapState *state = NULL;
-  FLAGCXCHECK(flagcxCalloc(&state, 1));
-  state->rank = rank;
-  state->nranks = nranks;
-  state->abortFlag = (*comm)->abortFlag;
-  (*comm)->bootstrap = state;
-  state->magic = ((struct flagcxBootstrapHandle *)commId)->magic;
-  (*comm)->magic = ((struct flagcxBootstrapHandle *)commId)->magic;
+  uint64_t magic = ((struct flagcxBootstrapHandle *)commId)->magic;
+  (*comm)->magic = magic;
 
   // Init bootstrap net
   FLAGCXCHECK(bootstrapNetInit());
 
-  // Init bootstrap state
-  FLAGCXCHECK(bootstrapInit((struct flagcxBootstrapHandle *)commId, state));
+  // Init bootstrap state (creates wrapped state)
+  FLAGCXCHECK(bootstrapCollInit((struct flagcxBootstrapHandle *)commId, rank,
+                                nranks, magic, (*comm)->abortFlag,
+                                &(*comm)->bootstrap));
+  struct flagcxBootstrapState *state = (*comm)->bootstrap;
 
   // Ready to detect heterogeneous/homogeneous communicator
   // Use bootstrap allgather to exchange Device info
@@ -1664,8 +1666,8 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
   FLAGCXCHECK(flagcxCalloc(&vendorData, nranks));
   memcpy(vendorData + rank, &vendor, sizeof(flagcxVendor));
   FLAGCXCHECK(
-      bootstrapAllGather(state, (void *)vendorData, sizeof(flagcxVendor)));
-  FLAGCXCHECK(bootstrapBarrier(state, rank, nranks, 0));
+      bootstrapCollAllGather(state, (void *)vendorData, sizeof(flagcxVendor)));
+  FLAGCXCHECK(bootstrapCollBarrier(state, rank, nranks, 0));
 
   // Compute intra-node topology using hostHash
   {
@@ -1673,8 +1675,8 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
     uint64_t *hostHashes = nullptr;
     FLAGCXCHECK(flagcxCalloc(&hostHashes, nranks));
     hostHashes[rank] = myHash;
-    FLAGCXCHECK(bootstrapAllGather(state, hostHashes, sizeof(uint64_t)));
-    FLAGCXCHECK(bootstrapBarrier(state, rank, nranks, 0));
+    FLAGCXCHECK(bootstrapCollAllGather(state, hostHashes, sizeof(uint64_t)));
+    FLAGCXCHECK(bootstrapCollBarrier(state, rank, nranks, 0));
 
     int localCount = 0;
     for (int r = 0; r < nranks; r++) {
@@ -1709,12 +1711,13 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
       vendorData, &(*comm)->commType, globalRankToHomoRankData + rank,
       &(*comm)->homoRootRank, &(*comm)->homoRanks, clusterIdData + rank,
       clusterInterRankData + rank, &(*comm)->nclusters, rank, nranks));
+  FLAGCXCHECK(bootstrapCollAllGather(state, (void *)globalRankToHomoRankData,
+                                     sizeof(int)));
   FLAGCXCHECK(
-      bootstrapAllGather(state, (void *)globalRankToHomoRankData, sizeof(int)));
-  FLAGCXCHECK(bootstrapAllGather(state, (void *)clusterIdData, sizeof(int)));
+      bootstrapCollAllGather(state, (void *)clusterIdData, sizeof(int)));
   FLAGCXCHECK(
-      bootstrapAllGather(state, (void *)clusterInterRankData, sizeof(int)));
-  FLAGCXCHECK(bootstrapBarrier(state, rank, nranks, 0));
+      bootstrapCollAllGather(state, (void *)clusterInterRankData, sizeof(int)));
+  FLAGCXCHECK(bootstrapCollBarrier(state, rank, nranks, 0));
   (*comm)->homoRank = globalRankToHomoRankData[rank];
   (*comm)->clusterIds = clusterIdData;
   (*comm)->globalRank2HomoRank = globalRankToHomoRankData;
@@ -1895,9 +1898,9 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
       flagcxHeteroGetUniqueId(commId);
       memcpy((void *)&uniqueIdData[0], (void *)commId, sizeof(flagcxUniqueId));
     }
-    FLAGCXCHECK(bootstrapAllGather(state, (void *)uniqueIdData,
-                                   sizeof(flagcxUniqueId)));
-    FLAGCXCHECK(bootstrapBarrier(state, rank, nranks, 0));
+    FLAGCXCHECK(bootstrapCollAllGather(state, (void *)uniqueIdData,
+                                       sizeof(flagcxUniqueId)));
+    FLAGCXCHECK(bootstrapCollBarrier(state, rank, nranks, 0));
 
     memcpy((void *)commId, (void *)&uniqueIdData[0], sizeof(flagcxUniqueId));
     // call flagcxHeteroCommInitRank
@@ -1908,7 +1911,7 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
     if (useHostComm() || (*comm)->hasSingleRankHomoComm) {
       if (!flagcxParamTopoDetectionDisable()) {
         FLAGCXCHECK((*comm)->heteroComm->netAdaptor->getProperties(
-            (*comm)->heteroComm->netDev, state->properties));
+            (*comm)->heteroComm->netDev, state->coll->properties));
       }
       FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorHost]->commInitRank(
           &(*comm)->hostComm, nranks, commId, rank, state));
@@ -1923,9 +1926,9 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
     FLAGCXCHECK(flagcxCalloc(&nicDistanceData, nranks));
     FLAGCXCHECK(flagcxGetNicDistance((*comm)->heteroComm->topoServer, rank,
                                      nicDistanceData + rank));
-    FLAGCXCHECK(bootstrapAllGather(state, (void *)nicDistanceData,
-                                   sizeof(flagcxNicDistance)));
-    FLAGCXCHECK(bootstrapBarrier(state, rank, nranks, 0));
+    FLAGCXCHECK(bootstrapCollAllGather(state, (void *)nicDistanceData,
+                                       sizeof(flagcxNicDistance)));
+    FLAGCXCHECK(bootstrapCollBarrier(state, rank, nranks, 0));
     for (int i = 0; i < (*comm)->nclusters; ++i) {
       int minDistance = INT_MAX;
       std::unordered_map<int, std::vector<int>> nicDistanceToRanks;
@@ -1986,9 +1989,9 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
              sizeof(flagcxUniqueId));
     }
     // Collect uniqueIdData globally
-    FLAGCXCHECK(bootstrapAllGather(state, (void *)uniqueIdData,
-                                   sizeof(flagcxUniqueId)));
-    FLAGCXCHECK(bootstrapBarrier(state, rank, nranks, 0));
+    FLAGCXCHECK(bootstrapCollAllGather(state, (void *)uniqueIdData,
+                                       sizeof(flagcxUniqueId)));
+    FLAGCXCHECK(bootstrapCollBarrier(state, rank, nranks, 0));
     // Call cclAdaptor->commInitRank
     if ((*comm)->homoInterRootRank != -1) {
       memcpy((void *)commId, (void *)&uniqueIdData[(*comm)->homoInterRootRank],

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -1911,7 +1911,7 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
     if (useHostComm() || (*comm)->hasSingleRankHomoComm) {
       if (!flagcxParamTopoDetectionDisable()) {
         FLAGCXCHECK((*comm)->heteroComm->netAdaptor->getProperties(
-            (*comm)->heteroComm->netDev, state->coll->properties));
+            (*comm)->heteroComm->netDev, bootstrapGetNetProperties()));
       }
       FLAGCXCHECK(cclAdaptors[flagcxCCLAdaptorHost]->commInitRank(
           &(*comm)->hostComm, nranks, commId, rank, state));

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -1572,7 +1572,7 @@ static flagcxResult_t flagcxDevCommStateDestroy(flagcxComm_t comm) {
 
 flagcxResult_t flagcxHomoCommInit(flagcxUniqueId_t commId,
                                   flagcxUniqueId *uniqueIdData,
-                                  struct flagcxBootstrapState *state,
+                                  struct bootstrapState *state,
                                   flagcxComm_t comm,
                                   flagcxInnerComm_t *homoComm /*out*/) {
   int rank = comm->rank;
@@ -1653,7 +1653,7 @@ flagcxResult_t flagcxCommInitRank(flagcxComm_t *comm, int nranks,
   FLAGCXCHECK(bootstrapCollInit((struct flagcxBootstrapHandle *)commId, rank,
                                 nranks, magic, (*comm)->abortFlag,
                                 &(*comm)->bootstrap));
-  struct flagcxBootstrapState *state = (*comm)->bootstrap;
+  struct bootstrapState *state = (*comm)->bootstrap;
 
   // Ready to detect heterogeneous/homogeneous communicator
   // Use bootstrap allgather to exchange Device info

--- a/flagcx/service/bootstrap.cc
+++ b/flagcx/service/bootstrap.cc
@@ -89,6 +89,10 @@ static flagcxResult_t bootstrapNetRecv(struct flagcxSocket *sock, void *data,
   FLAGCXCHECK(flagcxSocketRecv(sock, data, std::min(recvSize, size)));
   return flagcxSuccess;
 }
+// Sequential send-then-recv is safe here because bootstrapNetSendRecv is only
+// called on ring topology with separate ringSendSocket and ringRecvSocket.
+// One rank's send-to-next and recv-from-prev use independent sockets, so there
+// is no risk of deadlock.
 static flagcxResult_t bootstrapNetSendRecv(struct flagcxSocket *sendSocket,
                                            void *sendData, int sendSize,
                                            struct flagcxSocket *recvSocket,
@@ -106,14 +110,15 @@ struct extInfo {
 };
 
 #include <cstdint>
-enum {
-  BOOTSTRAP_TIMER_TOTAL = 0,
-  BOOTSTRAP_TIMER_ALLOC,
-  BOOTSTRAP_TIMER_MEM,
-  BOOTSTRAP_TIMER_COMM,
-  BOOTSTRAP_TIMER_CALC,
-  BOOTSTRAP_TIMERS_COUNT
-};
+#include <sys/resource.h>
+
+static flagcxResult_t setFilesLimit() {
+  struct rlimit filesLimit;
+  SYSCHECK(getrlimit(RLIMIT_NOFILE, &filesLimit), "getrlimit");
+  filesLimit.rlim_cur = filesLimit.rlim_max;
+  SYSCHECK(setrlimit(RLIMIT_NOFILE, &filesLimit), "setrlimit");
+  return flagcxSuccess;
+}
 
 // Root thread for collective bootstrap ring setup
 static void *bootstrapRoot(void *rargs) {
@@ -121,6 +126,8 @@ static void *bootstrapRoot(void *rargs) {
   struct flagcxSocket *listenSock = args->listenSock;
   uint64_t magic = args->magic;
   free(args);
+
+  setFilesLimit();
 
   struct extInfo info;
   struct extInfo *rankInfo = NULL;
@@ -161,6 +168,9 @@ static void *bootstrapRoot(void *rargs) {
 
   TRACE(FLAGCX_INIT, "DONE magic %lx", magic);
 fail:
+  if (res != flagcxSuccess) {
+    WARN("bootstrapRoot thread failed with error %d", res);
+  }
   if (rankInfo)
     free(rankInfo);
   flagcxSocketClose(listenSock);
@@ -224,10 +234,10 @@ struct unexConn {
   struct unexConn *next;
 };
 
-// Helper to unwrap flagcxBootstrapState -> bootstrapCollState
+// Helper to unwrap bootstrapState -> bootstrapCollState
 // The coll state is always valid regardless of current mode.
 static inline struct bootstrapCollState *
-unwrapCollState(struct flagcxBootstrapState *state) {
+unwrapCollState(struct bootstrapState *state) {
   if (state == NULL || state->coll == NULL) {
     return NULL;
   }
@@ -241,9 +251,9 @@ unwrapCollState(struct flagcxBootstrapState *state) {
 flagcxResult_t bootstrapCollInit(struct flagcxBootstrapHandle *handle, int rank,
                                  int nranks, uint64_t magic,
                                  volatile uint32_t *abortFlag,
-                                 struct flagcxBootstrapState **stateOut) {
+                                 struct bootstrapState **stateOut) {
   // Allocate wrapper
-  struct flagcxBootstrapState *wrapper;
+  struct bootstrapState *wrapper;
   FLAGCXCHECK(flagcxCalloc(&wrapper, 1));
   wrapper->mode = FLAGCX_BOOTSTRAP_COLL;
 
@@ -335,7 +345,7 @@ flagcxResult_t bootstrapCollInit(struct flagcxBootstrapHandle *handle, int rank,
 // Collective Mode: Send/Recv internals (ring relay)
 // ============================================================================
 
-static flagcxResult_t bootstrapCollConnect(struct flagcxBootstrapState *state,
+static flagcxResult_t bootstrapCollConnect(struct bootstrapState *state,
                                            int peer, int tag,
                                            struct flagcxSocket *sock) {
   flagcxResult_t ret = flagcxSuccess;
@@ -409,7 +419,7 @@ static void unexpectedFree(struct bootstrapCollState *state) {
   }
 }
 
-static flagcxResult_t bootstrapCollAccept(struct flagcxBootstrapState *state,
+static flagcxResult_t bootstrapCollAccept(struct bootstrapState *state,
                                           int peer, int tag,
                                           struct flagcxSocket *sock) {
   flagcxResult_t ret = flagcxSuccess;
@@ -440,9 +450,9 @@ fail:
   return ret;
 }
 
-static flagcxResult_t
-bootstrapCollSendInternal(struct flagcxBootstrapState *state, int peer, int tag,
-                          void *data, int size) {
+static flagcxResult_t bootstrapCollSendInternal(struct bootstrapState *state,
+                                                int peer, int tag, void *data,
+                                                int size) {
   flagcxResult_t ret = flagcxSuccess;
   struct flagcxSocket sock;
 
@@ -456,9 +466,9 @@ exit:
   return ret;
 }
 
-static flagcxResult_t
-bootstrapCollRecvInternal(struct flagcxBootstrapState *state, int peer, int tag,
-                          void *data, int size) {
+static flagcxResult_t bootstrapCollRecvInternal(struct bootstrapState *state,
+                                                int peer, int tag, void *data,
+                                                int size) {
   flagcxResult_t ret;
   struct flagcxSocket sock;
   FLAGCXCHECK(bootstrapCollAccept(state, peer, tag, &sock));
@@ -473,8 +483,8 @@ exit:
 // Unified Send / Recv / Exchange / Close (dispatch on mode)
 // ============================================================================
 
-flagcxResult_t bootstrapSend(struct flagcxBootstrapState *state, int peer,
-                             int tag, void *data, int size) {
+flagcxResult_t bootstrapSend(struct bootstrapState *state, int peer, int tag,
+                             void *data, int size) {
   if (state == NULL)
     return flagcxInvalidArgument;
 
@@ -493,8 +503,8 @@ flagcxResult_t bootstrapSend(struct flagcxBootstrapState *state, int peer,
   return bootstrapCollSendInternal(state, peer, tag, data, size);
 }
 
-flagcxResult_t bootstrapRecv(struct flagcxBootstrapState *state, int peer,
-                             int tag, void *data, int size) {
+flagcxResult_t bootstrapRecv(struct bootstrapState *state, int peer, int tag,
+                             void *data, int size) {
   if (state == NULL)
     return flagcxInvalidArgument;
 
@@ -522,7 +532,7 @@ flagcxResult_t bootstrapRecv(struct flagcxBootstrapState *state, int peer,
   return bootstrapCollRecvInternal(state, peer, tag, data, size);
 }
 
-flagcxResult_t bootstrapExchange(struct flagcxBootstrapState *state, int peer,
+flagcxResult_t bootstrapExchange(struct bootstrapState *state, int peer,
                                  int tag, const void *sendData, int sendSize,
                                  void *recvData, int recvSize) {
   if (state == NULL)
@@ -551,7 +561,7 @@ flagcxResult_t bootstrapExchange(struct flagcxBootstrapState *state, int peer,
   return flagcxSuccess;
 }
 
-flagcxResult_t bootstrapClose(struct flagcxBootstrapState *state) {
+flagcxResult_t bootstrapClose(struct bootstrapState *state) {
   if (state == NULL)
     return flagcxSuccess;
 
@@ -591,7 +601,7 @@ flagcxResult_t bootstrapClose(struct flagcxBootstrapState *state) {
   return flagcxSuccess;
 }
 
-flagcxResult_t bootstrapCollAbort(struct flagcxBootstrapState *state) {
+flagcxResult_t bootstrapCollAbort(struct bootstrapState *state) {
   if (state == NULL)
     return flagcxSuccess;
   struct bootstrapCollState *coll = state->coll;
@@ -627,7 +637,7 @@ static flagcxResult_t bootstrapRingAllGather(struct flagcxSocket *prevSocket,
   return flagcxSuccess;
 }
 
-flagcxResult_t bootstrapCollAllGather(struct flagcxBootstrapState *state,
+flagcxResult_t bootstrapCollAllGather(struct bootstrapState *state,
                                       void *allData, int size) {
   struct bootstrapCollState *coll = unwrapCollState(state);
   if (coll == NULL)
@@ -640,7 +650,7 @@ flagcxResult_t bootstrapCollAllGather(struct flagcxBootstrapState *state,
   return flagcxSuccess;
 }
 
-flagcxResult_t bootstrapCollIntraNodeBarrier(struct flagcxBootstrapState *state,
+flagcxResult_t bootstrapCollIntraNodeBarrier(struct bootstrapState *state,
                                              int *ranks, int rank, int nranks,
                                              int tag) {
   if (nranks == 1)
@@ -661,15 +671,15 @@ flagcxResult_t bootstrapCollIntraNodeBarrier(struct flagcxBootstrapState *state,
   return flagcxSuccess;
 }
 
-flagcxResult_t bootstrapCollBarrier(struct flagcxBootstrapState *state,
-                                    int rank, int nranks, int tag) {
+flagcxResult_t bootstrapCollBarrier(struct bootstrapState *state, int rank,
+                                    int nranks, int tag) {
   return bootstrapCollIntraNodeBarrier(state, NULL, rank, nranks, tag);
 }
 
-flagcxResult_t
-bootstrapCollIntraNodeBroadcast(struct flagcxBootstrapState *state, int *ranks,
-                                int rank, int nranks, int root, void *bcastData,
-                                int size) {
+flagcxResult_t bootstrapCollIntraNodeBroadcast(struct bootstrapState *state,
+                                               int *ranks, int rank, int nranks,
+                                               int root, void *bcastData,
+                                               int size) {
   if (nranks == 1)
     return flagcxSuccess;
   TRACE(FLAGCX_INIT, "rank %d nranks %d root %d size %d - ENTER", rank, nranks,
@@ -693,9 +703,9 @@ bootstrapCollIntraNodeBroadcast(struct flagcxBootstrapState *state, int *ranks,
   return flagcxSuccess;
 }
 
-flagcxResult_t bootstrapCollBroadcast(struct flagcxBootstrapState *state,
-                                      int rank, int nranks, int root,
-                                      void *bcastData, int size) {
+flagcxResult_t bootstrapCollBroadcast(struct bootstrapState *state, int rank,
+                                      int nranks, int root, void *bcastData,
+                                      int size) {
   return bootstrapCollIntraNodeBroadcast(state, NULL, rank, nranks, root,
                                          bcastData, size);
 }
@@ -855,7 +865,7 @@ bootstrapRingAllReduce(struct flagcxSocket *prevSocket,
 }
 
 static flagcxResult_t
-bootstrapRingReduce(struct flagcxBootstrapState *commState,
+bootstrapRingReduce(struct bootstrapState *commState,
                     struct flagcxSocket *prevSocket,
                     struct flagcxSocket *nextSocket, int rank, int nranks,
                     const char *sendbuff, char *recvbuff, size_t count,
@@ -904,7 +914,7 @@ bootstrapRingReduce(struct flagcxBootstrapState *commState,
   return flagcxSuccess;
 }
 
-flagcxResult_t AllReduceBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t AllReduceBootstrap(struct bootstrapState *state,
                                   const void *sendbuff, void *recvbuff,
                                   size_t count, flagcxDataType_t datatype,
                                   flagcxRedOp_t op) {
@@ -925,7 +935,7 @@ flagcxResult_t AllReduceBootstrap(struct flagcxBootstrapState *state,
   return flagcxSuccess;
 }
 
-flagcxResult_t ReduceBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t ReduceBootstrap(struct bootstrapState *state,
                                const void *sendbuff, void *recvbuff,
                                size_t count, flagcxDataType_t datatype,
                                flagcxRedOp_t op, int root) {
@@ -946,7 +956,7 @@ flagcxResult_t ReduceBootstrap(struct flagcxBootstrapState *state,
   return flagcxSuccess;
 }
 
-flagcxResult_t ReduceScatterBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t ReduceScatterBootstrap(struct bootstrapState *state,
                                       const void *sendbuff, void *recvbuff,
                                       size_t recvcount,
                                       flagcxDataType_t datatype,
@@ -975,7 +985,7 @@ flagcxResult_t ReduceScatterBootstrap(struct flagcxBootstrapState *state,
   return flagcxSuccess;
 }
 
-flagcxResult_t AlltoAllBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t AlltoAllBootstrap(struct bootstrapState *state,
                                  const void *sendbuff, void *recvbuff,
                                  size_t count, flagcxDataType_t datatype) {
   struct bootstrapCollState *coll = unwrapCollState(state);
@@ -1021,7 +1031,7 @@ flagcxResult_t AlltoAllBootstrap(struct flagcxBootstrapState *state,
   return flagcxSuccess;
 }
 
-flagcxResult_t BroadcastBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t BroadcastBootstrap(struct bootstrapState *state,
                                   const void *sendbuff, void *recvbuff,
                                   size_t count, flagcxDataType_t datatype,
                                   int root) {
@@ -1059,7 +1069,7 @@ flagcxResult_t BroadcastBootstrap(struct flagcxBootstrapState *state,
   return flagcxSuccess;
 }
 
-flagcxResult_t GatherBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t GatherBootstrap(struct bootstrapState *state,
                                const void *sendbuff, void *recvbuff,
                                size_t count, flagcxDataType_t datatype,
                                int root) {
@@ -1068,7 +1078,7 @@ flagcxResult_t GatherBootstrap(struct flagcxBootstrapState *state,
     return flagcxInvalidArgument;
   int rank = coll->rank;
   int nranks = coll->nranks;
-  const int bootstrapTag = -9994;
+  const int bootstrapTag = -9996;
 
   if (nranks == 1) {
     if (sendbuff != recvbuff) {
@@ -1098,7 +1108,54 @@ flagcxResult_t GatherBootstrap(struct flagcxBootstrapState *state,
   return flagcxSuccess;
 }
 
-flagcxResult_t AlltoAllvBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t ScatterBootstrap(struct bootstrapState *state,
+                                const void *sendbuff, void *recvbuff,
+                                size_t count, flagcxDataType_t datatype,
+                                int root) {
+  struct bootstrapCollState *coll = unwrapCollState(state);
+  if (coll == NULL)
+    return flagcxInvalidArgument;
+  int rank = coll->rank;
+  int nranks = coll->nranks;
+  size_t size = count * getFlagcxDataTypeSize(datatype);
+  const int bootstrapTag = -9997;
+
+  if (rank == root) {
+    // Root sends to all non-root ranks
+    memcpy((void *)recvbuff, (const char *)sendbuff + rank * size, size);
+    for (int i = 0; i < nranks; i++) {
+      if (i != root) {
+        FLAGCXCHECK(bootstrapSend(state, i, bootstrapTag,
+                                  (void *)((const char *)sendbuff + i * size),
+                                  size));
+      }
+    }
+  } else {
+    // Non-root receives from root
+    FLAGCXCHECK(bootstrapRecv(state, root, bootstrapTag, recvbuff, size));
+  }
+  return flagcxSuccess;
+}
+
+flagcxResult_t AllGatherBootstrap(struct bootstrapState *state,
+                                  const void *sendbuff, void *recvbuff,
+                                  size_t sendcount, flagcxDataType_t datatype) {
+  struct bootstrapCollState *coll = unwrapCollState(state);
+  if (coll == NULL)
+    return flagcxInvalidArgument;
+  int rank = coll->rank;
+  size_t size = sendcount * getFlagcxDataTypeSize(datatype);
+
+  // Copy own data into the correct slot (memmove handles in-place case
+  // where sendbuff == recvbuff + rank * size)
+  memmove((char *)recvbuff + rank * size, sendbuff, size);
+
+  // Use the existing bootstrapCollAllGather on the receive buffer
+  FLAGCXCHECK(bootstrapCollAllGather(state, recvbuff, size));
+  return flagcxSuccess;
+}
+
+flagcxResult_t AlltoAllvBootstrap(struct bootstrapState *state,
                                   const void *sendbuff, size_t *sendcounts,
                                   size_t *sdispls, void *recvbuff,
                                   size_t *recvcounts, size_t *rdispls,
@@ -1116,7 +1173,7 @@ flagcxResult_t AlltoAllvBootstrap(struct flagcxBootstrapState *state,
              (void *)((char *)sendbuff + sdispls[i] * typeSize),
              sendcounts[i] * typeSize);
     }
-    const int bootstrapTag = -9995;
+    const int bootstrapTag = -9998;
     if (rank > i) {
       FLAGCXCHECK(
           bootstrapSend(state, i, bootstrapTag,
@@ -1140,58 +1197,13 @@ flagcxResult_t AlltoAllvBootstrap(struct flagcxBootstrapState *state,
   return flagcxSuccess;
 }
 
-flagcxResult_t ScatterBootstrap(struct flagcxBootstrapState *state,
-                                const void *sendbuff, void *recvbuff,
-                                size_t count, flagcxDataType_t datatype,
-                                int root) {
-  struct bootstrapCollState *coll = unwrapCollState(state);
-  if (coll == NULL)
-    return flagcxInvalidArgument;
-  int rank = coll->rank;
-  int nranks = coll->nranks;
-  size_t size = count * getFlagcxDataTypeSize(datatype);
-
-  if (rank == root) {
-    // Root sends to all non-root ranks
-    memcpy((void *)recvbuff, (const char *)sendbuff + rank * size, size);
-    for (int i = 0; i < nranks; i++) {
-      if (i != root) {
-        FLAGCXCHECK(bootstrapSend(state, i, -9994,
-                                  (void *)((const char *)sendbuff + i * size),
-                                  size));
-      }
-    }
-  } else {
-    // Non-root receives from root
-    FLAGCXCHECK(bootstrapRecv(state, root, -9994, recvbuff, size));
-  }
-  return flagcxSuccess;
-}
-
-flagcxResult_t AllGatherBootstrap(struct flagcxBootstrapState *state,
-                                  const void *sendbuff, void *recvbuff,
-                                  size_t sendcount, flagcxDataType_t datatype) {
-  struct bootstrapCollState *coll = unwrapCollState(state);
-  if (coll == NULL)
-    return flagcxInvalidArgument;
-  int rank = coll->rank;
-  size_t size = sendcount * getFlagcxDataTypeSize(datatype);
-
-  // Copy own data into the correct slot
-  memcpy((char *)recvbuff + rank * size, sendbuff, size);
-
-  // Use the existing bootstrapCollAllGather on the receive buffer
-  FLAGCXCHECK(bootstrapCollAllGather(state, recvbuff, size));
-  return flagcxSuccess;
-}
-
 // ============================================================================
 // P2P Mode: RPC-style Listen / Connect / Accept
 // ============================================================================
 
 flagcxResult_t bootstrapP2pListen(uint64_t magic, volatile uint32_t *abortFlag,
                                   void *listenHandle,
-                                  struct flagcxBootstrapState **stateOut) {
+                                  struct bootstrapState **stateOut) {
   // Ensure network interface is discovered
   FLAGCXCHECK(bootstrapNetInit());
 
@@ -1215,7 +1227,7 @@ flagcxResult_t bootstrapP2pListen(uint64_t magic, volatile uint32_t *abortFlag,
   memcpy(&handle->addr, &p2p->localAddr, sizeof(union flagcxSocketAddress));
 
   // Wrap in state
-  struct flagcxBootstrapState *wrapper;
+  struct bootstrapState *wrapper;
   FLAGCXCHECK(flagcxCalloc(&wrapper, 1));
   wrapper->mode = FLAGCX_BOOTSTRAP_P2P;
   wrapper->p2p = p2p;
@@ -1226,7 +1238,7 @@ flagcxResult_t bootstrapP2pListen(uint64_t magic, volatile uint32_t *abortFlag,
 
 flagcxResult_t bootstrapP2pConnect(void *peerHandle, uint64_t magic,
                                    volatile uint32_t *abortFlag,
-                                   struct flagcxBootstrapState **stateOut) {
+                                   struct bootstrapState **stateOut) {
   // Ensure network interface is discovered
   FLAGCXCHECK(bootstrapNetInit());
 
@@ -1246,7 +1258,7 @@ flagcxResult_t bootstrapP2pConnect(void *peerHandle, uint64_t magic,
   FLAGCXCHECK(flagcxSocketConnect(&p2p->sock));
 
   // Wrap in state
-  struct flagcxBootstrapState *wrapper;
+  struct bootstrapState *wrapper;
   FLAGCXCHECK(flagcxCalloc(&wrapper, 1));
   wrapper->mode = FLAGCX_BOOTSTRAP_P2P;
   wrapper->p2p = p2p;
@@ -1255,8 +1267,8 @@ flagcxResult_t bootstrapP2pConnect(void *peerHandle, uint64_t magic,
   return flagcxSuccess;
 }
 
-flagcxResult_t bootstrapP2pAccept(struct flagcxBootstrapState *listenState,
-                                  struct flagcxBootstrapState **connStateOut) {
+flagcxResult_t bootstrapP2pAccept(struct bootstrapState *listenState,
+                                  struct bootstrapState **connStateOut) {
   if (listenState == NULL || listenState->mode != FLAGCX_BOOTSTRAP_P2P) {
     WARN("bootstrapP2pAccept: not a P2P listen state");
     return flagcxInvalidArgument;
@@ -1279,7 +1291,7 @@ flagcxResult_t bootstrapP2pAccept(struct flagcxBootstrapState *listenState,
   FLAGCXCHECK(flagcxSocketAccept(&connP2p->sock, &listenP2p->sock));
 
   // Wrap in state
-  struct flagcxBootstrapState *wrapper;
+  struct bootstrapState *wrapper;
   FLAGCXCHECK(flagcxCalloc(&wrapper, 1));
   wrapper->mode = FLAGCX_BOOTSTRAP_P2P;
   wrapper->p2p = connP2p;

--- a/flagcx/service/bootstrap.cc
+++ b/flagcx/service/bootstrap.cc
@@ -462,6 +462,7 @@ static void unexpectedFree(struct bootstrapCollState *state) {
   while (elem) {
     prev = elem;
     elem = elem->next;
+    flagcxSocketClose(&prev->sock);
     free(prev);
   }
 }
@@ -632,8 +633,6 @@ flagcxResult_t bootstrapClose(struct bootstrapState *state) {
     unexpectedFree(coll);
     if (__atomic_load_n(coll->abortFlag, __ATOMIC_RELAXED) == 0) {
       WARN("Unexpected connections are not empty");
-      free(state);
-      return flagcxInternalError;
     }
   }
 
@@ -1053,37 +1052,40 @@ flagcxResult_t AlltoAllBootstrap(struct bootstrapState *state,
   bool inPlace = (sendbuff == recvbuff);
   char *tmpBuff = nullptr;
   if (inPlace) {
-    FLAGCXCHECK(flagcxCalloc(&tmpBuff, size));
-    memcpy(tmpBuff, (char *)sendbuff + rank * size, size);
+    FLAGCXCHECK(flagcxCalloc(&tmpBuff, nranks * size));
+    memcpy(tmpBuff, sendbuff, nranks * size);
+    sendbuff = tmpBuff;
   }
 
   const int bootstrapTag = BOOTSTRAP_TAG_ALLTOALL;
+  flagcxResult_t res = flagcxSuccess;
   for (int i = 0; i < nranks; i++) {
     if (i == rank) {
-      if (inPlace) {
-        memcpy((char *)recvbuff + rank * size, tmpBuff, size);
-      } else {
-        memcpy((char *)recvbuff + rank * size, (char *)sendbuff + rank * size,
-               size);
-      }
+      memcpy((char *)recvbuff + rank * size, (char *)sendbuff + rank * size,
+             size);
       continue;
     }
     if (rank > i) {
-      FLAGCXCHECK(bootstrapSend(state, i, bootstrapTag,
-                                (char *)sendbuff + i * size, size));
-      FLAGCXCHECK(bootstrapRecv(state, i, bootstrapTag,
-                                (char *)recvbuff + i * size, size));
+      FLAGCXCHECKGOTO(bootstrapSend(state, i, bootstrapTag,
+                                    (char *)sendbuff + i * size, size),
+                      res, cleanup);
+      FLAGCXCHECKGOTO(bootstrapRecv(state, i, bootstrapTag,
+                                    (char *)recvbuff + i * size, size),
+                      res, cleanup);
     } else {
-      FLAGCXCHECK(bootstrapRecv(state, i, bootstrapTag,
-                                (char *)recvbuff + i * size, size));
-      FLAGCXCHECK(bootstrapSend(state, i, bootstrapTag,
-                                (char *)sendbuff + i * size, size));
+      FLAGCXCHECKGOTO(bootstrapRecv(state, i, bootstrapTag,
+                                    (char *)recvbuff + i * size, size),
+                      res, cleanup);
+      FLAGCXCHECKGOTO(bootstrapSend(state, i, bootstrapTag,
+                                    (char *)sendbuff + i * size, size),
+                      res, cleanup);
     }
   }
 
+cleanup:
   if (tmpBuff)
     free(tmpBuff);
-  return flagcxSuccess;
+  return res;
 }
 
 flagcxResult_t BroadcastBootstrap(struct bootstrapState *state,

--- a/flagcx/service/bootstrap.cc
+++ b/flagcx/service/bootstrap.cc
@@ -15,6 +15,14 @@
 #include <unistd.h>
 #include <vector>
 
+// Internal tags for typed collective operations (must be unique per operation)
+#define BOOTSTRAP_TAG_REDUCE (-9993)
+#define BOOTSTRAP_TAG_BROADCAST (-9994)
+#define BOOTSTRAP_TAG_ALLTOALL (-9995)
+#define BOOTSTRAP_TAG_GATHER (-9996)
+#define BOOTSTRAP_TAG_SCATTER (-9997)
+#define BOOTSTRAP_TAG_ALLTOALLV (-9998)
+
 struct bootstrapRootArgs {
   struct flagcxSocket *listenSock;
   uint64_t magic;
@@ -923,7 +931,7 @@ bootstrapRingReduce(struct bootstrapState *commState,
                                          length.data(), datatype, op));
 
   // gather to root
-  const int bootstrapTag = -9993;
+  const int bootstrapTag = BOOTSTRAP_TAG_REDUCE;
   if (rank == root) {
     for (int i = 0; i < nranks; i++) {
       if (i == rank)
@@ -1027,7 +1035,7 @@ flagcxResult_t AlltoAllBootstrap(struct bootstrapState *state,
     memcpy(tmpBuff, (char *)sendbuff + rank * size, size);
   }
 
-  const int bootstrapTag = -9995;
+  const int bootstrapTag = BOOTSTRAP_TAG_ALLTOALL;
   for (int i = 0; i < nranks; i++) {
     if (i == rank) {
       if (inPlace) {
@@ -1065,7 +1073,7 @@ flagcxResult_t BroadcastBootstrap(struct bootstrapState *state,
     return flagcxInvalidArgument;
   int rank = coll->rank;
   int nranks = coll->nranks;
-  const int bootstrapTag = -9994;
+  const int bootstrapTag = BOOTSTRAP_TAG_BROADCAST;
   if (nranks == 1) {
     if (sendbuff != recvbuff) {
       memcpy(recvbuff, sendbuff, getFlagcxDataTypeSize(datatype) * count);
@@ -1103,7 +1111,7 @@ flagcxResult_t GatherBootstrap(struct bootstrapState *state,
     return flagcxInvalidArgument;
   int rank = coll->rank;
   int nranks = coll->nranks;
-  const int bootstrapTag = -9996;
+  const int bootstrapTag = BOOTSTRAP_TAG_GATHER;
 
   if (nranks == 1) {
     if (sendbuff != recvbuff) {
@@ -1143,7 +1151,7 @@ flagcxResult_t ScatterBootstrap(struct bootstrapState *state,
   int rank = coll->rank;
   int nranks = coll->nranks;
   size_t size = count * getFlagcxDataTypeSize(datatype);
-  const int bootstrapTag = -9997;
+  const int bootstrapTag = BOOTSTRAP_TAG_SCATTER;
 
   if (rank == root) {
     // Root sends to all non-root ranks
@@ -1198,7 +1206,7 @@ flagcxResult_t AlltoAllvBootstrap(struct bootstrapState *state,
              (void *)((char *)sendbuff + sdispls[i] * typeSize),
              sendcounts[i] * typeSize);
     }
-    const int bootstrapTag = -9998;
+    const int bootstrapTag = BOOTSTRAP_TAG_ALLTOALLV;
     if (rank > i) {
       FLAGCXCHECK(
           bootstrapSend(state, i, bootstrapTag,

--- a/flagcx/service/bootstrap.cc
+++ b/flagcx/service/bootstrap.cc
@@ -174,6 +174,7 @@ static void *bootstrapRoot(void *rargs) {
   flagcxResult_t res = flagcxSuccess;
 
   /* Receive addresses from all ranks */
+  int checkedIn = 0;
   do {
     struct flagcxSocket sock;
     FLAGCXCHECKGOTO(flagcxSocketInit(&sock), res, fail);
@@ -184,12 +185,20 @@ static void *bootstrapRoot(void *rargs) {
     if (nranks == 0) {
       nranks = info.nranks;
       FLAGCXCHECKGOTO(flagcxCalloc(&rankInfo, nranks), res, fail);
-    }
-    if (info.rank < 0 || info.rank >= nranks) {
+    } else if (info.nranks != nranks) {
+      WARN("Bootstrap Root: rank %d nranks mismatch: expected %d, got %d",
+           info.rank, nranks, info.nranks);
+      res = flagcxInvalidArgument;
       goto fail;
     }
+    if (info.rank < 0 || info.rank >= nranks) {
+      res = flagcxInvalidArgument;
+      goto fail;
+    }
+    if (rankInfo[info.rank].nranks == 0)
+      checkedIn++;
     rankInfo[info.rank] = info;
-  } while (rankInfo[nranks - 1].nranks == 0);
+  } while (checkedIn < nranks);
 
   /* Send everyone info about their "next" rank in the ring */
   for (int i = 0; i < nranks; ++i) {
@@ -234,6 +243,9 @@ flagcxResult_t bootstrapCollCreateRoot(struct flagcxBootstrapHandle *handle,
   args->magic = handle->magic;
   if (pthread_create(&thread, NULL, bootstrapRoot, (void *)args) != 0) {
     WARN("bootstrapCollCreateRoot: pthread_create failed");
+    free(args);
+    flagcxSocketClose(listenSock);
+    free(listenSock);
     return flagcxSystemError;
   }
   flagcxSetThreadName(thread, "FlagCX BootRoot");
@@ -889,11 +901,18 @@ bootstrapRingAllReduce(struct flagcxSocket *prevSocket,
                                          sendbuff, recvbuff, offset.data(),
                                          length.data(), datatype, op));
 
-  // AllGather the results
+  // AllGather the results with variable chunk sizes
   // Copy my chunk into correct position
-  memcpy(recvbuff + offset[rank], recvbuff, length[rank]);
-  FLAGCXCHECK(bootstrapRingAllGather(prevSocket, nextSocket, rank, nranks,
-                                     recvbuff, ChunkBytes));
+  memmove(recvbuff + offset[rank], recvbuff, length[rank]);
+
+  // Ring AllGather with per-slice variable sizes
+  for (int i = 0; i < nranks - 1; i++) {
+    size_t sslice = (rank - i + nranks) % nranks;
+    size_t rslice = (rank - i - 1 + nranks) % nranks;
+    FLAGCXCHECK(bootstrapNetSendRecv(
+        nextSocket, recvbuff + offset[sslice], (int)length[sslice], prevSocket,
+        recvbuff + offset[rslice], (int)length[rslice]));
+  }
   return flagcxSuccess;
 }
 
@@ -929,6 +948,9 @@ bootstrapRingReduce(struct bootstrapState *commState,
   FLAGCXCHECK(bootstrapRingReduceScatter(prevSocket, nextSocket, rank, nranks,
                                          sendbuff, recvbuff, offset.data(),
                                          length.data(), datatype, op));
+
+  // Move my reduced chunk to its final position before gather to root
+  memmove(recvbuff + offset[rank], recvbuff, length[rank]);
 
   // gather to root
   const int bootstrapTag = BOOTSTRAP_TAG_REDUCE;

--- a/flagcx/service/bootstrap.cc
+++ b/flagcx/service/bootstrap.cc
@@ -81,160 +81,119 @@ static flagcxResult_t bootstrapNetRecv(struct flagcxSocket *sock, void *data,
   int recvSize;
   FLAGCXCHECK(flagcxSocketRecv(sock, &recvSize, sizeof(int)));
   if (recvSize > size) {
-    WARN("Message truncated : received %d bytes instead of %d", recvSize, size);
+    WARN(
+        "bootstrapNetRecv: message truncated : received %d bytes instead of %d",
+        recvSize, size);
     return flagcxInternalError;
   }
   FLAGCXCHECK(flagcxSocketRecv(sock, data, std::min(recvSize, size)));
   return flagcxSuccess;
 }
-static flagcxResult_t bootstrapNetSendRecv(struct flagcxSocket *sendSock,
+static flagcxResult_t bootstrapNetSendRecv(struct flagcxSocket *sendSocket,
                                            void *sendData, int sendSize,
-                                           struct flagcxSocket *recvSock,
+                                           struct flagcxSocket *recvSocket,
                                            void *recvData, int recvSize) {
-  int senderRecvSize;
-  FLAGCXCHECK(flagcxSocketSendRecv(sendSock, &sendSize, sizeof(int), recvSock,
-                                   &senderRecvSize, sizeof(int)));
-  if (senderRecvSize > recvSize) {
-    WARN("Message truncated : received %d bytes instead of %d", senderRecvSize,
-         recvSize);
-    return flagcxInternalError;
-  }
-  FLAGCXCHECK(flagcxSocketSendRecv(sendSock, sendData, sendSize, recvSock,
-                                   recvData, recvSize));
+  FLAGCXCHECK(bootstrapNetSend(sendSocket, sendData, sendSize));
+  FLAGCXCHECK(bootstrapNetRecv(recvSocket, recvData, recvSize));
   return flagcxSuccess;
 }
 
 struct extInfo {
   int rank;
   int nranks;
-  union flagcxSocketAddress extAddressListenRoot;
   union flagcxSocketAddress extAddressListen;
+  union flagcxSocketAddress extAddressListenRoot;
 };
 
-#include <sys/resource.h>
+#include <cstdint>
+enum {
+  BOOTSTRAP_TIMER_TOTAL = 0,
+  BOOTSTRAP_TIMER_ALLOC,
+  BOOTSTRAP_TIMER_MEM,
+  BOOTSTRAP_TIMER_COMM,
+  BOOTSTRAP_TIMER_CALC,
+  BOOTSTRAP_TIMERS_COUNT
+};
 
-static flagcxResult_t setFilesLimit() {
-  struct rlimit filesLimit;
-  SYSCHECK(getrlimit(RLIMIT_NOFILE, &filesLimit), "getrlimit");
-  filesLimit.rlim_cur = filesLimit.rlim_max;
-  SYSCHECK(setrlimit(RLIMIT_NOFILE, &filesLimit), "setrlimit");
-  return flagcxSuccess;
-}
-
+// Root thread for collective bootstrap ring setup
 static void *bootstrapRoot(void *rargs) {
   struct bootstrapRootArgs *args = (struct bootstrapRootArgs *)rargs;
   struct flagcxSocket *listenSock = args->listenSock;
   uint64_t magic = args->magic;
-  flagcxResult_t res = flagcxSuccess;
-  int nranks = 0, c = 0;
-  struct extInfo info;
-  union flagcxSocketAddress *rankAddresses = NULL;
-  union flagcxSocketAddress *rankAddressesRoot =
-      NULL; // for initial rank <-> root information exchange
-  union flagcxSocketAddress *zero = NULL;
-  FLAGCXCHECKGOTO(flagcxCalloc(&zero, 1), res, out);
-  setFilesLimit();
+  free(args);
 
-  TRACE(FLAGCX_INIT, "BEGIN");
+  struct extInfo info;
+  struct extInfo *rankInfo = NULL;
+  int nranks = 0;
+  flagcxResult_t res = flagcxSuccess;
+
   /* Receive addresses from all ranks */
   do {
     struct flagcxSocket sock;
-    FLAGCXCHECKGOTO(flagcxSocketInit(&sock), res, out);
-    FLAGCXCHECKGOTO(flagcxSocketAccept(&sock, listenSock), res, out);
-    FLAGCXCHECKGOTO(bootstrapNetRecv(&sock, &info, sizeof(info)), res, out);
-    FLAGCXCHECKGOTO(flagcxSocketClose(&sock), res, out);
+    FLAGCXCHECKGOTO(flagcxSocketInit(&sock), res, fail);
+    FLAGCXCHECKGOTO(flagcxSocketAccept(&sock, listenSock), res, fail);
+    FLAGCXCHECKGOTO(bootstrapNetRecv(&sock, &info, sizeof(info)), res, fail);
+    FLAGCXCHECKGOTO(flagcxSocketClose(&sock), res, fail);
 
-    if (c == 0) {
+    if (nranks == 0) {
       nranks = info.nranks;
-      FLAGCXCHECKGOTO(flagcxCalloc(&rankAddresses, nranks), res, out);
-      FLAGCXCHECKGOTO(flagcxCalloc(&rankAddressesRoot, nranks), res, out);
+      FLAGCXCHECKGOTO(flagcxCalloc(&rankInfo, nranks), res, fail);
     }
-
-    if (nranks != info.nranks) {
-      WARN("Bootstrap Root : mismatch in rank count from procs %d : %d", nranks,
-           info.nranks);
-      goto out;
+    if (info.rank < 0 || info.rank >= nranks) {
+      goto fail;
     }
+    rankInfo[info.rank] = info;
+  } while (rankInfo[nranks - 1].nranks == 0);
 
-    if (memcmp(zero, &rankAddressesRoot[info.rank],
-               sizeof(union flagcxSocketAddress)) != 0) {
-      WARN("Bootstrap Root : rank %d of %d ranks has already checked in",
-           info.rank, nranks);
-      goto out;
-    }
-
-    INFO(FLAGCX_INIT, "Bootstrap Root : rank %d of %d ranks checked in",
-         info.rank, nranks);
-
-    // Save the connection handle for that rank
-    memcpy(rankAddressesRoot + info.rank, &info.extAddressListenRoot,
-           sizeof(union flagcxSocketAddress));
-    memcpy(rankAddresses + info.rank, &info.extAddressListen,
-           sizeof(union flagcxSocketAddress));
-
-    ++c;
-    TRACE(FLAGCX_INIT, "Received connect from rank %d total %d/%d", info.rank,
-          c, nranks);
-  } while (c < nranks);
-  TRACE(FLAGCX_INIT, "COLLECTED ALL %d HANDLES", nranks);
-
-  // Send the connect handle for the next rank in the AllGather ring
-  for (int r = 0; r < nranks; ++r) {
-    int next = (r + 1) % nranks;
+  /* Send everyone info about their "next" rank in the ring */
+  for (int i = 0; i < nranks; ++i) {
+    int next = (i + 1) % nranks;
     struct flagcxSocket sock;
-    FLAGCXCHECKGOTO(flagcxSocketInit(&sock, rankAddressesRoot + r, magic,
-                                     flagcxSocketTypeBootstrap),
-                    res, out);
-    FLAGCXCHECKGOTO(flagcxSocketConnect(&sock), res, out);
-    FLAGCXCHECKGOTO(bootstrapNetSend(&sock, rankAddresses + next,
+    FLAGCXCHECKGOTO(flagcxSocketInit(&sock, &rankInfo[i].extAddressListenRoot,
+                                     magic, flagcxSocketTypeBootstrap),
+                    res, fail);
+    FLAGCXCHECKGOTO(flagcxSocketConnect(&sock), res, fail);
+    FLAGCXCHECKGOTO(bootstrapNetSend(&sock, &rankInfo[next].extAddressListen,
                                      sizeof(union flagcxSocketAddress)),
-                    res, out);
-    FLAGCXCHECKGOTO(flagcxSocketClose(&sock), res, out);
+                    res, fail);
+    FLAGCXCHECKGOTO(flagcxSocketClose(&sock), res, fail);
   }
-  INFO(FLAGCX_INIT, "SENT OUT ALL %d HANDLES", nranks);
 
-out:
-  if (listenSock != NULL) {
-    flagcxSocketClose(listenSock);
-    free(listenSock);
-  }
-  if (rankAddresses)
-    free(rankAddresses);
-  if (rankAddressesRoot)
-    free(rankAddressesRoot);
-  if (zero)
-    free(zero);
-  free(rargs);
-
-  TRACE(FLAGCX_INIT, "DONE");
+  TRACE(FLAGCX_INIT, "DONE magic %lx", magic);
+fail:
+  if (rankInfo)
+    free(rankInfo);
+  flagcxSocketClose(listenSock);
+  free(listenSock);
   return NULL;
 }
 
-flagcxResult_t bootstrapCreateRoot(struct flagcxBootstrapHandle *handle,
-                                   bool idFromEnv) {
+flagcxResult_t bootstrapCollCreateRoot(struct flagcxBootstrapHandle *handle,
+                                       bool idFromEnv) {
   struct flagcxSocket *listenSock;
   struct bootstrapRootArgs *args;
   pthread_t thread;
 
   FLAGCXCHECK(flagcxCalloc(&listenSock, 1));
   FLAGCXCHECK(flagcxSocketInit(listenSock, &handle->addr, handle->magic,
-                               flagcxSocketTypeBootstrap, NULL, 0));
+                               flagcxSocketTypeBootstrap));
   FLAGCXCHECK(flagcxSocketListen(listenSock));
   FLAGCXCHECK(flagcxSocketGetAddr(listenSock, &handle->addr));
 
   FLAGCXCHECK(flagcxCalloc(&args, 1));
   args->listenSock = listenSock;
   args->magic = handle->magic;
-  NEQCHECK(pthread_create(&thread, NULL, bootstrapRoot, (void *)args), 0);
-  flagcxSetThreadName(thread, "FLAGCX bootstrapRoot");
-  NEQCHECK(pthread_detach(thread), 0); // will not be pthread_join()'d
+  if (pthread_create(&thread, NULL, bootstrapRoot, (void *)args) != 0) {
+    WARN("bootstrapCollCreateRoot: pthread_create failed");
+    return flagcxSystemError;
+  }
+  flagcxSetThreadName(thread, "FlagCX BootRoot");
+  (void)pthread_detach(thread);
   return flagcxSuccess;
 }
 
 flagcxResult_t bootstrapGetUniqueId(struct flagcxBootstrapHandle *handle) {
-  memset(handle, 0, sizeof(flagcxBootstrapHandle));
-  FLAGCXCHECK(getRandomData(&handle->magic, sizeof(handle->magic)));
-
+  memset(handle, 0, sizeof(*handle));
   const char *env = flagcxGetEnv("FLAGCX_COMM_ID");
   if (env) {
     INFO(FLAGCX_ENV, "FLAGCX_COMM_ID set by environment to %s", env);
@@ -243,14 +202,20 @@ flagcxResult_t bootstrapGetUniqueId(struct flagcxBootstrapHandle *handle) {
            "[<ipv6>]:<port> or <hostname>:<port>");
       return flagcxInvalidArgument;
     }
+    handle->magic = FLAGCX_MAGIC;
   } else {
+    FLAGCXCHECK(getRandomData(&handle->magic, sizeof(handle->magic)));
     memcpy(&handle->addr, &bootstrapNetIfAddr,
            sizeof(union flagcxSocketAddress));
-    FLAGCXCHECK(bootstrapCreateRoot(handle, false));
+    FLAGCXCHECK(bootstrapCollCreateRoot(handle, false));
   }
 
   return flagcxSuccess;
 }
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
 
 struct unexConn {
   int peer;
@@ -259,11 +224,40 @@ struct unexConn {
   struct unexConn *next;
 };
 
-flagcxResult_t bootstrapInit(struct flagcxBootstrapHandle *handle,
-                             void *commState) {
-  struct bootstrapState *state = (struct bootstrapState *)commState;
-  int rank = state->rank;
-  int nranks = state->nranks;
+// Helper to unwrap flagcxBootstrapState -> bootstrapCollState
+// The coll state is always valid regardless of current mode.
+static inline struct bootstrapCollState *
+unwrapCollState(struct flagcxBootstrapState *state) {
+  if (state == NULL || state->coll == NULL) {
+    return NULL;
+  }
+  return state->coll;
+}
+
+// ============================================================================
+// Collective Mode Init
+// ============================================================================
+
+flagcxResult_t bootstrapCollInit(struct flagcxBootstrapHandle *handle, int rank,
+                                 int nranks, uint64_t magic,
+                                 volatile uint32_t *abortFlag,
+                                 struct flagcxBootstrapState **stateOut) {
+  // Allocate wrapper
+  struct flagcxBootstrapState *wrapper;
+  FLAGCXCHECK(flagcxCalloc(&wrapper, 1));
+  wrapper->mode = FLAGCX_BOOTSTRAP_COLL;
+
+  // Allocate coll state
+  struct bootstrapCollState *state;
+  FLAGCXCHECK(flagcxCalloc(&state, 1));
+  wrapper->coll = state;
+
+  // Fill in parameters
+  state->rank = rank;
+  state->nranks = nranks;
+  state->magic = magic;
+  state->abortFlag = abortFlag;
+
   flagcxSocketAddress nextAddr;
   struct flagcxSocket sock, listenSockRoot;
   struct extInfo info = {0};
@@ -323,8 +317,8 @@ flagcxResult_t bootstrapInit(struct flagcxBootstrapHandle *handle,
   FLAGCXCHECK(flagcxCalloc(&state->peerCommAddresses, nranks));
   FLAGCXCHECK(
       flagcxSocketGetAddr(&state->listenSock, state->peerCommAddresses + rank));
-  FLAGCXCHECK(bootstrapAllGather(state, state->peerCommAddresses,
-                                 sizeof(union flagcxSocketAddress)));
+  FLAGCXCHECK(bootstrapCollAllGather(wrapper, state->peerCommAddresses,
+                                     sizeof(union flagcxSocketAddress)));
 
   // Set bootstrap net info
   state->bootstrapNetIfName = bootstrapNetIfName;
@@ -333,27 +327,27 @@ flagcxResult_t bootstrapInit(struct flagcxBootstrapHandle *handle,
   state->properties = properties;
   INFO(FLAGCX_INIT, "rank %d nranks %d - DONE", rank, nranks);
 
+  *stateOut = wrapper;
   return flagcxSuccess;
 }
 
-// Bootstrap send/receive functions
-//
-// We do not keep connections opened with all ranks at all times, and we have no
-// guarantee that connections to our unique listen socket will arrive in the
-// same order as we need them. Therefore, when establishing a connection, the
-// sender sends a (peer, tag) tuple to allow the receiver to identify the flow,
-// and keep it in an unexpected queue if needed.
+// ============================================================================
+// Collective Mode: Send/Recv internals (ring relay)
+// ============================================================================
 
-flagcxResult_t bootstrapConnect(void *commState, int peer, int tag,
-                                struct flagcxSocket *sock) {
+static flagcxResult_t bootstrapCollConnect(struct flagcxBootstrapState *state,
+                                           int peer, int tag,
+                                           struct flagcxSocket *sock) {
   flagcxResult_t ret = flagcxSuccess;
-  struct bootstrapState *state = (struct bootstrapState *)commState;
+  struct bootstrapCollState *coll = unwrapCollState(state);
+  if (coll == NULL)
+    return flagcxInvalidArgument;
 
-  FLAGCXCHECKGOTO(flagcxSocketInit(sock, state->peerCommAddresses + peer,
-                                   state->magic, flagcxSocketTypeBootstrap),
+  FLAGCXCHECKGOTO(flagcxSocketInit(sock, coll->peerCommAddresses + peer,
+                                   coll->magic, flagcxSocketTypeBootstrap),
                   ret, fail);
   FLAGCXCHECKGOTO(flagcxSocketConnect(sock), ret, fail);
-  FLAGCXCHECKGOTO(bootstrapNetSend(sock, &state->rank, sizeof(int)), ret, fail);
+  FLAGCXCHECKGOTO(bootstrapNetSend(sock, &coll->rank, sizeof(int)), ret, fail);
   FLAGCXCHECKGOTO(bootstrapNetSend(sock, &tag, sizeof(int)), ret, fail);
   return flagcxSuccess;
 fail:
@@ -361,32 +355,15 @@ fail:
   return ret;
 }
 
-flagcxResult_t bootstrapSend(void *commState, int peer, int tag, void *data,
-                             int size) {
-  flagcxResult_t ret = flagcxSuccess;
-  struct flagcxSocket sock;
-
-  TRACE(FLAGCX_BOOTSTRAP, "Sending to peer=%d tag=%d size=%d", peer, tag, size);
-  FLAGCXCHECK(bootstrapConnect(commState, peer, tag, &sock));
-  FLAGCXCHECKGOTO(bootstrapNetSend(&sock, data, size), ret, exit);
-
-  TRACE(FLAGCX_BOOTSTRAP, "Sent to peer=%d tag=%d size=%d", peer, tag, size);
-
-exit:
-  FLAGCXCHECK(flagcxSocketClose(&sock));
-  return ret;
-}
-
-flagcxResult_t unexpectedEnqueue(struct bootstrapState *state, int peer,
-                                 int tag, struct flagcxSocket *sock) {
-  // New unex
+static flagcxResult_t unexpectedEnqueue(struct bootstrapCollState *state,
+                                        int peer, int tag,
+                                        struct flagcxSocket *sock) {
   struct unexConn *unex;
   FLAGCXCHECK(flagcxCalloc(&unex, 1));
   unex->peer = peer;
   unex->tag = tag;
   memcpy(&unex->sock, sock, sizeof(struct flagcxSocket));
 
-  // Enqueue
   struct unexConn *list = state->unexpectedConnections;
   if (list == NULL) {
     state->unexpectedConnections = unex;
@@ -398,9 +375,9 @@ flagcxResult_t unexpectedEnqueue(struct bootstrapState *state, int peer,
   return flagcxSuccess;
 }
 
-flagcxResult_t unexpectedDequeue(struct bootstrapState *state, int peer,
-                                 int tag, struct flagcxSocket *sock,
-                                 int *found) {
+static flagcxResult_t unexpectedDequeue(struct bootstrapCollState *state,
+                                        int peer, int tag,
+                                        struct flagcxSocket *sock, int *found) {
   struct unexConn *elem = state->unexpectedConnections;
   struct unexConn *prev = NULL;
   *found = 0;
@@ -422,41 +399,40 @@ flagcxResult_t unexpectedDequeue(struct bootstrapState *state, int peer,
   return flagcxSuccess;
 }
 
-static void unexpectedFree(struct bootstrapState *state) {
+static void unexpectedFree(struct bootstrapCollState *state) {
   struct unexConn *elem = state->unexpectedConnections;
   struct unexConn *prev = NULL;
-
   while (elem) {
     prev = elem;
     elem = elem->next;
     free(prev);
   }
-  return;
 }
 
-// We can't know who we'll receive from, so we need to receive everything at
-// once
-flagcxResult_t bootstrapAccept(void *commState, int peer, int tag,
-                               struct flagcxSocket *sock) {
+static flagcxResult_t bootstrapCollAccept(struct flagcxBootstrapState *state,
+                                          int peer, int tag,
+                                          struct flagcxSocket *sock) {
   flagcxResult_t ret = flagcxSuccess;
-  struct bootstrapState *state = (struct bootstrapState *)commState;
+  struct bootstrapCollState *coll = unwrapCollState(state);
+  if (coll == NULL)
+    return flagcxInvalidArgument;
   int newPeer, newTag;
 
   // Search unexpected connections first
   int found;
-  FLAGCXCHECK(unexpectedDequeue(state, peer, tag, sock, &found));
+  FLAGCXCHECK(unexpectedDequeue(coll, peer, tag, sock, &found));
   if (found)
     return flagcxSuccess;
 
   // Then look for new connections
   while (1) {
     FLAGCXCHECKGOTO(flagcxSocketInit(sock), ret, fail);
-    FLAGCXCHECKGOTO(flagcxSocketAccept(sock, &state->listenSock), ret, fail);
+    FLAGCXCHECKGOTO(flagcxSocketAccept(sock, &coll->listenSock), ret, fail);
     FLAGCXCHECKGOTO(bootstrapNetRecv(sock, &newPeer, sizeof(int)), ret, fail);
     FLAGCXCHECKGOTO(bootstrapNetRecv(sock, &newTag, sizeof(int)), ret, fail);
     if (newPeer == peer && newTag == tag)
       return flagcxSuccess;
-    FLAGCXCHECKGOTO(unexpectedEnqueue(state, newPeer, newTag, sock), ret, fail);
+    FLAGCXCHECKGOTO(unexpectedEnqueue(coll, newPeer, newTag, sock), ret, fail);
   }
   return flagcxSuccess;
 fail:
@@ -464,13 +440,28 @@ fail:
   return ret;
 }
 
-// We can't know who we'll receive from, so we need to receive everything at
-// once
-flagcxResult_t bootstrapRecv(void *commState, int peer, int tag, void *data,
-                             int size) {
+static flagcxResult_t
+bootstrapCollSendInternal(struct flagcxBootstrapState *state, int peer, int tag,
+                          void *data, int size) {
+  flagcxResult_t ret = flagcxSuccess;
+  struct flagcxSocket sock;
+
+  TRACE(FLAGCX_BOOTSTRAP, "Sending to peer=%d tag=%d size=%d", peer, tag, size);
+  FLAGCXCHECK(bootstrapCollConnect(state, peer, tag, &sock));
+  FLAGCXCHECKGOTO(bootstrapNetSend(&sock, data, size), ret, exit);
+  TRACE(FLAGCX_BOOTSTRAP, "Sent to peer=%d tag=%d size=%d", peer, tag, size);
+
+exit:
+  FLAGCXCHECK(flagcxSocketClose(&sock));
+  return ret;
+}
+
+static flagcxResult_t
+bootstrapCollRecvInternal(struct flagcxBootstrapState *state, int peer, int tag,
+                          void *data, int size) {
   flagcxResult_t ret;
   struct flagcxSocket sock;
-  FLAGCXCHECK(bootstrapAccept(commState, peer, tag, &sock));
+  FLAGCXCHECK(bootstrapCollAccept(state, peer, tag, &sock));
   TRACE(FLAGCX_BOOTSTRAP, "Receiving tag=%d peer=%d size=%d", tag, peer, size);
   FLAGCXCHECKGOTO(bootstrapNetRecv(&sock, ((char *)data), size), ret, exit);
 exit:
@@ -478,110 +469,249 @@ exit:
   return ret;
 }
 
-// Collective algorithms, based on bootstrapSend/Recv, and sometimes
-// bootstrapConnect/Accept
+// ============================================================================
+// Unified Send / Recv / Exchange / Close (dispatch on mode)
+// ============================================================================
 
-flagcxResult_t bootstrapRingAllGather(struct flagcxSocket *prevSocket,
-                                      struct flagcxSocket *nextSocket, int rank,
-                                      int nranks, char *data, int size) {
-  /* Simple ring based AllGather
-   * At each step i receive data from (rank-i-1) from prev
-   * and send previous step's data from (rank-i) to next
-   */
+flagcxResult_t bootstrapSend(struct flagcxBootstrapState *state, int peer,
+                             int tag, void *data, int size) {
+  if (state == NULL)
+    return flagcxInvalidArgument;
+
+  if (state->mode == FLAGCX_BOOTSTRAP_P2P) {
+    // P2P mode: peer param ignored, send directly to connected socket
+    struct bootstrapP2pState *p2p = state->p2p;
+    if (p2p == NULL || p2p->isListener)
+      return flagcxInvalidArgument;
+    FLAGCXCHECK(flagcxSocketSend(&p2p->sock, &tag, sizeof(int)));
+    FLAGCXCHECK(flagcxSocketSend(&p2p->sock, &size, sizeof(int)));
+    FLAGCXCHECK(flagcxSocketSend(&p2p->sock, data, size));
+    return flagcxSuccess;
+  }
+
+  // Coll mode: connect-per-send via ring topology
+  return bootstrapCollSendInternal(state, peer, tag, data, size);
+}
+
+flagcxResult_t bootstrapRecv(struct flagcxBootstrapState *state, int peer,
+                             int tag, void *data, int size) {
+  if (state == NULL)
+    return flagcxInvalidArgument;
+
+  if (state->mode == FLAGCX_BOOTSTRAP_P2P) {
+    // P2P mode: peer param ignored, recv directly from connected socket
+    struct bootstrapP2pState *p2p = state->p2p;
+    if (p2p == NULL || p2p->isListener)
+      return flagcxInvalidArgument;
+    int recvTag, recvSize;
+    FLAGCXCHECK(flagcxSocketRecv(&p2p->sock, &recvTag, sizeof(int)));
+    FLAGCXCHECK(flagcxSocketRecv(&p2p->sock, &recvSize, sizeof(int)));
+    if (recvTag != tag) {
+      WARN("P2P recv: tag mismatch expected %d got %d", tag, recvTag);
+      return flagcxInternalError;
+    }
+    if (recvSize > size) {
+      WARN("P2P recv: message truncated %d > buffer %d", recvSize, size);
+      return flagcxInternalError;
+    }
+    FLAGCXCHECK(flagcxSocketRecv(&p2p->sock, data, recvSize));
+    return flagcxSuccess;
+  }
+
+  // Coll mode: accept from listen socket
+  return bootstrapCollRecvInternal(state, peer, tag, data, size);
+}
+
+flagcxResult_t bootstrapExchange(struct flagcxBootstrapState *state, int peer,
+                                 int tag, const void *sendData, int sendSize,
+                                 void *recvData, int recvSize) {
+  if (state == NULL)
+    return flagcxInvalidArgument;
+
+  if (state->mode == FLAGCX_BOOTSTRAP_P2P) {
+    // P2P mode: send then recv (single peer, no deadlock risk)
+    FLAGCXCHECK(bootstrapSend(state, peer, tag, (void *)sendData, sendSize));
+    FLAGCXCHECK(bootstrapRecv(state, peer, tag, recvData, recvSize));
+    return flagcxSuccess;
+  }
+
+  // Coll mode: deadlock-free ordering by rank
+  struct bootstrapCollState *coll = unwrapCollState(state);
+  if (coll == NULL)
+    return flagcxInvalidArgument;
+  int myRank = coll->rank;
+
+  if (myRank < peer) {
+    FLAGCXCHECK(bootstrapSend(state, peer, tag, (void *)sendData, sendSize));
+    FLAGCXCHECK(bootstrapRecv(state, peer, tag, recvData, recvSize));
+  } else {
+    FLAGCXCHECK(bootstrapRecv(state, peer, tag, recvData, recvSize));
+    FLAGCXCHECK(bootstrapSend(state, peer, tag, (void *)sendData, sendSize));
+  }
+  return flagcxSuccess;
+}
+
+flagcxResult_t bootstrapClose(struct flagcxBootstrapState *state) {
+  if (state == NULL)
+    return flagcxSuccess;
+
+  if (state->mode == FLAGCX_BOOTSTRAP_P2P) {
+    struct bootstrapP2pState *p2p = state->p2p;
+    if (p2p != NULL) {
+      flagcxSocketClose(&p2p->sock);
+      free(p2p);
+    }
+    free(state);
+    return flagcxSuccess;
+  }
+
+  // Coll mode
+  struct bootstrapCollState *coll = state->coll;
+  if (coll == NULL) {
+    free(state);
+    return flagcxSuccess;
+  }
+  if (coll->unexpectedConnections != NULL) {
+    unexpectedFree(coll);
+    if (__atomic_load_n(coll->abortFlag, __ATOMIC_RELAXED) == 0) {
+      WARN("Unexpected connections are not empty");
+      free(state);
+      return flagcxInternalError;
+    }
+  }
+
+  FLAGCXCHECK(flagcxSocketClose(&coll->listenSock));
+  FLAGCXCHECK(flagcxSocketClose(&coll->ringSendSocket));
+  FLAGCXCHECK(flagcxSocketClose(&coll->ringRecvSocket));
+
+  free(coll->peerCommAddresses);
+  free(coll->properties);
+  free(coll);
+  free(state);
+  return flagcxSuccess;
+}
+
+flagcxResult_t bootstrapCollAbort(struct flagcxBootstrapState *state) {
+  if (state == NULL)
+    return flagcxSuccess;
+  struct bootstrapCollState *coll = state->coll;
+  if (coll == NULL) {
+    free(state);
+    return flagcxSuccess;
+  }
+  FLAGCXCHECK(flagcxSocketClose(&coll->listenSock));
+  FLAGCXCHECK(flagcxSocketClose(&coll->ringSendSocket));
+  FLAGCXCHECK(flagcxSocketClose(&coll->ringRecvSocket));
+  free(coll->peerCommAddresses);
+  free(coll->peerProxyAddresses);
+  free(coll->properties);
+  free(coll);
+  free(state);
+  return flagcxSuccess;
+}
+
+// ============================================================================
+// Collective Mode: Collective Operations
+// ============================================================================
+
+static flagcxResult_t bootstrapRingAllGather(struct flagcxSocket *prevSocket,
+                                             struct flagcxSocket *nextSocket,
+                                             int rank, int nranks, char *data,
+                                             int size) {
   for (int i = 0; i < nranks - 1; i++) {
     size_t rslice = (rank - i - 1 + nranks) % nranks;
     size_t sslice = (rank - i + nranks) % nranks;
-
-    // Send slice to the right, recv slice from the left
     FLAGCXCHECK(bootstrapNetSendRecv(nextSocket, data + sslice * size, size,
                                      prevSocket, data + rslice * size, size));
   }
   return flagcxSuccess;
 }
 
-// Another Version of RingAllGather
-// The data bytes gather from multiple ranks are uneven.
-flagcxResult_t bootstrapRingAllGatherV2(struct flagcxSocket *prevSocket,
-                                        struct flagcxSocket *nextSocket,
-                                        int rank, int nranks, char *data,
-                                        size_t *offset, size_t *length) {
-  /* Simple ring based AllGather
-   * At each step i receive data from (rank-i-1) from prev
-   * and send previous step's data from (rank-i) to next
-   */
-  uint64_t timers[TIMERS_COLL_COUNT] = {0};
-  timers[TIMER_COLL_TOTAL] = clockNano();
-
-  for (int i = 0; i < nranks - 1; i++) {
-    size_t rslice = (rank - i - 1 + nranks) % nranks;
-    size_t sslice = (rank - i + nranks) % nranks;
-
-    // Send slice to the right, recv slice from the left
-    FLAGCXCHECK(bootstrapNetSendRecv(
-        nextSocket, (void *)(data + offset[sslice]), length[sslice], prevSocket,
-        (void *)(data + offset[rslice]), length[rslice]));
-  }
-  timers[TIMER_COLL_TOTAL] = clockNano() - timers[TIMER_COLL_TOTAL];
-  INFO(FLAGCX_COLL, "COLL timings - %s: rank %d nranks %d total %.2fms.",
-       "BootstrapRingAllGatherV2", rank, nranks,
-       timers[TIMER_COLL_TOTAL] / 1e6);
-  return flagcxSuccess;
-}
-flagcxResult_t bootstrapAllGather(void *commState, void *allData, int size) {
-  struct bootstrapState *state = (struct bootstrapState *)commState;
-  int rank = state->rank;
-  int nranks = state->nranks;
-
-  TRACE(FLAGCX_INIT, "rank %d nranks %d size %d", rank, nranks, size);
-
-  FLAGCXCHECK(bootstrapRingAllGather(&state->ringRecvSocket,
-                                     &state->ringSendSocket, rank, nranks,
+flagcxResult_t bootstrapCollAllGather(struct flagcxBootstrapState *state,
+                                      void *allData, int size) {
+  struct bootstrapCollState *coll = unwrapCollState(state);
+  if (coll == NULL)
+    return flagcxInvalidArgument;
+  int rank = coll->rank;
+  int nranks = coll->nranks;
+  FLAGCXCHECK(bootstrapRingAllGather(&coll->ringRecvSocket,
+                                     &coll->ringSendSocket, rank, nranks,
                                      (char *)allData, size));
-
-  TRACE(FLAGCX_INIT, "rank %d nranks %d size %d - DONE", rank, nranks, size);
   return flagcxSuccess;
 }
 
-flagcxResult_t AllGatherBootstrap(void *commState, const void *sendbuff,
-                                  void *recvbuff, size_t sendcount,
-                                  flagcxDataType_t datatype) {
-  struct bootstrapState *state = (struct bootstrapState *)commState;
-  int rank = state->rank;
-  // if not in-place
-  if (sendbuff !=
-      (void *)((char *)recvbuff +
-               rank * getFlagcxDataTypeSize(datatype) * sendcount)) {
-    memcpy((void *)((char *)recvbuff +
-                    rank * getFlagcxDataTypeSize(datatype) * sendcount),
-           sendbuff, getFlagcxDataTypeSize(datatype) * sendcount);
+flagcxResult_t bootstrapCollIntraNodeBarrier(struct flagcxBootstrapState *state,
+                                             int *ranks, int rank, int nranks,
+                                             int tag) {
+  if (nranks == 1)
+    return flagcxSuccess;
+  TRACE(FLAGCX_INIT, "rank %d nranks %d tag %x - ENTER", rank, nranks, tag);
+
+  int data[1];
+  for (int mask = 1; mask < nranks; mask <<= 1) {
+    int src = (rank - mask + nranks) % nranks;
+    int dst = (rank + mask) % nranks;
+    FLAGCXCHECK(bootstrapSend(state, ranks ? ranks[dst] : dst, tag, data,
+                              sizeof(data)));
+    FLAGCXCHECK(bootstrapRecv(state, ranks ? ranks[src] : src, tag, data,
+                              sizeof(data)));
   }
-  return bootstrapAllGather(commState, recvbuff,
-                            getFlagcxDataTypeSize(datatype) * sendcount);
+
+  TRACE(FLAGCX_INIT, "rank %d nranks %d tag %x - DONE", rank, nranks, tag);
+  return flagcxSuccess;
 }
-/*
- * Reduce-Scatter
- *
- * Reduces data in sendbuff using op operation and leaves reduced result
- * scattered over the devices so that recvbuff on rank i will contain the i-th
- * block of the result.
- *
- * Block size among all ranks are not necessary equal.
- * The i-th block begins at offset[i] and has the length of length[i].
- * The recvbuff of rank i should has the length of at least length[i].
- *
- * In-place operations will happen if recvbuff == sendbuff + offset[rank].
- */
-flagcxResult_t bootstrapRingReduceScatter(
+
+flagcxResult_t bootstrapCollBarrier(struct flagcxBootstrapState *state,
+                                    int rank, int nranks, int tag) {
+  return bootstrapCollIntraNodeBarrier(state, NULL, rank, nranks, tag);
+}
+
+flagcxResult_t
+bootstrapCollIntraNodeBroadcast(struct flagcxBootstrapState *state, int *ranks,
+                                int rank, int nranks, int root, void *bcastData,
+                                int size) {
+  if (nranks == 1)
+    return flagcxSuccess;
+  TRACE(FLAGCX_INIT, "rank %d nranks %d root %d size %d - ENTER", rank, nranks,
+        root, size);
+
+  if (rank == root) {
+    for (int i = 0; i < nranks; i++) {
+      if (i != root)
+        FLAGCXCHECK(bootstrapSend(state, ranks ? ranks[i] : i,
+                                  /*tag=*/ranks ? ranks[i] : i, bcastData,
+                                  size));
+    }
+  } else {
+    FLAGCXCHECK(bootstrapRecv(state, ranks ? ranks[root] : root,
+                              /*tag=*/ranks ? ranks[rank] : rank, bcastData,
+                              size));
+  }
+
+  TRACE(FLAGCX_INIT, "rank %d nranks %d root %d size %d - DONE", rank, nranks,
+        root, size);
+  return flagcxSuccess;
+}
+
+flagcxResult_t bootstrapCollBroadcast(struct flagcxBootstrapState *state,
+                                      int rank, int nranks, int root,
+                                      void *bcastData, int size) {
+  return bootstrapCollIntraNodeBroadcast(state, NULL, rank, nranks, root,
+                                         bcastData, size);
+}
+
+// ============================================================================
+// Typed Collective Operations (Reduce, AllReduce, etc.)
+// ============================================================================
+
+static flagcxResult_t bootstrapRingReduceScatter(
     struct flagcxSocket *prevSocket, struct flagcxSocket *nextSocket, int rank,
     int nranks, const char *sendbuff, char *recvbuff, size_t *offset,
     size_t *length, flagcxDataType_t datatype, flagcxRedOp_t op) {
   uint64_t timers[TIMERS_COLL_COUNT] = {0};
   timers[TIMER_COLL_TOTAL] = clockNano();
 
-  // Allocate two temporary buffer with size length[0] to ensure that it can
-  // fill any chunk size.
   timers[TIMER_COLL_ALLOC] = clockNano();
-  // found the largest chunk
   size_t subSize = 0;
   for (int i = 0; i < nranks; ++i) {
     subSize = std::max(length[i], subSize);
@@ -594,11 +724,7 @@ flagcxResult_t bootstrapRingReduceScatter(
 
   uint64_t start = 0;
   uint64_t end = 0;
-  // for iteration 0 -> n-1
   for (int iter = 0; iter < nranks - 1; ++iter) {
-    // for each iteration ${iter}
-    // 1. rank ${rank} should send data of chunk $(send_chunk_no) to next rank
-    // 2. rank ${rank} should recv data of chunk $(recv_chunk_no) from prev rank
     int send_chunk_no = (rank + 2 * nranks - iter - 1) % nranks;
     int recv_chunk_no = (rank + 2 * nranks - iter - 2) % nranks;
     bool needSend = length[send_chunk_no] != 0;
@@ -606,19 +732,16 @@ flagcxResult_t bootstrapRingReduceScatter(
 
     INFO(FLAGCX_COLL,
          "rank %d nranks %d; iter=%d; send_chunk_no=%d; send_chunk_size=%lu; "
-         "needSend=%d; "
-         "recv_chunk_no=%d; recv_chunk_size=%lu; needRecv=%d",
+         "needSend=%d; recv_chunk_no=%d; recv_chunk_size=%lu; needRecv=%d",
          rank, nranks, iter, send_chunk_no, length[send_chunk_no], needSend,
          recv_chunk_no, length[recv_chunk_no], needRecv);
     if (!needSend && !needRecv) {
       continue;
     }
 
-    // step 1: prepare send data if needed
     if (needSend) {
       start = clockNano();
       if (iter == 0) {
-        // initial iteration
         memcpy(data_for_send, sendbuff + offset[send_chunk_no],
                length[send_chunk_no]);
       } else {
@@ -628,7 +751,6 @@ flagcxResult_t bootstrapRingReduceScatter(
       timers[TIMER_COLL_MEM] += end - start;
     }
 
-    // step 2: exchange data using Send/Recv
     start = clockNano();
     if (needSend && needRecv) {
       FLAGCXCHECK(bootstrapNetSendRecv(
@@ -644,9 +766,6 @@ flagcxResult_t bootstrapRingReduceScatter(
     end = clockNano();
     timers[TIMER_COLL_COMM] += end - start;
 
-    // step3 : local reduction for data_for_send & chunk ${recv_chunk_no} if
-    // recv something
-    //         save result in data_for_recv
     if (!needRecv) {
       continue;
     }
@@ -678,7 +797,6 @@ flagcxResult_t bootstrapRingReduceScatter(
     timers[TIMER_COLL_CALC] += end - start;
   }
 
-  // copy the final reduction to recvbuff
   memcpy(recvbuff, data_for_recv, length[rank]);
   free(data_for_send);
   free(data_for_recv);
@@ -694,44 +812,25 @@ flagcxResult_t bootstrapRingReduceScatter(
   return flagcxSuccess;
 }
 
-const size_t MIN_CHUNK_SIZE = 1024 * 1024 * 4; // 4MB
-
-size_t roundUp(size_t value, size_t multiple) {
-  size_t remainder = value % multiple;
-  if (remainder == 0) {
-    return value;
-  }
-  return value + multiple - remainder;
-}
-
-flagcxResult_t bootstrapRingAllReduce(struct flagcxSocket *prevSocket,
-                                      struct flagcxSocket *nextSocket, int rank,
-                                      int nranks, const char *sendbuff,
-                                      char *recvbuff, size_t count,
-                                      flagcxDataType_t datatype,
-                                      flagcxRedOp_t op) {
-
-  // The ring algorithm works as follows.
-  //
-  // The given input is split into a number of chunks equal to the
-  // number of processes. Once the reducescatter has finished, every
-  // process hosts one chunk of reduced output, in sequential order
-  // (rank 0 has chunk 0, rank 1 has chunk 1, etc.). As the input may
-  // not be divisible by the number of processes, the chunk on the
-  // final ranks may have partial output or may be empty.
-  //
-
+static flagcxResult_t
+bootstrapRingAllReduce(struct flagcxSocket *prevSocket,
+                       struct flagcxSocket *nextSocket, int rank, int nranks,
+                       const char *sendbuff, char *recvbuff, size_t count,
+                       flagcxDataType_t datatype, flagcxRedOp_t op) {
   size_t size = count * getFlagcxDataTypeSize(datatype);
-  size_t ChunkBytes = std::max((size + nranks - 1) / nranks, MIN_CHUNK_SIZE);
-  // Ensure that min chunk size is a multiple of the element size.
-  ChunkBytes = roundUp(ChunkBytes, getFlagcxDataTypeSize(datatype));
-  INFO(FLAGCX_COLL, "rank %d nranks %d; size=%lu; typesize=%lu; ChunkBytes=%lu",
+  // ChunkBytes = ceil(size / nranks)
+  size_t ChunkBytes = (size + nranks - 1) / nranks;
+  // Round up to type size
+  ChunkBytes = (ChunkBytes + getFlagcxDataTypeSize(datatype) - 1) /
+               getFlagcxDataTypeSize(datatype) *
+               getFlagcxDataTypeSize(datatype);
+
+  INFO(FLAGCX_COLL, "rank %d nranks %d; size=%lu; typeSize=%lu; ChunkBytes=%lu",
        rank, nranks, size, getFlagcxDataTypeSize(datatype), ChunkBytes);
 
-  // step 1: split the data and prepare offset and length array
   std::vector<size_t> offset(nranks, 0);
   std::vector<size_t> length(nranks, 0);
-  for (size_t i = 0; i < nranks; ++i) {
+  for (size_t i = 0; i < (size_t)nranks; ++i) {
     if (ChunkBytes * i >= size) {
       offset[i] = size;
       length[i] = 0;
@@ -742,44 +841,37 @@ flagcxResult_t bootstrapRingAllReduce(struct flagcxSocket *prevSocket,
         ChunkBytes * (i + 1) >= size ? size - ChunkBytes * i : ChunkBytes;
   }
 
-  // step 2: reduce scatter
-  FLAGCXCHECK(bootstrapRingReduceScatter(
-      prevSocket, nextSocket, rank, nranks, sendbuff, recvbuff + offset[rank],
-      offset.data(), length.data(), datatype, op));
+  // ReduceScatter
+  FLAGCXCHECK(bootstrapRingReduceScatter(prevSocket, nextSocket, rank, nranks,
+                                         sendbuff, recvbuff, offset.data(),
+                                         length.data(), datatype, op));
 
-  // step 3: all gather
-  FLAGCXCHECK(bootstrapRingAllGatherV2(prevSocket, nextSocket, rank, nranks,
-                                       recvbuff, offset.data(), length.data()));
+  // AllGather the results
+  // Copy my chunk into correct position
+  memcpy(recvbuff + offset[rank], recvbuff, length[rank]);
+  FLAGCXCHECK(bootstrapRingAllGather(prevSocket, nextSocket, rank, nranks,
+                                     recvbuff, ChunkBytes));
   return flagcxSuccess;
 }
 
-flagcxResult_t
-bootstrapRingReduce(void *commState, struct flagcxSocket *prevSocket,
+static flagcxResult_t
+bootstrapRingReduce(struct flagcxBootstrapState *commState,
+                    struct flagcxSocket *prevSocket,
                     struct flagcxSocket *nextSocket, int rank, int nranks,
                     const char *sendbuff, char *recvbuff, size_t count,
                     flagcxDataType_t datatype, flagcxRedOp_t op, int root) {
-
-  // The ring algorithm works as follows.
-  //
-  // The given input is split into a number of chunks equal to the
-  // number of processes. Once the reducescatter has finished, every
-  // process hosts one chunk of reduced output, in sequential order
-  // (rank 0 has chunk 0, rank 1 has chunk 1, etc.). As the input may
-  // not be divisible by the number of processes, the chunk on the
-  // final ranks may have partial output or may be empty.
-  //
-
   size_t size = count * getFlagcxDataTypeSize(datatype);
-  size_t ChunkBytes = std::max((size + nranks - 1) / nranks, MIN_CHUNK_SIZE);
-  // Ensure that min chunk size is a multiple of the element size.
-  ChunkBytes = roundUp(ChunkBytes, getFlagcxDataTypeSize(datatype));
-  INFO(FLAGCX_COLL, "rank %d nranks %d; size=%lu; typesize=%lu; ChunkBytes=%lu",
+  size_t ChunkBytes = (size + nranks - 1) / nranks;
+  ChunkBytes = (ChunkBytes + getFlagcxDataTypeSize(datatype) - 1) /
+               getFlagcxDataTypeSize(datatype) *
+               getFlagcxDataTypeSize(datatype);
+
+  INFO(FLAGCX_COLL, "rank %d nranks %d; size=%lu; typeSize=%lu; ChunkBytes=%lu",
        rank, nranks, size, getFlagcxDataTypeSize(datatype), ChunkBytes);
 
-  // step 1: split the data and prepare offset and length array
   std::vector<size_t> offset(nranks, 0);
   std::vector<size_t> length(nranks, 0);
-  for (size_t i = 0; i < nranks; ++i) {
+  for (size_t i = 0; i < (size_t)nranks; ++i) {
     if (ChunkBytes * i >= size) {
       offset[i] = size;
       length[i] = 0;
@@ -790,12 +882,12 @@ bootstrapRingReduce(void *commState, struct flagcxSocket *prevSocket,
         ChunkBytes * (i + 1) >= size ? size - ChunkBytes * i : ChunkBytes;
   }
 
-  // step 2: reduce scatter
-  FLAGCXCHECK(bootstrapRingReduceScatter(
-      prevSocket, nextSocket, rank, nranks, sendbuff, recvbuff + offset[rank],
-      offset.data(), length.data(), datatype, op));
+  // reduce scatter
+  FLAGCXCHECK(bootstrapRingReduceScatter(prevSocket, nextSocket, rank, nranks,
+                                         sendbuff, recvbuff, offset.data(),
+                                         length.data(), datatype, op));
 
-  // step 3: gather
+  // gather to root
   const int bootstrapTag = -9993;
   if (rank == root) {
     for (int i = 0; i < nranks; i++) {
@@ -812,12 +904,15 @@ bootstrapRingReduce(void *commState, struct flagcxSocket *prevSocket,
   return flagcxSuccess;
 }
 
-flagcxResult_t AllReduceBootstrap(void *commState, const void *sendbuff,
-                                  void *recvbuff, size_t count,
-                                  flagcxDataType_t datatype, flagcxRedOp_t op) {
-  struct bootstrapState *state = (struct bootstrapState *)commState;
-  int rank = state->rank;
-  int nranks = state->nranks;
+flagcxResult_t AllReduceBootstrap(struct flagcxBootstrapState *state,
+                                  const void *sendbuff, void *recvbuff,
+                                  size_t count, flagcxDataType_t datatype,
+                                  flagcxRedOp_t op) {
+  struct bootstrapCollState *coll = unwrapCollState(state);
+  if (coll == NULL)
+    return flagcxInvalidArgument;
+  int rank = coll->rank;
+  int nranks = coll->nranks;
   if (nranks == 1) {
     if (sendbuff != recvbuff) {
       memcpy(recvbuff, sendbuff, count * getFlagcxDataTypeSize(datatype));
@@ -825,20 +920,20 @@ flagcxResult_t AllReduceBootstrap(void *commState, const void *sendbuff,
     return flagcxSuccess;
   }
   FLAGCXCHECK(bootstrapRingAllReduce(
-      &state->ringRecvSocket, &state->ringSendSocket, rank, nranks,
+      &coll->ringRecvSocket, &coll->ringSendSocket, rank, nranks,
       (char *)sendbuff, (char *)recvbuff, count, datatype, op));
-
   return flagcxSuccess;
 }
 
-flagcxResult_t ReduceBootstrap(void *commState, const void *sendbuff,
-                               void *recvbuff, size_t count,
-                               flagcxDataType_t datatype, flagcxRedOp_t op,
-                               int root) {
-  struct bootstrapState *state = (struct bootstrapState *)commState;
-  int rank = state->rank;
-  int nranks = state->nranks;
-
+flagcxResult_t ReduceBootstrap(struct flagcxBootstrapState *state,
+                               const void *sendbuff, void *recvbuff,
+                               size_t count, flagcxDataType_t datatype,
+                               flagcxRedOp_t op, int root) {
+  struct bootstrapCollState *coll = unwrapCollState(state);
+  if (coll == NULL)
+    return flagcxInvalidArgument;
+  int rank = coll->rank;
+  int nranks = coll->nranks;
   if (nranks == 1) {
     if (sendbuff != recvbuff) {
       memcpy(recvbuff, sendbuff, count * getFlagcxDataTypeSize(datatype));
@@ -846,130 +941,96 @@ flagcxResult_t ReduceBootstrap(void *commState, const void *sendbuff,
     return flagcxSuccess;
   }
   FLAGCXCHECK(bootstrapRingReduce(
-      commState, &state->ringRecvSocket, &state->ringSendSocket, rank, nranks,
+      state, &coll->ringRecvSocket, &coll->ringSendSocket, rank, nranks,
       (char *)sendbuff, (char *)recvbuff, count, datatype, op, root));
   return flagcxSuccess;
 }
 
-flagcxResult_t ReduceScatterBootstrap(void *commState, const void *sendbuff,
-                                      void *recvbuff, size_t recvcount,
+flagcxResult_t ReduceScatterBootstrap(struct flagcxBootstrapState *state,
+                                      const void *sendbuff, void *recvbuff,
+                                      size_t recvcount,
                                       flagcxDataType_t datatype,
                                       flagcxRedOp_t op) {
-  struct bootstrapState *state = (struct bootstrapState *)commState;
-  int rank = state->rank;
-  int nranks = state->nranks;
+  struct bootstrapCollState *coll = unwrapCollState(state);
+  if (coll == NULL)
+    return flagcxInvalidArgument;
+  int rank = coll->rank;
+  int nranks = coll->nranks;
   if (nranks == 1) {
     if (sendbuff != recvbuff) {
       memcpy(recvbuff, sendbuff, recvcount * getFlagcxDataTypeSize(datatype));
     }
     return flagcxSuccess;
   }
-  // prepare offset, length vector
   std::vector<size_t> offset(nranks, 0);
   std::vector<size_t> length(nranks, 0);
-  for (size_t i = 0; i < nranks; ++i) {
+  for (size_t i = 0; i < (size_t)nranks; ++i) {
     offset[i] = i * recvcount * getFlagcxDataTypeSize(datatype);
     length[i] = recvcount * getFlagcxDataTypeSize(datatype);
   }
   FLAGCXCHECK(bootstrapRingReduceScatter(
-      &state->ringRecvSocket, &state->ringSendSocket, rank, nranks,
+      &coll->ringRecvSocket, &coll->ringSendSocket, rank, nranks,
       (char *)sendbuff, (char *)recvbuff, offset.data(), length.data(),
       datatype, op));
   return flagcxSuccess;
 }
 
-flagcxResult_t AlltoAllBootstrap(void *commState, const void *sendbuff,
-                                 void *recvbuff, size_t count,
-                                 flagcxDataType_t datatype) {
-  struct bootstrapState *state = (struct bootstrapState *)commState;
-  int rank = state->rank;
-  int nranks = state->nranks;
+flagcxResult_t AlltoAllBootstrap(struct flagcxBootstrapState *state,
+                                 const void *sendbuff, void *recvbuff,
+                                 size_t count, flagcxDataType_t datatype) {
+  struct bootstrapCollState *coll = unwrapCollState(state);
+  if (coll == NULL)
+    return flagcxInvalidArgument;
+  int rank = coll->rank;
+  int nranks = coll->nranks;
   size_t size = count * getFlagcxDataTypeSize(datatype);
 
   bool inPlace = (sendbuff == recvbuff);
   char *tmpBuff = nullptr;
   if (inPlace) {
     FLAGCXCHECK(flagcxCalloc(&tmpBuff, size));
+    memcpy(tmpBuff, (char *)sendbuff + rank * size, size);
   }
 
-  for (int i = 0; i < nranks; ++i) {
+  const int bootstrapTag = -9995;
+  for (int i = 0; i < nranks; i++) {
     if (i == rank) {
-      if (!inPlace) {
-        memcpy((void *)((char *)recvbuff + size * i),
-               (void *)((char *)sendbuff + size * i), size);
+      if (inPlace) {
+        memcpy((char *)recvbuff + rank * size, tmpBuff, size);
+      } else {
+        memcpy((char *)recvbuff + rank * size, (char *)sendbuff + rank * size,
+               size);
       }
+      continue;
     }
-    const int bootstrapTag = -9991;
     if (rank > i) {
-      FLAGCXCHECK(bootstrapSend(commState, i, bootstrapTag,
-                                (void *)((char *)sendbuff + size * i), size));
-      if (inPlace) {
-        FLAGCXCHECK(
-            bootstrapRecv(commState, i, bootstrapTag, (void *)tmpBuff, size));
-        memcpy((void *)((char *)recvbuff + size * i), (void *)tmpBuff, size);
-      } else {
-        FLAGCXCHECK(bootstrapRecv(commState, i, bootstrapTag,
-                                  (void *)((char *)recvbuff + size * i), size));
-      }
-    } else if (rank < i) {
-      if (inPlace) {
-        FLAGCXCHECK(
-            bootstrapRecv(commState, i, bootstrapTag, (void *)tmpBuff, size));
-      } else {
-        FLAGCXCHECK(bootstrapRecv(commState, i, bootstrapTag,
-                                  (void *)((char *)recvbuff + size * i), size));
-      }
-      FLAGCXCHECK(bootstrapSend(commState, i, bootstrapTag,
-                                (void *)((char *)sendbuff + size * i), size));
-      if (inPlace) {
-        memcpy((void *)((char *)recvbuff + size * i), (void *)tmpBuff, size);
-      }
+      FLAGCXCHECK(bootstrapSend(state, i, bootstrapTag,
+                                (char *)sendbuff + i * size, size));
+      FLAGCXCHECK(bootstrapRecv(state, i, bootstrapTag,
+                                (char *)recvbuff + i * size, size));
+    } else {
+      FLAGCXCHECK(bootstrapRecv(state, i, bootstrapTag,
+                                (char *)recvbuff + i * size, size));
+      FLAGCXCHECK(bootstrapSend(state, i, bootstrapTag,
+                                (char *)sendbuff + i * size, size));
     }
   }
-  free(tmpBuff);
+
+  if (tmpBuff)
+    free(tmpBuff);
   return flagcxSuccess;
 }
 
-flagcxResult_t BroadcastBootstrap(void *commState, const void *sendbuff,
-                                  void *recvbuff, size_t sendcount,
-                                  flagcxDataType_t datatype, int root) {
-  struct bootstrapState *state = (struct bootstrapState *)commState;
-  int rank = state->rank;
-  int nranks = state->nranks;
-  const int bootstrapTag = -9992;
-  if (nranks == 1) {
-    if (sendbuff != recvbuff) {
-      memcpy(recvbuff, sendbuff, getFlagcxDataTypeSize(datatype) * sendcount);
-    }
-    return flagcxSuccess;
-  }
-  if (rank == root) {
-    if (sendbuff != recvbuff) {
-      memcpy(recvbuff, sendbuff, getFlagcxDataTypeSize(datatype) * sendcount);
-    }
-    // root sends data to all other ranks
-    for (int i = 0; i < nranks; ++i) {
-      if (i != root) {
-        FLAGCXCHECK(bootstrapSend(commState, i, bootstrapTag,
-                                  (void *)(sendbuff),
-                                  sendcount * getFlagcxDataTypeSize(datatype)));
-      }
-    }
-  } else {
-    // all other ranks receive data from root
-    FLAGCXCHECK(bootstrapRecv(commState, root, bootstrapTag, recvbuff,
-                              sendcount * getFlagcxDataTypeSize(datatype)));
-  }
-  return flagcxSuccess;
-}
-
-flagcxResult_t ScatterBootstrap(void *commState, const void *sendbuff,
-                                void *recvbuff, size_t count,
-                                flagcxDataType_t datatype, int root) {
-  struct bootstrapState *state = (struct bootstrapState *)commState;
-  int rank = state->rank;
-  int nranks = state->nranks;
-  const int bootstrapTag = -9993;
+flagcxResult_t BroadcastBootstrap(struct flagcxBootstrapState *state,
+                                  const void *sendbuff, void *recvbuff,
+                                  size_t count, flagcxDataType_t datatype,
+                                  int root) {
+  struct bootstrapCollState *coll = unwrapCollState(state);
+  if (coll == NULL)
+    return flagcxInvalidArgument;
+  int rank = coll->rank;
+  int nranks = coll->nranks;
+  const int bootstrapTag = -9994;
   if (nranks == 1) {
     if (sendbuff != recvbuff) {
       memcpy(recvbuff, sendbuff, getFlagcxDataTypeSize(datatype) * count);
@@ -978,35 +1039,35 @@ flagcxResult_t ScatterBootstrap(void *commState, const void *sendbuff,
   }
 
   if (rank == root) {
-    // For root process, only copy its own portion of data
     size_t rootOffset = root * count * getFlagcxDataTypeSize(datatype);
     if ((char *)sendbuff + rootOffset != recvbuff) {
       memcpy(recvbuff, (const char *)sendbuff + rootOffset,
              getFlagcxDataTypeSize(datatype) * count);
     }
-    // root sends data to all other ranks
     for (int i = 0; i < nranks; ++i) {
       if (i != root) {
         size_t offset = i * count * getFlagcxDataTypeSize(datatype);
-        FLAGCXCHECK(bootstrapSend(commState, i, bootstrapTag,
+        FLAGCXCHECK(bootstrapSend(state, i, bootstrapTag,
                                   (char *)sendbuff + offset,
                                   count * getFlagcxDataTypeSize(datatype)));
       }
     }
   } else {
-    // all other ranks receive data from root
-    FLAGCXCHECK(bootstrapRecv(commState, root, bootstrapTag, recvbuff,
+    FLAGCXCHECK(bootstrapRecv(state, root, bootstrapTag, recvbuff,
                               count * getFlagcxDataTypeSize(datatype)));
   }
   return flagcxSuccess;
 }
 
-flagcxResult_t GatherBootstrap(void *commState, const void *sendbuff,
-                               void *recvbuff, size_t count,
-                               flagcxDataType_t datatype, int root) {
-  struct bootstrapState *state = (struct bootstrapState *)commState;
-  int rank = state->rank;
-  int nranks = state->nranks;
+flagcxResult_t GatherBootstrap(struct flagcxBootstrapState *state,
+                               const void *sendbuff, void *recvbuff,
+                               size_t count, flagcxDataType_t datatype,
+                               int root) {
+  struct bootstrapCollState *coll = unwrapCollState(state);
+  if (coll == NULL)
+    return flagcxInvalidArgument;
+  int rank = coll->rank;
+  int nranks = coll->nranks;
   const int bootstrapTag = -9994;
 
   if (nranks == 1) {
@@ -1017,136 +1078,36 @@ flagcxResult_t GatherBootstrap(void *commState, const void *sendbuff,
   }
 
   if (rank == root) {
-    // Handle root's own data
     size_t rootOffset = root * count * getFlagcxDataTypeSize(datatype);
     if (sendbuff != (char *)recvbuff + rootOffset) {
       memcpy((char *)recvbuff + rootOffset, sendbuff,
              getFlagcxDataTypeSize(datatype) * count);
     }
-
-    // Receive data from other ranks
     for (int i = 0; i < nranks; ++i) {
       if (i != root) {
         int offset = i * count * getFlagcxDataTypeSize(datatype);
-        FLAGCXCHECK(bootstrapRecv(commState, i, bootstrapTag,
+        FLAGCXCHECK(bootstrapRecv(state, i, bootstrapTag,
                                   (char *)recvbuff + offset,
                                   count * getFlagcxDataTypeSize(datatype)));
       }
     }
   } else {
-    // Non-root ranks send data to root
-    FLAGCXCHECK(bootstrapSend(commState, root, bootstrapTag, (void *)sendbuff,
+    FLAGCXCHECK(bootstrapSend(state, root, bootstrapTag, (void *)sendbuff,
                               count * getFlagcxDataTypeSize(datatype)));
   }
   return flagcxSuccess;
 }
 
-flagcxResult_t bootstrapIntraNodeBarrier(void *commState, int *ranks, int rank,
-                                         int nranks, int tag) {
-  if (nranks == 1)
-    return flagcxSuccess;
-  TRACE(FLAGCX_INIT, "rank %d nranks %d tag %x - ENTER", rank, nranks, tag);
-
-  /* Simple [intra] process barrier
-   *
-   * Based on the dissemination algorithm by Debra Hensgen, Raphael Finkel, and
-   * Udi Manbet, "Two Algorithms for Barrier Synchronization," International
-   * Journal of Parallel Programming, 17(1):1-17, 1988"
-   */
-  int data[1];
-  for (int mask = 1; mask < nranks; mask <<= 1) {
-    int src = (rank - mask + nranks) % nranks;
-    int dst = (rank + mask) % nranks;
-    FLAGCXCHECK(bootstrapSend(commState, ranks ? ranks[dst] : dst, tag, data,
-                              sizeof(data)));
-    FLAGCXCHECK(bootstrapRecv(commState, ranks ? ranks[src] : src, tag, data,
-                              sizeof(data)));
-  }
-
-  TRACE(FLAGCX_INIT, "rank %d nranks %d tag %x - DONE", rank, nranks, tag);
-  return flagcxSuccess;
-}
-
-flagcxResult_t bootstrapBarrier(void *commState, int rank, int nranks,
-                                int tag) {
-  return bootstrapIntraNodeBarrier(commState, NULL, rank, nranks, tag);
-}
-
-// [IntraNode] in-place Broadcast
-flagcxResult_t bootstrapIntraNodeBroadcast(void *commState, int *ranks,
-                                           int rank, int nranks, int root,
-                                           void *bcastData, int size) {
-  if (nranks == 1)
-    return flagcxSuccess;
-  TRACE(FLAGCX_INIT, "rank %d nranks %d root %d size %d - ENTER", rank, nranks,
-        root, size);
-
-  if (rank == root) {
-    for (int i = 0; i < nranks; i++) {
-      if (i != root)
-        FLAGCXCHECK(bootstrapSend(commState, ranks ? ranks[i] : i,
-                                  /*tag=*/ranks ? ranks[i] : i, bcastData,
-                                  size));
-    }
-  } else {
-    FLAGCXCHECK(bootstrapRecv(commState, ranks ? ranks[root] : root,
-                              /*tag=*/ranks ? ranks[rank] : rank, bcastData,
-                              size));
-  }
-
-  TRACE(FLAGCX_INIT, "rank %d nranks %d root %d size %d - DONE", rank, nranks,
-        root, size);
-  return flagcxSuccess;
-}
-
-flagcxResult_t bootstrapBroadcast(void *commState, int rank, int nranks,
-                                  int root, void *bcastData, int size) {
-  return bootstrapIntraNodeBroadcast(commState, NULL, rank, nranks, root,
-                                     bcastData, size);
-}
-
-flagcxResult_t bootstrapClose(void *commState) {
-  struct bootstrapState *state = (struct bootstrapState *)commState;
-  if (state->unexpectedConnections != NULL) {
-    unexpectedFree(state);
-    if (__atomic_load_n(state->abortFlag, __ATOMIC_RELAXED) == 0) {
-      WARN("Unexpected connections are not empty");
-      return flagcxInternalError;
-    }
-  }
-
-  FLAGCXCHECK(flagcxSocketClose(&state->listenSock));
-  FLAGCXCHECK(flagcxSocketClose(&state->ringSendSocket));
-  FLAGCXCHECK(flagcxSocketClose(&state->ringRecvSocket));
-
-  free(state->peerCommAddresses);
-  free(state->properties);
-  free(state);
-
-  return flagcxSuccess;
-}
-
-flagcxResult_t bootstrapAbort(void *commState) {
-  struct bootstrapState *state = (struct bootstrapState *)commState;
-  if (commState == NULL)
-    return flagcxSuccess;
-  FLAGCXCHECK(flagcxSocketClose(&state->listenSock));
-  FLAGCXCHECK(flagcxSocketClose(&state->ringSendSocket));
-  FLAGCXCHECK(flagcxSocketClose(&state->ringRecvSocket));
-  free(state->peerCommAddresses);
-  free(state->peerProxyAddresses);
-  free(state->properties);
-  free(state);
-  return flagcxSuccess;
-}
-// AlltoALlv require sendbuff and recvbuff not overlap
-flagcxResult_t AlltoAllvBootstrap(void *commState, const void *sendbuff,
-                                  size_t *sendcounts, size_t *sdispls,
-                                  void *recvbuff, size_t *recvcounts,
-                                  size_t *rdispls, flagcxDataType_t datatype) {
-  struct bootstrapState *state = (struct bootstrapState *)commState;
-  int rank = state->rank;
-  int nranks = state->nranks;
+flagcxResult_t AlltoAllvBootstrap(struct flagcxBootstrapState *state,
+                                  const void *sendbuff, size_t *sendcounts,
+                                  size_t *sdispls, void *recvbuff,
+                                  size_t *recvcounts, size_t *rdispls,
+                                  flagcxDataType_t datatype) {
+  struct bootstrapCollState *coll = unwrapCollState(state);
+  if (coll == NULL)
+    return flagcxInvalidArgument;
+  int rank = coll->rank;
+  int nranks = coll->nranks;
   size_t typeSize = getFlagcxDataTypeSize(datatype);
 
   for (int i = 0; i < nranks; ++i) {
@@ -1155,30 +1116,174 @@ flagcxResult_t AlltoAllvBootstrap(void *commState, const void *sendbuff,
              (void *)((char *)sendbuff + sdispls[i] * typeSize),
              sendcounts[i] * typeSize);
     }
-    const int bootstrapTag = -9995; // Suggest making this unique if possible
+    const int bootstrapTag = -9995;
     if (rank > i) {
-      // Send to rank i
       FLAGCXCHECK(
-          bootstrapSend(commState, i, bootstrapTag,
+          bootstrapSend(state, i, bootstrapTag,
                         (void *)((char *)sendbuff + sdispls[i] * typeSize),
                         sendcounts[i] * typeSize));
-      // Recv from rank i
       FLAGCXCHECK(
-          bootstrapRecv(commState, i, bootstrapTag,
+          bootstrapRecv(state, i, bootstrapTag,
                         (void *)((char *)recvbuff + rdispls[i] * typeSize),
                         recvcounts[i] * typeSize));
     } else if (rank < i) {
-      // Receive from rank i
       FLAGCXCHECK(
-          bootstrapRecv(commState, i, bootstrapTag,
+          bootstrapRecv(state, i, bootstrapTag,
                         (void *)((char *)recvbuff + rdispls[i] * typeSize),
                         recvcounts[i] * typeSize));
-      // Send to rank i
       FLAGCXCHECK(
-          bootstrapSend(commState, i, bootstrapTag,
+          bootstrapSend(state, i, bootstrapTag,
                         (void *)((char *)sendbuff + sdispls[i] * typeSize),
                         sendcounts[i] * typeSize));
     }
   }
+  return flagcxSuccess;
+}
+
+flagcxResult_t ScatterBootstrap(struct flagcxBootstrapState *state,
+                                const void *sendbuff, void *recvbuff,
+                                size_t count, flagcxDataType_t datatype,
+                                int root) {
+  struct bootstrapCollState *coll = unwrapCollState(state);
+  if (coll == NULL)
+    return flagcxInvalidArgument;
+  int rank = coll->rank;
+  int nranks = coll->nranks;
+  size_t size = count * getFlagcxDataTypeSize(datatype);
+
+  if (rank == root) {
+    // Root sends to all non-root ranks
+    memcpy((void *)recvbuff, (const char *)sendbuff + rank * size, size);
+    for (int i = 0; i < nranks; i++) {
+      if (i != root) {
+        FLAGCXCHECK(bootstrapSend(state, i, -9994,
+                                  (void *)((const char *)sendbuff + i * size),
+                                  size));
+      }
+    }
+  } else {
+    // Non-root receives from root
+    FLAGCXCHECK(bootstrapRecv(state, root, -9994, recvbuff, size));
+  }
+  return flagcxSuccess;
+}
+
+flagcxResult_t AllGatherBootstrap(struct flagcxBootstrapState *state,
+                                  const void *sendbuff, void *recvbuff,
+                                  size_t sendcount, flagcxDataType_t datatype) {
+  struct bootstrapCollState *coll = unwrapCollState(state);
+  if (coll == NULL)
+    return flagcxInvalidArgument;
+  int rank = coll->rank;
+  size_t size = sendcount * getFlagcxDataTypeSize(datatype);
+
+  // Copy own data into the correct slot
+  memcpy((char *)recvbuff + rank * size, sendbuff, size);
+
+  // Use the existing bootstrapCollAllGather on the receive buffer
+  FLAGCXCHECK(bootstrapCollAllGather(state, recvbuff, size));
+  return flagcxSuccess;
+}
+
+// ============================================================================
+// P2P Mode: RPC-style Listen / Connect / Accept
+// ============================================================================
+
+flagcxResult_t bootstrapP2pListen(uint64_t magic, volatile uint32_t *abortFlag,
+                                  void *listenHandle,
+                                  struct flagcxBootstrapState **stateOut) {
+  // Ensure network interface is discovered
+  FLAGCXCHECK(bootstrapNetInit());
+
+  // Allocate P2P state
+  struct bootstrapP2pState *p2p;
+  FLAGCXCHECK(flagcxCalloc(&p2p, 1));
+  p2p->isListener = true;
+  p2p->magic = magic;
+  p2p->abortFlag = abortFlag;
+
+  // Bind listen socket on discovered NIC
+  FLAGCXCHECK(flagcxSocketInit(&p2p->sock, &bootstrapNetIfAddr, magic,
+                               flagcxSocketTypeBootstrap, abortFlag));
+  FLAGCXCHECK(flagcxSocketListen(&p2p->sock));
+  FLAGCXCHECK(flagcxSocketGetAddr(&p2p->sock, &p2p->localAddr));
+
+  // Fill handle for peer to use in bootstrapP2pConnect
+  struct flagcxBootstrapHandle *handle =
+      (struct flagcxBootstrapHandle *)listenHandle;
+  handle->magic = magic;
+  memcpy(&handle->addr, &p2p->localAddr, sizeof(union flagcxSocketAddress));
+
+  // Wrap in state
+  struct flagcxBootstrapState *wrapper;
+  FLAGCXCHECK(flagcxCalloc(&wrapper, 1));
+  wrapper->mode = FLAGCX_BOOTSTRAP_P2P;
+  wrapper->p2p = p2p;
+
+  *stateOut = wrapper;
+  return flagcxSuccess;
+}
+
+flagcxResult_t bootstrapP2pConnect(void *peerHandle, uint64_t magic,
+                                   volatile uint32_t *abortFlag,
+                                   struct flagcxBootstrapState **stateOut) {
+  // Ensure network interface is discovered
+  FLAGCXCHECK(bootstrapNetInit());
+
+  struct flagcxBootstrapHandle *handle =
+      (struct flagcxBootstrapHandle *)peerHandle;
+
+  // Allocate P2P state
+  struct bootstrapP2pState *p2p;
+  FLAGCXCHECK(flagcxCalloc(&p2p, 1));
+  p2p->isListener = false;
+  p2p->magic = magic;
+  p2p->abortFlag = abortFlag;
+
+  // Connect to peer's listen socket
+  FLAGCXCHECK(flagcxSocketInit(&p2p->sock, &handle->addr, magic,
+                               flagcxSocketTypeBootstrap, abortFlag));
+  FLAGCXCHECK(flagcxSocketConnect(&p2p->sock));
+
+  // Wrap in state
+  struct flagcxBootstrapState *wrapper;
+  FLAGCXCHECK(flagcxCalloc(&wrapper, 1));
+  wrapper->mode = FLAGCX_BOOTSTRAP_P2P;
+  wrapper->p2p = p2p;
+
+  *stateOut = wrapper;
+  return flagcxSuccess;
+}
+
+flagcxResult_t bootstrapP2pAccept(struct flagcxBootstrapState *listenState,
+                                  struct flagcxBootstrapState **connStateOut) {
+  if (listenState == NULL || listenState->mode != FLAGCX_BOOTSTRAP_P2P) {
+    WARN("bootstrapP2pAccept: not a P2P listen state");
+    return flagcxInvalidArgument;
+  }
+  struct bootstrapP2pState *listenP2p = listenState->p2p;
+  if (listenP2p == NULL || !listenP2p->isListener) {
+    WARN("bootstrapP2pAccept: state is not in listen mode");
+    return flagcxInvalidArgument;
+  }
+
+  // Allocate new connected P2P state
+  struct bootstrapP2pState *connP2p;
+  FLAGCXCHECK(flagcxCalloc(&connP2p, 1));
+  connP2p->isListener = false;
+  connP2p->magic = listenP2p->magic;
+  connP2p->abortFlag = listenP2p->abortFlag;
+
+  // Accept incoming connection
+  FLAGCXCHECK(flagcxSocketInit(&connP2p->sock));
+  FLAGCXCHECK(flagcxSocketAccept(&connP2p->sock, &listenP2p->sock));
+
+  // Wrap in state
+  struct flagcxBootstrapState *wrapper;
+  FLAGCXCHECK(flagcxCalloc(&wrapper, 1));
+  wrapper->mode = FLAGCX_BOOTSTRAP_P2P;
+  wrapper->p2p = connP2p;
+
+  *connStateOut = wrapper;
   return flagcxSuccess;
 }

--- a/flagcx/service/bootstrap.cc
+++ b/flagcx/service/bootstrap.cc
@@ -23,6 +23,7 @@ struct bootstrapRootArgs {
 /* Init functions */
 static char bootstrapNetIfName[MAX_IF_NAME_SIZE + 1];
 union flagcxSocketAddress bootstrapNetIfAddr;
+static flagcxNetProperties_t bootstrapNetProperties;
 static int bootstrapNetInitDone = 0;
 pthread_mutex_t bootstrapNetLock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -64,6 +65,36 @@ flagcxResult_t bootstrapNetInit() {
     pthread_mutex_unlock(&bootstrapNetLock);
   }
   return flagcxSuccess;
+}
+
+// ============================================================================
+// Accessor APIs
+// ============================================================================
+
+int bootstrapGetRank(struct bootstrapState *state) {
+  if (state == NULL || state->mode != FLAGCX_BOOTSTRAP_COLL ||
+      state->coll == NULL) {
+    return -1;
+  }
+  return state->coll->rank;
+}
+
+int bootstrapGetNranks(struct bootstrapState *state) {
+  if (state == NULL || state->mode != FLAGCX_BOOTSTRAP_COLL ||
+      state->coll == NULL) {
+    return -1;
+  }
+  return state->coll->nranks;
+}
+
+flagcxNetProperties_t *bootstrapGetNetProperties() {
+  return &bootstrapNetProperties;
+}
+
+const char *bootstrapGetNetIfName() { return bootstrapNetIfName; }
+
+union flagcxSocketAddress *bootstrapGetNetIfAddr() {
+  return &bootstrapNetIfAddr;
 }
 
 /* Socket Interface Selection type */
@@ -331,10 +362,6 @@ flagcxResult_t bootstrapCollInit(struct flagcxBootstrapHandle *handle, int rank,
                                      sizeof(union flagcxSocketAddress)));
 
   // Set bootstrap net info
-  state->bootstrapNetIfName = bootstrapNetIfName;
-  flagcxNetProperties_t *properties;
-  FLAGCXCHECK(flagcxCalloc(&properties, 1));
-  state->properties = properties;
   INFO(FLAGCX_INIT, "rank %d nranks %d - DONE", rank, nranks);
 
   *stateOut = wrapper;
@@ -595,7 +622,6 @@ flagcxResult_t bootstrapClose(struct bootstrapState *state) {
   FLAGCXCHECK(flagcxSocketClose(&coll->ringRecvSocket));
 
   free(coll->peerCommAddresses);
-  free(coll->properties);
   free(coll);
   free(state);
   return flagcxSuccess;
@@ -614,7 +640,6 @@ flagcxResult_t bootstrapCollAbort(struct bootstrapState *state) {
   FLAGCXCHECK(flagcxSocketClose(&coll->ringRecvSocket));
   free(coll->peerCommAddresses);
   free(coll->peerProxyAddresses);
-  free(coll->properties);
   free(coll);
   free(state);
   return flagcxSuccess;

--- a/flagcx/service/bootstrap.cc
+++ b/flagcx/service/bootstrap.cc
@@ -587,9 +587,16 @@ flagcxResult_t bootstrapExchange(struct bootstrapState *state, int peer,
     return flagcxInvalidArgument;
 
   if (state->mode == FLAGCX_BOOTSTRAP_P2P) {
-    // P2P mode: send then recv (single peer, no deadlock risk)
-    FLAGCXCHECK(bootstrapSend(state, peer, tag, (void *)sendData, sendSize));
-    FLAGCXCHECK(bootstrapRecv(state, peer, tag, recvData, recvSize));
+    // P2P mode: order by role to avoid deadlock when payload exceeds
+    // socket buffer (connector sends first, acceptor recvs first).
+    struct bootstrapP2pState *p2p = state->p2p;
+    if (p2p->isConnector) {
+      FLAGCXCHECK(bootstrapSend(state, peer, tag, (void *)sendData, sendSize));
+      FLAGCXCHECK(bootstrapRecv(state, peer, tag, recvData, recvSize));
+    } else {
+      FLAGCXCHECK(bootstrapRecv(state, peer, tag, recvData, recvSize));
+      FLAGCXCHECK(bootstrapSend(state, peer, tag, (void *)sendData, sendSize));
+    }
     return flagcxSuccess;
   }
 
@@ -1306,6 +1313,7 @@ flagcxResult_t bootstrapP2pConnect(void *peerHandle, uint64_t magic,
   struct bootstrapP2pState *p2p;
   FLAGCXCHECK(flagcxCalloc(&p2p, 1));
   p2p->isListener = false;
+  p2p->isConnector = true;
   p2p->magic = magic;
   p2p->abortFlag = abortFlag;
 
@@ -1340,6 +1348,7 @@ flagcxResult_t bootstrapP2pAccept(struct bootstrapState *listenState,
   struct bootstrapP2pState *connP2p;
   FLAGCXCHECK(flagcxCalloc(&connP2p, 1));
   connP2p->isListener = false;
+  connP2p->isConnector = false;
   connP2p->magic = listenP2p->magic;
   connP2p->abortFlag = listenP2p->abortFlag;
 

--- a/flagcx/service/include/bootstrap.h
+++ b/flagcx/service/include/bootstrap.h
@@ -45,7 +45,8 @@ struct bootstrapCollState {
 };
 
 struct bootstrapP2pState {
-  bool isListener;          // true = listen mode, false = connected mode
+  bool isListener;  // true = listen mode, false = connected mode
+  bool isConnector; // true = initiated connect, false = accepted connection
   struct flagcxSocket sock; // listen socket OR connected peer socket
   union flagcxSocketAddress localAddr;
   uint64_t magic;

--- a/flagcx/service/include/bootstrap.h
+++ b/flagcx/service/include/bootstrap.h
@@ -45,9 +45,6 @@ struct bootstrapCollState {
   void *properties;
 };
 
-// Keep old name as typedef for source compatibility during transition
-typedef struct bootstrapCollState bootstrapState;
-
 struct bootstrapP2pState {
   bool isListener;          // true = listen mode, false = connected mode
   struct flagcxSocket sock; // listen socket OR connected peer socket
@@ -56,7 +53,7 @@ struct bootstrapP2pState {
   volatile uint32_t *abortFlag;
 };
 
-struct flagcxBootstrapState {
+struct bootstrapState {
   enum flagcxBootstrapMode mode;
   union {
     struct bootstrapCollState *coll;
@@ -70,22 +67,22 @@ struct flagcxBootstrapState {
 
 // Send data to peer. In coll mode, uses ring relay. In P2P mode, sends
 // directly over the connected socket (peer param ignored).
-flagcxResult_t bootstrapSend(struct flagcxBootstrapState *state, int peer,
-                             int tag, void *data, int size);
+flagcxResult_t bootstrapSend(struct bootstrapState *state, int peer, int tag,
+                             void *data, int size);
 
 // Receive data from peer. In coll mode, accepts from ring. In P2P mode,
 // receives directly from the connected socket (peer param ignored).
-flagcxResult_t bootstrapRecv(struct flagcxBootstrapState *state, int peer,
-                             int tag, void *data, int size);
+flagcxResult_t bootstrapRecv(struct bootstrapState *state, int peer, int tag,
+                             void *data, int size);
 
 // Deadlock-free bidirectional exchange. In coll mode, lower rank sends first.
 // In P2P mode, uses the same ordering based on a "who initiated" convention.
-flagcxResult_t bootstrapExchange(struct flagcxBootstrapState *state, int peer,
+flagcxResult_t bootstrapExchange(struct bootstrapState *state, int peer,
                                  int tag, const void *sendData, int sendSize,
                                  void *recvData, int recvSize);
 
 // Unified close. Dispatches on state->mode to free the appropriate resources.
-flagcxResult_t bootstrapClose(struct flagcxBootstrapState *state);
+flagcxResult_t bootstrapClose(struct bootstrapState *state);
 
 // ============================================================================
 // Collective Mode API
@@ -103,24 +100,24 @@ flagcxResult_t bootstrapGetUniqueId(struct flagcxBootstrapHandle *handle);
 flagcxResult_t bootstrapCollInit(struct flagcxBootstrapHandle *handle, int rank,
                                  int nranks, uint64_t magic,
                                  volatile uint32_t *abortFlag,
-                                 struct flagcxBootstrapState **state);
+                                 struct bootstrapState **state);
 
 // Collective operations (coll mode only)
-flagcxResult_t bootstrapCollAllGather(struct flagcxBootstrapState *state,
+flagcxResult_t bootstrapCollAllGather(struct bootstrapState *state,
                                       void *allData, int size);
-flagcxResult_t bootstrapCollBarrier(struct flagcxBootstrapState *state,
-                                    int rank, int nranks, int tag);
-flagcxResult_t bootstrapCollBroadcast(struct flagcxBootstrapState *state,
-                                      int rank, int nranks, int root,
-                                      void *bcastData, int size);
-flagcxResult_t bootstrapCollIntraNodeBarrier(struct flagcxBootstrapState *state,
+flagcxResult_t bootstrapCollBarrier(struct bootstrapState *state, int rank,
+                                    int nranks, int tag);
+flagcxResult_t bootstrapCollBroadcast(struct bootstrapState *state, int rank,
+                                      int nranks, int root, void *bcastData,
+                                      int size);
+flagcxResult_t bootstrapCollIntraNodeBarrier(struct bootstrapState *state,
                                              int *ranks, int rank, int nranks,
                                              int tag);
-flagcxResult_t
-bootstrapCollIntraNodeBroadcast(struct flagcxBootstrapState *state, int *ranks,
-                                int rank, int nranks, int root, void *bcastData,
-                                int size);
-flagcxResult_t bootstrapCollAbort(struct flagcxBootstrapState *state);
+flagcxResult_t bootstrapCollIntraNodeBroadcast(struct bootstrapState *state,
+                                               int *ranks, int rank, int nranks,
+                                               int root, void *bcastData,
+                                               int size);
+flagcxResult_t bootstrapCollAbort(struct bootstrapState *state);
 
 // ============================================================================
 // P2P Mode API (RPC-style listen/connect/accept)
@@ -130,17 +127,17 @@ flagcxResult_t bootstrapCollAbort(struct flagcxBootstrapState *state);
 // Returns handle containing address for peer to connect.
 flagcxResult_t bootstrapP2pListen(uint64_t magic, volatile uint32_t *abortFlag,
                                   void *listenHandle,
-                                  struct flagcxBootstrapState **state);
+                                  struct bootstrapState **state);
 
 // Connect to a peer's listen socket using handle received out-of-band.
 flagcxResult_t bootstrapP2pConnect(void *peerHandle, uint64_t magic,
                                    volatile uint32_t *abortFlag,
-                                   struct flagcxBootstrapState **state);
+                                   struct bootstrapState **state);
 
 // Accept an incoming connection on a listen state. Returns a new connected
 // state.
-flagcxResult_t bootstrapP2pAccept(struct flagcxBootstrapState *listenState,
-                                  struct flagcxBootstrapState **connState);
+flagcxResult_t bootstrapP2pAccept(struct bootstrapState *listenState,
+                                  struct bootstrapState **connState);
 
 // ============================================================================
 // Typed collective communication operators (coll mode only)
@@ -149,7 +146,7 @@ flagcxResult_t bootstrapP2pAccept(struct flagcxBootstrapState *listenState,
 /*
  * Broadcast
  */
-flagcxResult_t BroadcastBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t BroadcastBootstrap(struct bootstrapState *state,
                                   const void *sendbuff, void *recvbuff,
                                   size_t count, flagcxDataType_t datatype,
                                   int root);
@@ -157,7 +154,7 @@ flagcxResult_t BroadcastBootstrap(struct flagcxBootstrapState *state,
 /*
  * Gather
  */
-flagcxResult_t GatherBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t GatherBootstrap(struct bootstrapState *state,
                                const void *sendbuff, void *recvbuff,
                                size_t count, flagcxDataType_t datatype,
                                int root);
@@ -165,7 +162,7 @@ flagcxResult_t GatherBootstrap(struct flagcxBootstrapState *state,
 /*
  * Scatter
  */
-flagcxResult_t ScatterBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t ScatterBootstrap(struct bootstrapState *state,
                                 const void *sendbuff, void *recvbuff,
                                 size_t count, flagcxDataType_t datatype,
                                 int root);
@@ -173,7 +170,7 @@ flagcxResult_t ScatterBootstrap(struct flagcxBootstrapState *state,
 /*
  * Reduce
  */
-flagcxResult_t ReduceBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t ReduceBootstrap(struct bootstrapState *state,
                                const void *sendbuff, void *recvbuff,
                                size_t count, flagcxDataType_t datatype,
                                flagcxRedOp_t op, int root);
@@ -181,7 +178,7 @@ flagcxResult_t ReduceBootstrap(struct flagcxBootstrapState *state,
 /*
  * All-reduce
  */
-flagcxResult_t AllReduceBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t AllReduceBootstrap(struct bootstrapState *state,
                                   const void *sendbuff, void *recvbuff,
                                   size_t count, flagcxDataType_t datatype,
                                   flagcxRedOp_t op);
@@ -189,14 +186,14 @@ flagcxResult_t AllReduceBootstrap(struct flagcxBootstrapState *state,
 /*
  * All-gather
  */
-flagcxResult_t AllGatherBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t AllGatherBootstrap(struct bootstrapState *state,
                                   const void *sendbuff, void *recvbuff,
                                   size_t sendcount, flagcxDataType_t datatype);
 
 /*
  * Reduce-scatter
  */
-flagcxResult_t ReduceScatterBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t ReduceScatterBootstrap(struct bootstrapState *state,
                                       const void *sendbuff, void *recvbuff,
                                       size_t recvcount,
                                       flagcxDataType_t datatype,
@@ -205,14 +202,14 @@ flagcxResult_t ReduceScatterBootstrap(struct flagcxBootstrapState *state,
 /*
  * All-to-all
  */
-flagcxResult_t AlltoAllBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t AlltoAllBootstrap(struct bootstrapState *state,
                                  const void *sendbuff, void *recvbuff,
                                  size_t count, flagcxDataType_t datatype);
 
 /*
  * All-to-all with variable block sizes
  */
-flagcxResult_t AlltoAllvBootstrap(struct flagcxBootstrapState *state,
+flagcxResult_t AlltoAllvBootstrap(struct bootstrapState *state,
                                   const void *sendbuff, size_t *sendcounts,
                                   size_t *sdispls, void *recvbuff,
                                   size_t *recvcounts, size_t *rdispls,

--- a/flagcx/service/include/bootstrap.h
+++ b/flagcx/service/include/bootstrap.h
@@ -12,6 +12,7 @@ extern "C" {
 #endif
 
 #include "flagcx.h"
+#include "flagcx_net.h"
 #include "socket.h"
 
 struct flagcxBootstrapHandle {

--- a/flagcx/service/include/bootstrap.h
+++ b/flagcx/service/include/bootstrap.h
@@ -41,8 +41,6 @@ struct bootstrapCollState {
   int nranks;
   uint64_t magic;
   volatile uint32_t *abortFlag;
-  char *bootstrapNetIfName;
-  void *properties;
 };
 
 struct bootstrapP2pState {
@@ -214,6 +212,19 @@ flagcxResult_t AlltoAllvBootstrap(struct bootstrapState *state,
                                   size_t *sdispls, void *recvbuff,
                                   size_t *recvcounts, size_t *rdispls,
                                   flagcxDataType_t datatype);
+
+// ============================================================================
+// Accessor APIs — encapsulate internal state for external callers
+// ============================================================================
+
+// Get rank/nranks from a collective-mode bootstrap state
+int bootstrapGetRank(struct bootstrapState *state);
+int bootstrapGetNranks(struct bootstrapState *state);
+
+// Global network context (populated by bootstrapNetInit)
+flagcxNetProperties_t *bootstrapGetNetProperties();
+const char *bootstrapGetNetIfName();
+union flagcxSocketAddress *bootstrapGetNetIfAddr();
 
 #ifdef __cplusplus
 } // end extern "C"

--- a/flagcx/service/include/bootstrap.h
+++ b/flagcx/service/include/bootstrap.h
@@ -21,7 +21,16 @@ struct flagcxBootstrapHandle {
 static_assert(sizeof(struct flagcxBootstrapHandle) <= sizeof(flagcxUniqueId),
               "Bootstrap handle is too large to fit inside FLAGCX unique ID");
 
-struct bootstrapState {
+// ============================================================================
+// Bootstrap State
+// ============================================================================
+
+enum flagcxBootstrapMode {
+  FLAGCX_BOOTSTRAP_COLL = 0, // Collective mode (ring topology, N ranks)
+  FLAGCX_BOOTSTRAP_P2P = 1   // P2P mode (direct socket, 1:1 RPC)
+};
+
+struct bootstrapCollState {
   struct flagcxSocket listenSock;
   struct flagcxSocket ringRecvSocket;
   struct flagcxSocket ringSendSocket;
@@ -36,160 +45,178 @@ struct bootstrapState {
   void *properties;
 };
 
+// Keep old name as typedef for source compatibility during transition
+typedef struct bootstrapCollState bootstrapState;
+
+struct bootstrapP2pState {
+  bool isListener;          // true = listen mode, false = connected mode
+  struct flagcxSocket sock; // listen socket OR connected peer socket
+  union flagcxSocketAddress localAddr;
+  uint64_t magic;
+  volatile uint32_t *abortFlag;
+};
+
+struct flagcxBootstrapState {
+  enum flagcxBootstrapMode mode;
+  union {
+    struct bootstrapCollState *coll;
+    struct bootstrapP2pState *p2p;
+  };
+};
+
+// ============================================================================
+// Unified API (dispatches based on state->mode)
+// ============================================================================
+
+// Send data to peer. In coll mode, uses ring relay. In P2P mode, sends
+// directly over the connected socket (peer param ignored).
+flagcxResult_t bootstrapSend(struct flagcxBootstrapState *state, int peer,
+                             int tag, void *data, int size);
+
+// Receive data from peer. In coll mode, accepts from ring. In P2P mode,
+// receives directly from the connected socket (peer param ignored).
+flagcxResult_t bootstrapRecv(struct flagcxBootstrapState *state, int peer,
+                             int tag, void *data, int size);
+
+// Deadlock-free bidirectional exchange. In coll mode, lower rank sends first.
+// In P2P mode, uses the same ordering based on a "who initiated" convention.
+flagcxResult_t bootstrapExchange(struct flagcxBootstrapState *state, int peer,
+                                 int tag, const void *sendData, int sendSize,
+                                 void *recvData, int recvSize);
+
+// Unified close. Dispatches on state->mode to free the appropriate resources.
+flagcxResult_t bootstrapClose(struct flagcxBootstrapState *state);
+
+// ============================================================================
+// Collective Mode API
+// ============================================================================
+
+// Shared network init — discovers local NIC for socket binding.
+// Idempotent, safe to call multiple times. Both Coll and P2P depend on this.
 flagcxResult_t bootstrapNetInit();
-flagcxResult_t bootstrapCreateRoot(struct flagcxBootstrapHandle *handle,
-                                   bool idFromEnv);
+
+flagcxResult_t bootstrapCollCreateRoot(struct flagcxBootstrapHandle *handle,
+                                       bool idFromEnv);
 flagcxResult_t bootstrapGetUniqueId(struct flagcxBootstrapHandle *handle);
-flagcxResult_t bootstrapInit(struct flagcxBootstrapHandle *handle,
-                             void *commState);
-flagcxResult_t bootstrapAllGather(void *commState, void *allData, int size);
 
-flagcxResult_t bootstrapSend(void *commState, int peer, int tag, void *data,
-                             int size);
-flagcxResult_t bootstrapRecv(void *commState, int peer, int tag, void *data,
-                             int size);
-flagcxResult_t bootstrapBarrier(void *commState, int rank, int nranks, int tag);
-flagcxResult_t bootstrapBroadcast(void *commState, int rank, int nranks,
-                                  int root, void *bcastData, int size);
-flagcxResult_t bootstrapIntraNodeBarrier(void *commState, int *ranks, int rank,
-                                         int nranks, int tag);
-flagcxResult_t bootstrapIntraNodeBroadcast(void *commState, int *ranks,
-                                           int rank, int nranks, int root,
-                                           void *bcastData, int size);
-flagcxResult_t bootstrapClose(void *commState);
-flagcxResult_t bootstrapAbort(void *commState);
+// Initialize collective bootstrap (ring topology, N ranks)
+flagcxResult_t bootstrapCollInit(struct flagcxBootstrapHandle *handle, int rank,
+                                 int nranks, uint64_t magic,
+                                 volatile uint32_t *abortFlag,
+                                 struct flagcxBootstrapState **state);
 
-/* A bunch of collective communication operators */
+// Collective operations (coll mode only)
+flagcxResult_t bootstrapCollAllGather(struct flagcxBootstrapState *state,
+                                      void *allData, int size);
+flagcxResult_t bootstrapCollBarrier(struct flagcxBootstrapState *state,
+                                    int rank, int nranks, int tag);
+flagcxResult_t bootstrapCollBroadcast(struct flagcxBootstrapState *state,
+                                      int rank, int nranks, int root,
+                                      void *bcastData, int size);
+flagcxResult_t bootstrapCollIntraNodeBarrier(struct flagcxBootstrapState *state,
+                                             int *ranks, int rank, int nranks,
+                                             int tag);
+flagcxResult_t
+bootstrapCollIntraNodeBroadcast(struct flagcxBootstrapState *state, int *ranks,
+                                int rank, int nranks, int root, void *bcastData,
+                                int size);
+flagcxResult_t bootstrapCollAbort(struct flagcxBootstrapState *state);
+
+// ============================================================================
+// P2P Mode API (RPC-style listen/connect/accept)
+// ============================================================================
+
+// Open a listen socket. Ensures bootstrapNetInit() has been called.
+// Returns handle containing address for peer to connect.
+flagcxResult_t bootstrapP2pListen(uint64_t magic, volatile uint32_t *abortFlag,
+                                  void *listenHandle,
+                                  struct flagcxBootstrapState **state);
+
+// Connect to a peer's listen socket using handle received out-of-band.
+flagcxResult_t bootstrapP2pConnect(void *peerHandle, uint64_t magic,
+                                   volatile uint32_t *abortFlag,
+                                   struct flagcxBootstrapState **state);
+
+// Accept an incoming connection on a listen state. Returns a new connected
+// state.
+flagcxResult_t bootstrapP2pAccept(struct flagcxBootstrapState *listenState,
+                                  struct flagcxBootstrapState **connState);
+
+// ============================================================================
+// Typed collective communication operators (coll mode only)
+// ============================================================================
+
 /*
  * Broadcast
- *
- * Root device send sendcount values from other GPUs into recvbuff,
- * receiving data from rank i at offset i*sendcount.
- * Assumes recvcount is equal to nranks*sendcount, which means that recvbuff
- * should have a size of at least nranks*sendcount elements.
- *
- * In-place operations will happen if sendbuff == recvbuff.
  */
-flagcxResult_t BroadcastBootstrap(void *commState, const void *sendbuff,
-                                  void *recvbuff, size_t sendcount,
-                                  flagcxDataType_t datatype, int root);
+flagcxResult_t BroadcastBootstrap(struct flagcxBootstrapState *state,
+                                  const void *sendbuff, void *recvbuff,
+                                  size_t count, flagcxDataType_t datatype,
+                                  int root);
 
-/* A bunch of collective communication operators */
 /*
  * Gather
- *
- * Each rank sends sendcount values from its sendbuff to the root rank.
- * Root rank receives data from rank i at offset i*sendcount in recvbuff.
- * Assumes recvcount is equal to nranks*sendcount, which means that recvbuff
- * should have a size of at least nranks*sendcount elements.
- *
- * In-place operations will happen if sendbuff == recvbuff + rank * sendcount.
  */
-flagcxResult_t GatherBootstrap(void *commState, const void *sendbuff,
-                               void *recvbuff, size_t count,
-                               flagcxDataType_t datatype, int root);
+flagcxResult_t GatherBootstrap(struct flagcxBootstrapState *state,
+                               const void *sendbuff, void *recvbuff,
+                               size_t count, flagcxDataType_t datatype,
+                               int root);
 
-/* A bunch of collective communication operators */
 /*
  * Scatter
- *
- * Root rank sends sendcount values to each rank, with data for rank i
- * starting at offset i*sendcount in sendbuff.
- * Each rank receives sendcount values into its recvbuff.
- * Assumes sendcount is equal to recvcount for each rank.
- *
- * In-place operations will happen if recvbuff = sendbuff + rank * sendcount.
  */
-flagcxResult_t ScatterBootstrap(void *commState, const void *sendbuff,
-                                void *recvbuff, size_t count,
-                                flagcxDataType_t datatype, int root);
-/* A bunch of collective communication operators */
-/*
- * All-Gather
- *
- * Each device gathers sendcount values from other GPUs into recvbuff,
- * receiving data from rank i at offset i*sendcount.
- * Assumes recvcount is equal to nranks*sendcount, which means that recvbuff
- * should have a size of at least nranks*sendcount elements.
- *
- * In-place operations will happen if sendbuff == recvbuff + rank * sendcount.
- */
-flagcxResult_t AllGatherBootstrap(void *commState, const void *sendbuff,
-                                  void *recvbuff, size_t sendcount,
-                                  flagcxDataType_t datatype);
-/*
- * All-Reduce
- *
- * Reduces data arrays of length count(NOT bytes size) in sendbuff using op
- * operation, and leaves identical copies of result on each recvbuff.
- *
- * In-place operation will happen if sendbuff == recvbuff.
- */
-flagcxResult_t AllReduceBootstrap(void *commState, const void *sendbuff,
-                                  void *recvbuff, size_t count,
-                                  flagcxDataType_t datatype, flagcxRedOp_t op);
+flagcxResult_t ScatterBootstrap(struct flagcxBootstrapState *state,
+                                const void *sendbuff, void *recvbuff,
+                                size_t count, flagcxDataType_t datatype,
+                                int root);
+
 /*
  * Reduce
- *
- * Reduces data arrays of length count(NOT bytes size) in sendbuff using op
- * operation, and leaves identical copies of result on root recvbuff.
- *
- * In-place operation will happen if sendbuff == recvbuff.
  */
-flagcxResult_t ReduceBootstrap(void *commState, const void *sendbuff,
-                               void *recvbuff, size_t count,
-                               flagcxDataType_t datatype, flagcxRedOp_t op,
-                               int root);
+flagcxResult_t ReduceBootstrap(struct flagcxBootstrapState *state,
+                               const void *sendbuff, void *recvbuff,
+                               size_t count, flagcxDataType_t datatype,
+                               flagcxRedOp_t op, int root);
+
 /*
- * Reduce-Scatter
- *
- * Reduces data in sendbuff using op operation and leaves reduced result
- * scattered over the devices so that recvbuff on rank i will contain the i-th
- * block of the result.
- * Assumes sendcount is equal to nranks*recvcount, which means that sendbuff
- * should have a size of at least nranks*recvcount elements.
- *
- * In-place operations will happen if recvbuff == sendbuff + rank * recvcount.
+ * All-reduce
  */
-flagcxResult_t ReduceScatterBootstrap(void *commState, const void *sendbuff,
-                                      void *recvbuff, size_t recvcount,
+flagcxResult_t AllReduceBootstrap(struct flagcxBootstrapState *state,
+                                  const void *sendbuff, void *recvbuff,
+                                  size_t count, flagcxDataType_t datatype,
+                                  flagcxRedOp_t op);
+
+/*
+ * All-gather
+ */
+flagcxResult_t AllGatherBootstrap(struct flagcxBootstrapState *state,
+                                  const void *sendbuff, void *recvbuff,
+                                  size_t sendcount, flagcxDataType_t datatype);
+
+/*
+ * Reduce-scatter
+ */
+flagcxResult_t ReduceScatterBootstrap(struct flagcxBootstrapState *state,
+                                      const void *sendbuff, void *recvbuff,
+                                      size_t recvcount,
                                       flagcxDataType_t datatype,
                                       flagcxRedOp_t op);
 
 /*
  * All-to-all
- *
- * Every rank sends j-th block of its own sendbuff to the j-th rank of the
- * communicator. Meanwhile, every rank receives j-th block of its own recvbuff
- * from j-th rank.
- *
- * Every block has the size of count elements.
- *
- * In-place operations will happen if sendbuff == recvbuff.
  */
-flagcxResult_t AlltoAllBootstrap(void *commState, const void *sendbuff,
-                                 void *recvbuff, size_t count,
-                                 flagcxDataType_t datatype);
+flagcxResult_t AlltoAllBootstrap(struct flagcxBootstrapState *state,
+                                 const void *sendbuff, void *recvbuff,
+                                 size_t count, flagcxDataType_t datatype);
 
 /*
  * All-to-all with variable block sizes
- *
- * Every rank sends j-th block of its own sendbuff to the j-th rank of the
- * communicator. Meanwhile, every rank receives j-th block of its own recvbuff
- * from j-th rank.
- *
- * Each block can have different sizes:
- * - sendcounts[j] specifies the number of elements to send to rank j
- * - sdispls[j] specifies the offset in sendbuff for the j-th block
- * - recvcounts[j] specifies the number of elements to receive from rank j
- * - rdispls[j] specifies the offset in recvbuff for the j-th block
- *
- * In-place operations will happen if sendbuff == recvbuff.
  */
-flagcxResult_t AlltoAllvBootstrap(void *commState, const void *sendbuff,
-                                  size_t *sendcounts, size_t *sdispls,
-                                  void *recvbuff, size_t *recvcounts,
-                                  size_t *rdispls, flagcxDataType_t datatype);
+flagcxResult_t AlltoAllvBootstrap(struct flagcxBootstrapState *state,
+                                  const void *sendbuff, size_t *sendcounts,
+                                  size_t *sdispls, void *recvbuff,
+                                  size_t *recvcounts, size_t *rdispls,
+                                  flagcxDataType_t datatype);
 
 #ifdef __cplusplus
 } // end extern "C"

--- a/test/unittest/core/test_bootstrap_accessors.cpp
+++ b/test/unittest/core/test_bootstrap_accessors.cpp
@@ -1,0 +1,92 @@
+// Unit tests for bootstrap accessor APIs.
+// Source: flagcx/service/include/bootstrap.h, flagcx/service/bootstrap.cc
+// Links against libflagcx.
+
+#include <cstring>
+#include <gtest/gtest.h>
+
+#include "bootstrap.h"
+
+// =============================================================================
+// bootstrapGetRank / bootstrapGetNranks
+// =============================================================================
+
+TEST(BootstrapAccessors, GetRankNullState) {
+  EXPECT_EQ(bootstrapGetRank(nullptr), -1);
+  EXPECT_EQ(bootstrapGetNranks(nullptr), -1);
+}
+
+TEST(BootstrapAccessors, GetRankP2pModeReturnsNegOne) {
+  // P2P mode has no rank/nranks concept — accessors should return -1
+  struct bootstrapP2pState p2p;
+  memset(&p2p, 0, sizeof(p2p));
+
+  struct bootstrapState state;
+  state.mode = FLAGCX_BOOTSTRAP_P2P;
+  state.p2p = &p2p;
+
+  EXPECT_EQ(bootstrapGetRank(&state), -1);
+  EXPECT_EQ(bootstrapGetNranks(&state), -1);
+}
+
+TEST(BootstrapAccessors, GetRankCollMode) {
+  struct bootstrapCollState coll;
+  memset(&coll, 0, sizeof(coll));
+  coll.rank = 3;
+  coll.nranks = 8;
+
+  struct bootstrapState state;
+  state.mode = FLAGCX_BOOTSTRAP_COLL;
+  state.coll = &coll;
+
+  EXPECT_EQ(bootstrapGetRank(&state), 3);
+  EXPECT_EQ(bootstrapGetNranks(&state), 8);
+}
+
+TEST(BootstrapAccessors, GetRankCollNullInner) {
+  struct bootstrapState state;
+  state.mode = FLAGCX_BOOTSTRAP_COLL;
+  state.coll = nullptr;
+
+  EXPECT_EQ(bootstrapGetRank(&state), -1);
+  EXPECT_EQ(bootstrapGetNranks(&state), -1);
+}
+
+// =============================================================================
+// bootstrapGetNetProperties / bootstrapGetNetIfName / bootstrapGetNetIfAddr
+// =============================================================================
+
+TEST(BootstrapAccessors, GetNetPropertiesNotNull) {
+  // The global properties struct always exists (static storage)
+  flagcxNetProperties_t *props = bootstrapGetNetProperties();
+  ASSERT_NE(props, nullptr);
+}
+
+TEST(BootstrapAccessors, GetNetIfNameNotNull) {
+  const char *name = bootstrapGetNetIfName();
+  ASSERT_NE(name, nullptr);
+  // Before bootstrapNetInit is called, name may be empty string
+  // but the pointer itself must be valid
+}
+
+TEST(BootstrapAccessors, GetNetIfAddrNotNull) {
+  union flagcxSocketAddress *addr = bootstrapGetNetIfAddr();
+  ASSERT_NE(addr, nullptr);
+}
+
+TEST(BootstrapAccessors, NetInitPopulatesIfName) {
+  // After bootstrapNetInit succeeds, ifName should be non-empty
+  flagcxResult_t res = bootstrapNetInit();
+  if (res == flagcxSuccess) {
+    const char *name = bootstrapGetNetIfName();
+    EXPECT_GT(strlen(name), 0u);
+
+    union flagcxSocketAddress *addr = bootstrapGetNetIfAddr();
+    // Should have a valid address family
+    EXPECT_TRUE(addr->sa.sa_family == AF_INET ||
+                addr->sa.sa_family == AF_INET6);
+  } else {
+    // If no network interface is available, skip gracefully
+    GTEST_SKIP() << "bootstrapNetInit failed (no usable interface)";
+  }
+}

--- a/test/unittest/p2p/test_p2p_engine_rpc.cpp
+++ b/test/unittest/p2p/test_p2p_engine_rpc.cpp
@@ -194,7 +194,7 @@ TEST_F(P2pEngineRpcTest, GetMetadataContainsIpAndPort) {
   EXPECT_GE(parsed.notifPort, 0);
 }
 
-TEST_F(P2pEngineRpcTest, GetMetadataRdmaPortDiffersFromRpcPort) {
+TEST_F(P2pEngineRpcTest, GetMetadataPortMatchesRpcPort) {
   char *metaRaw = nullptr;
   ASSERT_EQ(flagcxP2pEngineGetMetadata(serverEngine, &metaRaw), 0);
   std::unique_ptr<char[]> metadata(metaRaw);
@@ -203,10 +203,10 @@ TEST_F(P2pEngineRpcTest, GetMetadataRdmaPortDiffersFromRpcPort) {
   ASSERT_TRUE(parseMetadata(metadata.get(), &parsed));
 
   const int rpcPort = flagcxP2pEngineGetRpcPort(serverEngine);
-  // The IB RDMA listen port (in metadata) should differ from the bootstrap
-  // RPC port, since they're separate listeners
-  EXPECT_NE(parsed.port, rpcPort)
-      << "IB listen port should not equal bootstrap RPC port";
+  // After bootstrap P2P integration, metadata exposes the bootstrap listen
+  // port — the same port used for RPC and initial connection handshake.
+  EXPECT_EQ(parsed.port, rpcPort)
+      << "metadata port should equal bootstrap RPC port";
 }
 
 // ============================================================================

--- a/test/unittest/p2p/test_p2p_engine_rpc.cpp
+++ b/test/unittest/p2p/test_p2p_engine_rpc.cpp
@@ -1,0 +1,362 @@
+// Unit tests for FlagCX P2P RPC Engine with Bootstrap P2P integration.
+// Tests engine lifecycle, metadata exchange, connect/accept handshake,
+// RPC server, and descriptor table exchange.
+//
+// Hardware-dependent tests skip gracefully via GTEST_SKIP().
+
+#include <chrono>
+#include <cstring>
+#include <future>
+#include <string>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "flagcx_p2p.h"
+
+namespace {
+
+// Helper to parse "ip:port?gpuIdx?notifPort" metadata
+struct ParsedMetadata {
+  std::string ip;
+  int port = -1;
+  int gpuIdx = -1;
+  int notifPort = -1;
+};
+
+bool parseMetadata(const char *raw, ParsedMetadata *out) {
+  if (raw == nullptr || out == nullptr)
+    return false;
+  std::string s(raw);
+  size_t q1 = s.find('?');
+  if (q1 == std::string::npos)
+    return false;
+  size_t q2 = s.find('?', q1 + 1);
+  if (q2 == std::string::npos)
+    return false;
+
+  std::string endpoint = s.substr(0, q1);
+  std::string gpuPart = s.substr(q1 + 1, q2 - q1 - 1);
+  std::string notifPart = s.substr(q2 + 1);
+
+  try {
+    size_t colon = endpoint.rfind(':');
+    if (colon == std::string::npos)
+      return false;
+    out->ip = endpoint.substr(0, colon);
+    out->port = std::stoi(endpoint.substr(colon + 1));
+    out->gpuIdx = std::stoi(gpuPart);
+    out->notifPort = std::stoi(notifPart);
+  } catch (...) {
+    return false;
+  }
+
+  return !out->ip.empty() && out->port >= 0;
+}
+
+// ============================================================================
+// Fixture: Sets up two engines (server + client)
+// ============================================================================
+
+class P2pEngineRpcTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    serverEngine = flagcxP2pEngineCreate();
+    clientEngine = flagcxP2pEngineCreate();
+    if (serverEngine == nullptr || clientEngine == nullptr) {
+      if (serverEngine) {
+        flagcxP2pEngineDestroy(serverEngine);
+        serverEngine = nullptr;
+      }
+      if (clientEngine) {
+        flagcxP2pEngineDestroy(clientEngine);
+        clientEngine = nullptr;
+      }
+      GTEST_SKIP() << "Unable to create P2P engines (no IB hardware)";
+    }
+  }
+
+  void TearDown() override {
+    if (serverConn) {
+      flagcxP2pEngineConnDestroy(serverConn);
+      serverConn = nullptr;
+    }
+    if (clientConn) {
+      flagcxP2pEngineConnDestroy(clientConn);
+      clientConn = nullptr;
+    }
+    if (serverEngine) {
+      flagcxP2pEngineDestroy(serverEngine);
+      serverEngine = nullptr;
+    }
+    if (clientEngine) {
+      flagcxP2pEngineDestroy(clientEngine);
+      clientEngine = nullptr;
+    }
+  }
+
+  // Helper: connect client to server via bootstrap port
+  void connectViaBsPort() {
+    ASSERT_NE(serverEngine, nullptr);
+    ASSERT_NE(clientEngine, nullptr);
+
+    char *metaRaw = nullptr;
+    ASSERT_EQ(flagcxP2pEngineGetMetadata(serverEngine, &metaRaw), 0);
+    ASSERT_NE(metaRaw, nullptr);
+    std::unique_ptr<char[]> metadata(metaRaw);
+
+    ParsedMetadata parsed;
+    ASSERT_TRUE(parseMetadata(metadata.get(), &parsed))
+        << "metadata=" << metadata.get();
+
+    // Get server's RPC port (bootstrap listen port)
+    const int serverRpcPort = flagcxP2pEngineGetRpcPort(serverEngine);
+    ASSERT_GT(serverRpcPort, 0);
+
+    // Accept in background thread
+    auto acceptFuture = std::async(std::launch::async, [this]() {
+      char ipBuf[256] = {};
+      int remoteGpuIdx = -1;
+      FlagcxP2pConn *conn = flagcxP2pEngineAccept(serverEngine, ipBuf,
+                                                  sizeof(ipBuf), &remoteGpuIdx);
+      acceptedIp = ipBuf;
+      acceptedRemoteGpuIdx = remoteGpuIdx;
+      return conn;
+    });
+
+    // Connect from client to server's bootstrap port
+    clientConn = flagcxP2pEngineConnect(clientEngine, parsed.ip.c_str(),
+                                        parsed.gpuIdx, serverRpcPort, false);
+    ASSERT_NE(clientConn, nullptr);
+
+    ASSERT_EQ(acceptFuture.wait_for(std::chrono::seconds(10)),
+              std::future_status::ready)
+        << "Accept timed out";
+    serverConn = acceptFuture.get();
+    ASSERT_NE(serverConn, nullptr);
+  }
+
+  FlagcxP2pEngine *serverEngine = nullptr;
+  FlagcxP2pEngine *clientEngine = nullptr;
+  FlagcxP2pConn *serverConn = nullptr;
+  FlagcxP2pConn *clientConn = nullptr;
+  std::string acceptedIp;
+  int acceptedRemoteGpuIdx = -1;
+};
+
+// ============================================================================
+// 1. Engine Lifecycle
+// ============================================================================
+
+TEST(P2pEngineLifecycle, CreateDestroyNoIb) {
+  // Doesn't require IB — just checks null-safety
+  FlagcxP2pEngine *engine = flagcxP2pEngineCreate();
+  // May be null if no IB, but should not crash
+  if (engine) {
+    flagcxP2pEngineDestroy(engine);
+  }
+}
+
+TEST(P2pEngineLifecycle, DoubleDestroyIsNoop) {
+  flagcxP2pEngineDestroy(nullptr);
+  flagcxP2pEngineDestroy(nullptr);
+  // Should not crash
+}
+
+TEST_F(P2pEngineRpcTest, EngineCreateInitializesBootstrap) {
+  ASSERT_NE(serverEngine, nullptr);
+  const int port = flagcxP2pEngineGetRpcPort(serverEngine);
+  EXPECT_GT(port, 0) << "Bootstrap listen port should be > 0";
+}
+
+// ============================================================================
+// 2. Metadata / Port Discovery
+// ============================================================================
+
+TEST_F(P2pEngineRpcTest, GetRpcPortReturnsBootstrapPort) {
+  const int port = flagcxP2pEngineGetRpcPort(serverEngine);
+  EXPECT_GT(port, 0);
+}
+
+TEST_F(P2pEngineRpcTest, GetMetadataContainsIpAndPort) {
+  char *metaRaw = nullptr;
+  ASSERT_EQ(flagcxP2pEngineGetMetadata(serverEngine, &metaRaw), 0);
+  ASSERT_NE(metaRaw, nullptr);
+  std::unique_ptr<char[]> metadata(metaRaw);
+
+  ParsedMetadata parsed;
+  ASSERT_TRUE(parseMetadata(metadata.get(), &parsed))
+      << "metadata=" << metadata.get();
+
+  EXPECT_FALSE(parsed.ip.empty());
+  EXPECT_GT(parsed.port, 0);
+  EXPECT_GE(parsed.gpuIdx, -1);
+  EXPECT_GE(parsed.notifPort, 0);
+}
+
+TEST_F(P2pEngineRpcTest, GetMetadataRdmaPortDiffersFromRpcPort) {
+  char *metaRaw = nullptr;
+  ASSERT_EQ(flagcxP2pEngineGetMetadata(serverEngine, &metaRaw), 0);
+  std::unique_ptr<char[]> metadata(metaRaw);
+
+  ParsedMetadata parsed;
+  ASSERT_TRUE(parseMetadata(metadata.get(), &parsed));
+
+  const int rpcPort = flagcxP2pEngineGetRpcPort(serverEngine);
+  // The IB RDMA listen port (in metadata) should differ from the bootstrap
+  // RPC port, since they're separate listeners
+  EXPECT_NE(parsed.port, rpcPort)
+      << "IB listen port should not equal bootstrap RPC port";
+}
+
+// ============================================================================
+// 3. Connect / Accept handshake
+// ============================================================================
+
+TEST_F(P2pEngineRpcTest, ConnectAcceptBasic) {
+  connectViaBsPort();
+  EXPECT_NE(clientConn, nullptr);
+  EXPECT_NE(serverConn, nullptr);
+}
+
+TEST_F(P2pEngineRpcTest, ConnectAcceptExchangesGpuIdx) {
+  connectViaBsPort();
+  // Check that remote GPU index was exchanged on accept side
+  EXPECT_GE(acceptedRemoteGpuIdx, -1);
+  // Both connections are non-null (verified in connectViaBsPort)
+  EXPECT_NE(clientConn, nullptr);
+  EXPECT_NE(serverConn, nullptr);
+}
+
+TEST_F(P2pEngineRpcTest, ConnectAcceptIsLocalSameHost) {
+  connectViaBsPort();
+  // Single-host test — both sides should detect local connection
+  EXPECT_TRUE(flagcxP2pEngineConnIsLocal(serverConn));
+  EXPECT_TRUE(flagcxP2pEngineConnIsLocal(clientConn));
+}
+
+TEST_F(P2pEngineRpcTest, ConnectToInvalidHostReturnsNull) {
+  // RFC 5737 TEST-NET-1: 192.0.2.0/24 — reserved, unreachable
+  FlagcxP2pConn *conn =
+      flagcxP2pEngineConnect(clientEngine, "192.0.2.1", -1, 12345, false);
+  EXPECT_EQ(conn, nullptr);
+}
+
+TEST_F(P2pEngineRpcTest, ConnectToInvalidPortReturnsNull) {
+  // Connect to localhost:1 (privileged, nothing listening)
+  FlagcxP2pConn *conn =
+      flagcxP2pEngineConnect(clientEngine, "127.0.0.1", -1, 1, false);
+  EXPECT_EQ(conn, nullptr);
+}
+
+TEST_F(P2pEngineRpcTest, AcceptAfterStopReturnsNull) {
+  flagcxP2pEngineStopAccept(serverEngine);
+  char ipBuf[256] = {};
+  int remoteGpuIdx = -1;
+  // After StopAccept, engine->bsListenState is NULL, should return NULL
+  FlagcxP2pConn *conn =
+      flagcxP2pEngineAccept(serverEngine, ipBuf, sizeof(ipBuf), &remoteGpuIdx);
+  EXPECT_EQ(conn, nullptr);
+}
+
+// ============================================================================
+// 4. RPC Server (thread-based accept loop)
+// ============================================================================
+
+TEST_F(P2pEngineRpcTest, StartRpcServerTwiceIsIdempotent) {
+  ASSERT_EQ(flagcxP2pEngineStartRpcServer(serverEngine), 0);
+  ASSERT_EQ(flagcxP2pEngineStartRpcServer(serverEngine), 0);
+  // Second call should return 0 (already running)
+}
+
+TEST_F(P2pEngineRpcTest, GetConnCreatesConnection) {
+  ASSERT_EQ(flagcxP2pEngineStartRpcServer(serverEngine), 0);
+
+  char *metaRaw = nullptr;
+  ASSERT_EQ(flagcxP2pEngineGetMetadata(serverEngine, &metaRaw), 0);
+  std::unique_ptr<char[]> metadata(metaRaw);
+
+  ParsedMetadata parsed;
+  ASSERT_TRUE(parseMetadata(metadata.get(), &parsed));
+
+  const int serverRpcPort = flagcxP2pEngineGetRpcPort(serverEngine);
+  ASSERT_GT(serverRpcPort, 0);
+
+  char sessionKey[256];
+  snprintf(sessionKey, sizeof(sessionKey), "%s:%d", parsed.ip.c_str(),
+           serverRpcPort);
+
+  // GetConn should create and cache the connection
+  FlagcxP2pConn *conn = flagcxP2pEngineGetConn(clientEngine, sessionKey);
+  ASSERT_NE(conn, nullptr);
+
+  // Clean up accepted connection on server side
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+}
+
+TEST_F(P2pEngineRpcTest, GetConnReturnsCachedOnSecondCall) {
+  ASSERT_EQ(flagcxP2pEngineStartRpcServer(serverEngine), 0);
+
+  char *metaRaw = nullptr;
+  ASSERT_EQ(flagcxP2pEngineGetMetadata(serverEngine, &metaRaw), 0);
+  std::unique_ptr<char[]> metadata(metaRaw);
+
+  ParsedMetadata parsed;
+  ASSERT_TRUE(parseMetadata(metadata.get(), &parsed));
+
+  const int serverRpcPort = flagcxP2pEngineGetRpcPort(serverEngine);
+  char sessionKey[256];
+  snprintf(sessionKey, sizeof(sessionKey), "%s:%d", parsed.ip.c_str(),
+           serverRpcPort);
+
+  FlagcxP2pConn *conn1 = flagcxP2pEngineGetConn(clientEngine, sessionKey);
+  ASSERT_NE(conn1, nullptr);
+
+  FlagcxP2pConn *conn2 = flagcxP2pEngineGetConn(clientEngine, sessionKey);
+  EXPECT_EQ(conn1, conn2) << "Second GetConn should return cached connection";
+}
+
+TEST_F(P2pEngineRpcTest, GetConnInvalidSessionReturnsNull) {
+  FlagcxP2pConn *conn = flagcxP2pEngineGetConn(clientEngine, "no_colon");
+  EXPECT_EQ(conn, nullptr);
+}
+
+// ============================================================================
+// 5. Descriptor Table Exchange
+// ============================================================================
+
+TEST_F(P2pEngineRpcTest, DescTableExchangedOnConnect) {
+  connectViaBsPort();
+  // After handshake with no registered memory, MakeDesc should fail
+  // (no remote regions to map) — this indirectly confirms empty desc table
+  FlagcxP2pRdmaDesc desc;
+  int ret = flagcxP2pEngineMakeDesc(clientConn, 0x1000, 64, &desc);
+  EXPECT_NE(ret, 0) << "MakeDesc should fail with no registered memory";
+}
+
+// ============================================================================
+// 6. Connection Teardown
+// ============================================================================
+
+TEST(P2pEngineConnTeardown, ConnDestroyNullIsNoop) {
+  flagcxP2pEngineConnDestroy(nullptr);
+  // Should not crash
+}
+
+TEST_F(P2pEngineRpcTest, ConnDestroyAfterHandshake) {
+  connectViaBsPort();
+  flagcxP2pEngineConnDestroy(clientConn);
+  clientConn = nullptr;
+  flagcxP2pEngineConnDestroy(serverConn);
+  serverConn = nullptr;
+  // Should not crash or leak
+}
+
+TEST_F(P2pEngineRpcTest, StopAcceptThenDestroy) {
+  flagcxP2pEngineStopAccept(serverEngine);
+  flagcxP2pEngineDestroy(serverEngine);
+  serverEngine = nullptr;
+  // Should not deadlock or crash
+}
+
+} // namespace


### PR DESCRIPTION
### PR Category
CRL

### PR Types
New Features

### PR Description
This PR extends the bootstrap layer to support a new P2P mode (RPC-style listen/connect/accept) alongside the existing collective/ring bootstrap, and wires that into the IB P2P engine so control-plane metadata + descriptor-table exchange can occur over a bootstrap socket rather than over the IB data socket.