### PR TITLE
[PAL] fix p2p socket destruction issue

### DIFF
--- a/flagcx/adaptor/net/ibrc_p2p_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_p2p_adaptor.cc
@@ -68,6 +68,7 @@ static_assert(sizeof(struct flagcxP2pListenHandle) <= FLAGCX_NET_HANDLE_MAXSIZE,
 // P2P listen comm
 struct flagcxP2pListenComm {
   int dev;
+  volatile uint32_t abortFlag;
   struct flagcxSocket sock;
 };
 
@@ -245,9 +246,10 @@ static flagcxResult_t flagcxP2pListen(int dev, void *opaqueHandle,
       (struct flagcxP2pListenHandle *)opaqueHandle;
   memset(handle, 0, sizeof(struct flagcxP2pListenHandle));
   comm->dev = dev;
+  comm->abortFlag = 0;
   handle->magic = FLAGCX_SOCKET_MAGIC;
   FLAGCXCHECK(flagcxSocketInit(&comm->sock, &flagcxIbIfAddr, handle->magic,
-                               flagcxSocketTypeNetIb, NULL, 1));
+                               flagcxSocketTypeNetIb, &comm->abortFlag, 1));
   FLAGCXCHECK(flagcxSocketListen(&comm->sock));
   FLAGCXCHECK(flagcxSocketGetAddr(&comm->sock, &handle->connectAddr));
   *listenComm = comm;
@@ -490,6 +492,9 @@ connect_fail:
 static flagcxResult_t flagcxP2pAccept(void *listenComm, void **recvComm) {
   struct flagcxP2pListenComm *lComm = (struct flagcxP2pListenComm *)listenComm;
   *recvComm = NULL;
+  if (lComm == NULL ||
+      __atomic_load_n(&lComm->abortFlag, __ATOMIC_RELAXED) != 0)
+    return flagcxInternalError;
 
   // Allocate recv comm
   struct flagcxP2pRecvComm *comm;
@@ -502,18 +507,28 @@ static flagcxResult_t flagcxP2pAccept(void *listenComm, void **recvComm) {
   struct flagcxP2pConnMeta remoteMeta[kFlagcxP2pMaxQpsPerEngine];
   int localReady = 1, remoteReady = 0;
   uint32_t localNumQps = 0, remoteNumQps = 0, agreedNumQps = 0;
-  FLAGCXCHECKGOTO(flagcxSocketInit(&comm->sock), res, accept_fail);
-  FLAGCXCHECKGOTO(flagcxSocketAccept(&comm->sock, &lComm->sock), res,
-                  accept_fail);
+  FLAGCXCHECKGOTO(flagcxSocketInit(&comm->sock, NULL, FLAGCX_SOCKET_MAGIC,
+                                   flagcxSocketTypeNetIb, &lComm->abortFlag),
+                  res, accept_fail);
+  res = flagcxSocketAccept(&comm->sock, &lComm->sock);
+  if (res != flagcxSuccess)
+    goto accept_fail;
   ready = 0;
   while (!ready) {
-    FLAGCXCHECKGOTO(flagcxSocketReady(&comm->sock, &ready), res, accept_fail);
+    if (__atomic_load_n(&lComm->abortFlag, __ATOMIC_RELAXED) != 0) {
+      res = flagcxInternalError;
+      goto accept_fail;
+    }
+    res = flagcxSocketReady(&comm->sock, &ready);
+    if (res != flagcxSuccess)
+      goto accept_fail;
     if (!ready) {
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
   }
   if (0) {
   accept_fail:
+    flagcxSocketClose(&comm->sock);
     free(comm);
     return res;
   }
@@ -913,10 +928,19 @@ static flagcxResult_t flagcxP2pCloseRecv(void *recvComm) {
   return flagcxSuccess;
 }
 
+flagcxResult_t flagcxNetIbP2pAbortListen(void *listenComm) {
+  struct flagcxP2pListenComm *comm = (struct flagcxP2pListenComm *)listenComm;
+  if (comm) {
+    __atomic_store_n(&comm->abortFlag, 1, __ATOMIC_RELEASE);
+    FLAGCXCHECK(flagcxSocketClose(&comm->sock));
+  }
+  return flagcxSuccess;
+}
+
 static flagcxResult_t flagcxP2pCloseListen(void *listenComm) {
   struct flagcxP2pListenComm *comm = (struct flagcxP2pListenComm *)listenComm;
   if (comm) {
-    FLAGCXCHECK(flagcxSocketClose(&comm->sock));
+    FLAGCXCHECK(flagcxNetIbP2pAbortListen(comm));
     free(comm);
   }
   return flagcxSuccess;

--- a/flagcx/core/flagcx_p2p.cc
+++ b/flagcx/core/flagcx_p2p.cc
@@ -44,6 +44,7 @@
 #include <unistd.h>
 
 extern struct flagcxNetAdaptor flagcxNetIbP2p;
+extern flagcxResult_t flagcxNetIbP2pAbortListen(void *listenComm);
 
 extern "C" flagcxResult_t flagcxP2pSliceBatch(void *sendComm, struct ibv_qp *qp,
                                               int count, FlagcxSlice **slices);
@@ -273,6 +274,8 @@ struct FlagcxP2pEngine {
      during connect/accept handshake. */
   struct bootstrapState *bsListenState;
   int bsListenPort;
+  std::atomic<bool> stopAccept;
+  volatile uint32_t acceptAbortFlag;
 
   /* Control-plane RPC service: accept daemon + per-session connection
      cache (initiator side) + kept-alive accepted connections (server
@@ -1687,6 +1690,8 @@ FlagcxP2pEngine *flagcxP2pEngineCreate() {
   engine->stopRpcServer = false;
   engine->bsListenState = NULL;
   engine->bsListenPort = 0;
+  engine->stopAccept = false;
+  engine->acceptAbortFlag = 0;
   memset(engine->listeners, 0, sizeof(engine->listeners));
   memset(&engine->notifListenSock, 0, sizeof(engine->notifListenSock));
 
@@ -1753,8 +1758,8 @@ FlagcxP2pEngine *flagcxP2pEngineCreate() {
   struct bootstrapState *bsState = NULL;
   char bsListenHandle[FLAGCX_NET_HANDLE_MAXSIZE];
   memset(bsListenHandle, 0, sizeof(bsListenHandle));
-  if (bootstrapP2pListen(FLAGCX_SOCKET_MAGIC, NULL, bsListenHandle, &bsState) ==
-      flagcxSuccess) {
+  if (bootstrapP2pListen(FLAGCX_SOCKET_MAGIC, &engine->acceptAbortFlag,
+                         bsListenHandle, &bsState) == flagcxSuccess) {
     engine->bsListenState = bsState;
     union flagcxSocketAddress bsAddr;
     flagcxSocketGetAddr(&bsState->p2p->sock, &bsAddr);
@@ -1770,8 +1775,7 @@ void flagcxP2pEngineDestroy(FlagcxP2pEngine *engine) {
   if (engine == NULL)
     return;
 
-  engine->stopNotif = true;
-  engine->stopRpcServer = true;
+  flagcxP2pEngineStopAccept(engine);
   if (engine->notifListenActive) {
     flagcxSocketClose(&engine->notifListenSock);
     engine->notifListenActive = false;
@@ -1806,7 +1810,8 @@ void flagcxP2pEngineDestroy(FlagcxP2pEngine *engine) {
     }
   }
 
-  if (engine->rpcServerThread.joinable()) {
+  if (engine->rpcServerThread.joinable() &&
+      engine->rpcServerThread.get_id() != std::this_thread::get_id()) {
     engine->rpcServerThread.join();
   }
   {
@@ -1861,23 +1866,30 @@ void flagcxP2pEngineStopAccept(FlagcxP2pEngine *engine) {
   if (engine == NULL)
     return;
 
+  engine->stopAccept.store(true, std::memory_order_release);
   engine->stopNotif = true;
+  engine->stopRpcServer.store(true, std::memory_order_release);
+  __atomic_store_n(&engine->acceptAbortFlag, 1, __ATOMIC_RELEASE);
+
   if (engine->notifListenActive) {
     flagcxSocketClose(&engine->notifListenSock);
     engine->notifListenActive = false;
   }
 
-  if (engine->bsListenState) {
-    bootstrapClose(engine->bsListenState);
-    engine->bsListenState = NULL;
-    engine->bsListenPort = 0;
+  if (engine->bsListenState && engine->bsListenState->p2p) {
+    flagcxSocketClose(&engine->bsListenState->p2p->sock);
   }
 
   for (int d = 0; d < engine->nDevs; d++) {
     if (engine->listeners[d].listenComm) {
-      engine->adaptor->closeListen(engine->listeners[d].listenComm);
-      engine->listeners[d].listenComm = NULL;
+      flagcxNetIbP2pAbortListen(engine->listeners[d].listenComm);
     }
+  }
+
+  if (engine->rpcServerThread.joinable() &&
+      engine->rpcServerThread.get_id() != std::this_thread::get_id()) {
+    engine->rpcServerThread.join();
+    engine->rpcServerActive.store(false, std::memory_order_release);
   }
 }
 
@@ -2047,6 +2059,8 @@ FlagcxP2pConn *flagcxP2pEngineAccept(FlagcxP2pEngine *engine, char *ipAddrBuf,
                                      size_t ipAddrBufLen, int *remoteGpuIdx) {
   if (engine == NULL || ipAddrBuf == NULL || remoteGpuIdx == NULL)
     return NULL;
+  if (engine->stopAccept.load(std::memory_order_acquire))
+    return NULL;
 
   const int dev = chooseEngineNetDev(engine);
   if (engine->bsListenState == NULL)
@@ -2058,6 +2072,10 @@ FlagcxP2pConn *flagcxP2pEngineAccept(FlagcxP2pEngine *engine, char *ipAddrBuf,
   // Step 1: Accept bootstrap P2P connection from connector
   struct bootstrapState *bsConn = NULL;
   if (bootstrapP2pAccept(engine->bsListenState, &bsConn) != flagcxSuccess) {
+    return NULL;
+  }
+  if (engine->stopAccept.load(std::memory_order_acquire)) {
+    bootstrapClose(bsConn);
     return NULL;
   }
 
@@ -2077,6 +2095,10 @@ FlagcxP2pConn *flagcxP2pEngineAccept(FlagcxP2pEngine *engine, char *ipAddrBuf,
 
   // Step 3: Accept IB connection using the adaptor
   void *recvComm = NULL;
+  if (engine->stopAccept.load(std::memory_order_acquire)) {
+    bootstrapClose(bsConn);
+    return NULL;
+  }
   if (engine->adaptor->accept(engine->listeners[dev].listenComm, &recvComm) !=
       flagcxSuccess) {
     bootstrapClose(bsConn);
@@ -2719,6 +2741,7 @@ int flagcxP2pEngineStartRpcServer(FlagcxP2pEngine *engine) {
       std::lock_guard<std::mutex> lock(engine->acceptedMutex);
       engine->acceptedConns.push_back(conn);
     }
+    engine->rpcServerActive.store(false, std::memory_order_release);
   });
   INFO(FLAGCX_INIT, "NET/IB_P2P : RPC server thread started (port=%d)",
        flagcxP2pEngineGetRpcPort(engine));

--- a/flagcx/core/socket.cc
+++ b/flagcx/core/socket.cc
@@ -18,6 +18,11 @@
 #include <string.h>
 #include <unistd.h>
 
+static inline bool socketAbortRequested(struct flagcxSocket *sock) {
+  return sock != NULL && sock->abortFlag != NULL &&
+         __atomic_load_n(sock->abortFlag, __ATOMIC_RELAXED) != 0;
+}
+
 static flagcxResult_t socketProgressOpt(int op, struct flagcxSocket *sock,
                                         void *ptr, int size, int *offset,
                                         int block, int *closed) {
@@ -493,11 +498,16 @@ flagcxResult_t flagcxSocketGetAddr(struct flagcxSocket *sock,
 }
 
 static flagcxResult_t socketTryAccept(struct flagcxSocket *sock) {
+  if (socketAbortRequested(sock))
+    return flagcxInProgress;
+
   socklen_t socklen = sizeof(union flagcxSocketAddress);
   sock->fd = accept(sock->acceptFd, &sock->addr.sa, &socklen);
   if (sock->fd != -1) {
     sock->state = flagcxSocketStateAccepted;
   } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
+    if (socketAbortRequested(sock) && (errno == EBADF || errno == EINVAL))
+      return flagcxInProgress;
     WARN("socketTryAccept: Accept failed: %s", strerror(errno));
     return flagcxSystemError;
   }
@@ -684,6 +694,10 @@ flagcxResult_t flagcxSocketReady(struct flagcxSocket *sock, int *running) {
     *running = 0;
     return flagcxSuccess;
   }
+  if (socketAbortRequested(sock)) {
+    *running = 0;
+    return flagcxInternalError;
+  }
   if (sock->state == flagcxSocketStateError ||
       sock->state == flagcxSocketStateClosed) {
     WARN("flagcxSocketReady: unexpected socket state %d", sock->state);
@@ -735,7 +749,7 @@ flagcxResult_t flagcxSocketConnect(struct flagcxSocket *sock) {
             sock->state == flagcxSocketStateConnectPolling ||
             sock->state == flagcxSocketStateConnected));
 
-  if (sock->abortFlag && __atomic_load_n(sock->abortFlag, __ATOMIC_RELAXED))
+  if (socketAbortRequested(sock))
     return flagcxInternalError;
 
   switch (sock->state) {
@@ -762,6 +776,10 @@ flagcxResult_t flagcxSocketAccept(struct flagcxSocket *sock,
     goto exit;
   }
   if (listenSock->state != flagcxSocketStateReady) {
+    if (socketAbortRequested(listenSock)) {
+      ret = flagcxInternalError;
+      goto exit;
+    }
     WARN("flagcxSocketAccept: wrong socket state %d", listenSock->state);
     if (listenSock->state == flagcxSocketStateError)
       ret = flagcxSystemError;
@@ -784,7 +802,7 @@ flagcxResult_t flagcxSocketAccept(struct flagcxSocket *sock,
            (sock->state == flagcxSocketStateAccepting ||
             sock->state == flagcxSocketStateAccepted));
 
-  if (sock->abortFlag && __atomic_load_n(sock->abortFlag, __ATOMIC_RELAXED))
+  if (socketAbortRequested(sock))
     return flagcxInternalError;
 
   switch (sock->state) {

--- a/flagcx/service/bootstrap.cc
+++ b/flagcx/service/bootstrap.cc
@@ -1353,8 +1353,15 @@ flagcxResult_t bootstrapP2pAccept(struct bootstrapState *listenState,
   connP2p->abortFlag = listenP2p->abortFlag;
 
   // Accept incoming connection
-  FLAGCXCHECK(flagcxSocketInit(&connP2p->sock));
-  FLAGCXCHECK(flagcxSocketAccept(&connP2p->sock, &listenP2p->sock));
+  FLAGCXCHECK(flagcxSocketInit(&connP2p->sock, NULL, listenP2p->magic,
+                               flagcxSocketTypeBootstrap,
+                               listenP2p->abortFlag));
+  flagcxResult_t res = flagcxSocketAccept(&connP2p->sock, &listenP2p->sock);
+  if (res != flagcxSuccess) {
+    flagcxSocketClose(&connP2p->sock);
+    free(connP2p);
+    return res;
+  }
 
   // Wrap in state
   struct bootstrapState *wrapper;


### PR DESCRIPTION
### PR Category
<!-- One of [ UIL (User Interface Layer) | CRL (Communication Runtime Layer) | PAL (Portable Abstraction Layer) | CICD | Others ] -->
PAL
### PR Types
<!-- One of [ New Features | Bug Fixes | Optimizations | Deprecations | Test Case | Docs | Others ] -->
Bug Fixes
### PR Description
<!-- Describe what you’ve done -->
This PR fixes the socket destruction problem:
#### Root Cause
The P2P engine shutdown path closed and freed bootstrap/IB listen sockets while an accept loop could still be blocked on them. During teardown, accept() could observe a closed or
  invalid listener fd and return EINVAL/EBADF, which surfaced as noisy socket warnings even though data transfer had already completed successfully.

#### Solution
This PR adds an explicit accept-cancellation path for the FlagCX P2P engine. flagcxP2pEngineStopAccept() now signals accept shutdown, wakes bootstrap and IB accept loops via abort-
  enabled listen sockets, and joins the internal RPC accept thread before final resource cleanup. Listener resources are only freed during engine destruction after accept users have
  exited. The socket layer also treats abort-triggered accept failures as expected cancellation, avoiding false warning logs during normal teardown.