### PR TITLE
[CRL] Shard P2P QPs across per-worker CQs and pin worker threads to NIC-local CPUs

### DIFF
--- a/flagcx/adaptor/device/ducuda_adaptor.cc
+++ b/flagcx/adaptor/device/ducuda_adaptor.cc
@@ -301,13 +301,11 @@ flagcxResult_t ducudaAdaptorDmaSupport(bool *dmaBufferSupport) {
   return flagcxSuccess;
 }
 
-flagcxResult_t
-ducudaAdaptorMemGetHandleForAddressRange(void *handleOut, void *buffer,
-                                       size_t size, unsigned long long flags) {
-  //unsupportted on dcu
+flagcxResult_t ducudaAdaptorMemGetHandleForAddressRange(
+    void *handleOut, void *buffer, size_t size, unsigned long long flags) {
+  // unsupportted on dcu
   return flagcxNotSupported;
 }
-
 
 flagcxResult_t ducudaAdaptorGetDeviceProperties(struct flagcxDevProps *props,
                                                 int dev) {
@@ -348,7 +346,7 @@ flagcxResult_t ducudaAdaptorGetDeviceByPciBusId(int *dev,
 }
 
 flagcxResult_t ducudaAdaptorStreamWaitValue64(flagcxStream_t stream, void *addr,
-                                            uint64_t value, int flags) {
+                                              uint64_t value, int flags) {
   (void)flags;
   if (stream == NULL || addr == NULL)
     return flagcxInvalidArgument;
@@ -357,8 +355,9 @@ flagcxResult_t ducudaAdaptorStreamWaitValue64(flagcxStream_t stream, void *addr,
                                      CU_STREAM_WAIT_VALUE_GEQ);
   return (err == CUDA_SUCCESS) ? flagcxSuccess : flagcxUnhandledDeviceError;
 }
-flagcxResult_t ducudaAdaptorStreamWriteValue64(flagcxStream_t stream, void *addr,
-                                            uint64_t value, int flags) {
+flagcxResult_t ducudaAdaptorStreamWriteValue64(flagcxStream_t stream,
+                                               void *addr, uint64_t value,
+                                               int flags) {
   (void)flags;
   if (stream == NULL || addr == NULL)
     return flagcxInvalidArgument;
@@ -368,7 +367,7 @@ flagcxResult_t ducudaAdaptorStreamWriteValue64(flagcxStream_t stream, void *addr
   return (err == CUDA_SUCCESS) ? flagcxSuccess : flagcxUnhandledDeviceError;
 }
 flagcxResult_t ducudaAdaptorEventElapsedTime(float *ms, flagcxEvent_t start,
-                                           flagcxEvent_t end) {
+                                             flagcxEvent_t end) {
   if (ms == NULL || start == NULL || end == NULL) {
     return flagcxInvalidArgument;
   }
@@ -394,8 +393,10 @@ flagcxResult_t ducudaAdaptorHostUnregister(void *ptr) {
 
 // Symmetric memory VMM stubs (not supported)
 flagcxResult_t ducudaAdaptorSymPhysAlloc(void *ptr, size_t size,
-                                       void **physHandle, void *shareableHandle,
-                                       size_t *handleSize, size_t *allocSize) {
+                                         void **physHandle,
+                                         void *shareableHandle,
+                                         size_t *handleSize,
+                                         size_t *allocSize) {
   if (ptr == NULL || physHandle == NULL || shareableHandle == NULL ||
       handleSize == NULL || allocSize == NULL)
     return flagcxInvalidArgument;
@@ -425,7 +426,7 @@ flagcxResult_t ducudaAdaptorSymPhysAlloc(void *ptr, size_t size,
   *physHandle = cuHandle;
   return flagcxSuccess;
 }
-flagcxResult_t ducudaAdaptorSymPhysFree(void *physHandle) { 
+flagcxResult_t ducudaAdaptorSymPhysFree(void *physHandle) {
   if (physHandle == NULL)
     return flagcxSuccess;
   CUmemGenericAllocationHandle *cuHandle =
@@ -435,8 +436,8 @@ flagcxResult_t ducudaAdaptorSymPhysFree(void *physHandle) {
   return flagcxSuccess;
 }
 flagcxResult_t ducudaAdaptorSymFlatMap(void *peerHandles[], int nPeers,
-                                     int selfIndex, void *selfPhysHandle,
-                                     size_t allocSize, void **flatBase) {
+                                       int selfIndex, void *selfPhysHandle,
+                                       size_t allocSize, void **flatBase) {
   if (peerHandles == NULL || selfPhysHandle == NULL || flatBase == NULL ||
       nPeers <= 0 || allocSize == 0)
     return flagcxInvalidArgument;
@@ -481,7 +482,7 @@ flagcxResult_t ducudaAdaptorSymFlatMap(void *peerHandles[], int nPeers,
   return flagcxSuccess;
 }
 flagcxResult_t ducudaAdaptorSymFlatUnmap(void *flatBase, size_t allocSize,
-                                       int nPeers) {
+                                         int nPeers) {
   if (flatBase == NULL)
     return flagcxSuccess;
   CUdeviceptr base = (CUdeviceptr)flatBase;
@@ -494,16 +495,16 @@ flagcxResult_t ducudaAdaptorSymMulticastSupported(int *supported) {
   // not supported on dcu
   if (supported == NULL)
     return flagcxInvalidArgument;
-  
+
   if (supported)
     *supported = 0;
   return flagcxSuccess;
 }
 flagcxResult_t ducudaAdaptorSymMulticastCreate(size_t allocSize,
-                                             int nLocalDevices,
-                                             const int *localDeviceOrdinals,
-                                             void **mcHandle,
-                                             int *shareableFd) {
+                                               int nLocalDevices,
+                                               const int *localDeviceOrdinals,
+                                               void **mcHandle,
+                                               int *shareableFd) {
   // not supported on dcu
   if (mcHandle)
     *mcHandle = NULL;
@@ -514,9 +515,9 @@ flagcxResult_t ducudaAdaptorSymMulticastCreate(size_t allocSize,
   return flagcxNotSupported;
 }
 flagcxResult_t ducudaAdaptorSymMulticastBind(void *mcHandle, int importFd,
-                                           void *physHandle, size_t allocSize,
-                                           int localRank, int nLocalDevices,
-                                           void **mcBase, size_t *mcMapSize) {
+                                             void *physHandle, size_t allocSize,
+                                             int localRank, int nLocalDevices,
+                                             void **mcBase, size_t *mcMapSize) {
   // not supported on dcu
   if (mcBase)
     *mcBase = NULL;
@@ -526,7 +527,8 @@ flagcxResult_t ducudaAdaptorSymMulticastBind(void *mcHandle, int importFd,
 
   return flagcxNotSupported;
 }
-flagcxResult_t ducudaAdaptorSymMulticastTeardown(void *mcBase, size_t mcMapSize) {
+flagcxResult_t ducudaAdaptorSymMulticastTeardown(void *mcBase,
+                                                 size_t mcMapSize) {
   // not supported on dcu
   return flagcxSuccess;
 }
@@ -590,9 +592,13 @@ struct flagcxDeviceAdaptor ducudaAdaptor {
                                         // *dev, const char *pciBusId);
       ducudaAdaptorLaunchHostFunc,
       // DMA buffer
-      ducudaAdaptorDmaSupport, // flagcxResult_t (*dmaSupport)(bool *dmaBufferSupport);
-      ducudaAdaptorMemGetHandleForAddressRange, // flagcxResult_t (*memGetHandleForAddressRange)(void *handleOut,
-            // void *buffer, size_t size, unsigned long long flags);
+      ducudaAdaptorDmaSupport, // flagcxResult_t (*dmaSupport)(bool
+                               // *dmaBufferSupport);
+      ducudaAdaptorMemGetHandleForAddressRange, // flagcxResult_t
+                                                // (*memGetHandleForAddressRange)(void
+                                                // *handleOut, void *buffer,
+                                                // size_t size, unsigned long
+                                                // long flags);
       ducudaAdaptorHostRegister,   // flagcxResult_t (*hostRegister)(void *,
                                    // size_t);
       ducudaAdaptorHostUnregister, // flagcxResult_t (*hostUnregister)(void *);

--- a/flagcx/adaptor/net/ibrc_p2p_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_p2p_adaptor.cc
@@ -27,10 +27,11 @@
 #include <unistd.h>
 #include <vector>
 
-extern struct ibv_cq *flagcxP2pPoolGetSharedCq(int ibDevN,
-                                               struct ibv_context *ctx);
+extern struct ibv_cq *flagcxP2pPoolGetCq(int ibDevN, struct ibv_context *ctx,
+                                         int slot);
+extern int flagcxP2pPoolGetWorkerCount(int ibDevN, struct ibv_context *ctx);
 extern void flagcxP2pPoolRegisterQp(int ibDevN, void *sendComm,
-                                    struct ibv_qp *qp);
+                                    struct ibv_qp *qp, int slot);
 extern void flagcxP2pPoolUnregisterQp(int ibDevN, struct ibv_qp *qp);
 extern flagcxResult_t flagcxP2pPoolSubmit(int ibDevN, void *sendComm,
                                           FlagcxSlice **slices, int count);
@@ -276,16 +277,13 @@ static flagcxResult_t flagcxP2pSetupConn(int dev, void *outerComm,
   base->pd = ibDev->pd;
   pthread_mutex_unlock(&ibDev->lock);
 
-  // Step 0: pull the shared CQ from the per-ibDev WorkerPool. The pool is
-  // lazily created on first call (and lives for the process lifetime).
-  struct ibv_cq *sharedCq = flagcxP2pPoolGetSharedCq(ibDevN, ibDev->context);
-  if (sharedCq == NULL) {
-    WARN("NET/IB_P2P : pool[%d] returned NULL shared CQ", ibDevN);
+  int poolWorkers = flagcxP2pPoolGetWorkerCount(ibDevN, ibDev->context);
+  if (poolWorkers <= 0) {
+    WARN("NET/IB_P2P : pool[%d] has no worker CQs", ibDevN);
     flagcxP2pReleasePd(ibDevN);
     base->pd = NULL;
     return flagcxInternalError;
   }
-  base->cq = sharedCq;
 
   int accessFlags = IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ |
                     IBV_ACCESS_REMOTE_ATOMIC;
@@ -303,11 +301,18 @@ static flagcxResult_t flagcxP2pSetupConn(int dev, void *outerComm,
   base->gidInfo.linkLayer = ibDev->link;
 
   for (int i = 0; i < numQps; i++) {
+    int slot = i % poolWorkers;
+    base->cq = flagcxP2pPoolGetCq(ibDevN, ibDev->context, slot);
+    if (base->cq == NULL) {
+      WARN("NET/IB_P2P : pool[%d] NULL CQ for slot %d", ibDevN, slot);
+      res = flagcxInternalError;
+      goto setup_fail;
+    }
     FLAGCXCHECKGOTO(
         flagcxIbCreateQp(ibDev->portNum, base, accessFlags, &qp_list[i]), res,
         setup_fail);
     qp_list[i].devIndex = 0;
-    flagcxP2pPoolRegisterQp(ibDevN, outerComm, qp_list[i].qp);
+    flagcxP2pPoolRegisterQp(ibDevN, outerComm, qp_list[i].qp, slot);
   }
 
   return flagcxSuccess;

--- a/flagcx/adaptor/net/ibrc_p2p_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_p2p_adaptor.cc
@@ -26,11 +26,10 @@
 #include <unistd.h>
 #include <vector>
 
-extern struct ibv_cq *flagcxP2pPoolGetCq(int ibDevN, struct ibv_context *ctx,
-                                         int slot);
-extern int flagcxP2pPoolGetWorkerCount(int ibDevN, struct ibv_context *ctx);
+extern struct ibv_cq *flagcxP2pPoolGetSharedCq(int ibDevN,
+                                               struct ibv_context *ctx);
 extern void flagcxP2pPoolRegisterQp(int ibDevN, void *sendComm,
-                                    struct ibv_qp *qp, int slot);
+                                    struct ibv_qp *qp);
 extern void flagcxP2pPoolUnregisterQp(int ibDevN, struct ibv_qp *qp);
 extern flagcxResult_t flagcxP2pPoolSubmit(int ibDevN, void *sendComm,
                                           FlagcxSlice **slices, int count);
@@ -276,13 +275,16 @@ static flagcxResult_t flagcxP2pSetupConn(int dev, void *outerComm,
   base->pd = ibDev->pd;
   pthread_mutex_unlock(&ibDev->lock);
 
-  int poolWorkers = flagcxP2pPoolGetWorkerCount(ibDevN, ibDev->context);
-  if (poolWorkers <= 0) {
-    WARN("NET/IB_P2P : pool[%d] has no worker CQs", ibDevN);
+  // Step 0: pull the shared CQ from the per-ibDev WorkerPool. The pool is
+  // lazily created on first call (and lives for the process lifetime).
+  struct ibv_cq *sharedCq = flagcxP2pPoolGetSharedCq(ibDevN, ibDev->context);
+  if (sharedCq == NULL) {
+    WARN("NET/IB_P2P : pool[%d] returned NULL shared CQ", ibDevN);
     flagcxP2pReleasePd(ibDevN);
     base->pd = NULL;
     return flagcxInternalError;
   }
+  base->cq = sharedCq;
 
   int accessFlags = IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ |
                     IBV_ACCESS_REMOTE_ATOMIC;
@@ -300,18 +302,11 @@ static flagcxResult_t flagcxP2pSetupConn(int dev, void *outerComm,
   base->gidInfo.linkLayer = ibDev->link;
 
   for (int i = 0; i < numQps; i++) {
-    int slot = i % poolWorkers;
-    base->cq = flagcxP2pPoolGetCq(ibDevN, ibDev->context, slot);
-    if (base->cq == NULL) {
-      WARN("NET/IB_P2P : pool[%d] NULL CQ for slot %d", ibDevN, slot);
-      res = flagcxInternalError;
-      goto setup_fail;
-    }
     FLAGCXCHECKGOTO(
         flagcxIbCreateQp(ibDev->portNum, base, accessFlags, &qp_list[i]), res,
         setup_fail);
     qp_list[i].devIndex = 0;
-    flagcxP2pPoolRegisterQp(ibDevN, outerComm, qp_list[i].qp, slot);
+    flagcxP2pPoolRegisterQp(ibDevN, outerComm, qp_list[i].qp);
   }
 
   return flagcxSuccess;

--- a/flagcx/adaptor/net/ibrc_p2p_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_p2p_adaptor.cc
@@ -746,9 +746,9 @@ static inline enum ibv_wr_opcode flagcxSliceOpcodeToVerbs(uint8_t op) {
   return op == FLAGCX_SLICE_OP_READ ? IBV_WR_RDMA_READ : IBV_WR_RDMA_WRITE;
 }
 
-extern "C" flagcxResult_t
-flagcxP2pSliceBatch(void *sendComm, struct ibv_qp *qp, int count,
-                    FlagcxSlice **slices, int *failedCount) {
+extern "C" flagcxResult_t flagcxP2pSliceBatch(void *sendComm, struct ibv_qp *qp,
+                                              int count, FlagcxSlice **slices,
+                                              int *failedCount) {
   struct flagcxP2pSendComm *comm = (struct flagcxP2pSendComm *)sendComm;
   if (failedCount != NULL)
     *failedCount = 0;

--- a/flagcx/adaptor/net/ibrc_p2p_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_p2p_adaptor.cc
@@ -22,7 +22,6 @@
 #include <pthread.h>
 #include <stdint.h>
 #include <string.h>
-#include <string>
 #include <thread>
 #include <unistd.h>
 #include <vector>
@@ -634,7 +633,6 @@ flagcxP2pBuildSingleSliceReq(struct flagcxP2pSendComm *comm, uint64_t localVa,
   req->slice.lkey = lkey;
   req->slice.rkey = rkey;
   req->slice.opcode = opcode;
-  req->slice.peerNicPath = std::string();
   req->slice.task = &req->task;
   req->slice.qpDepth = NULL;
   req->task.sliceList.push_back(&req->slice);
@@ -715,7 +713,6 @@ flagcxP2pIgetBatch(void *sendComm, int count, const uint64_t *srcOffs,
                               dst->lkey,
                               src->rkey,
                               FLAGCX_SLICE_OP_READ,
-                              std::string(),
                               &req->task,
                               NULL};
     req->task.sliceList.push_back(s);
@@ -749,9 +746,12 @@ static inline enum ibv_wr_opcode flagcxSliceOpcodeToVerbs(uint8_t op) {
   return op == FLAGCX_SLICE_OP_READ ? IBV_WR_RDMA_READ : IBV_WR_RDMA_WRITE;
 }
 
-extern "C" flagcxResult_t flagcxP2pSliceBatch(void *sendComm, struct ibv_qp *qp,
-                                              int count, FlagcxSlice **slices) {
+extern "C" flagcxResult_t
+flagcxP2pSliceBatch(void *sendComm, struct ibv_qp *qp, int count,
+                    FlagcxSlice **slices, int *failedCount) {
   struct flagcxP2pSendComm *comm = (struct flagcxP2pSendComm *)sendComm;
+  if (failedCount != NULL)
+    *failedCount = 0;
   const char *opLabel = (slices != NULL && count > 0 && slices[0] != NULL &&
                          slices[0]->opcode == FLAGCX_SLICE_OP_READ)
                             ? "READ"
@@ -762,23 +762,50 @@ extern "C" flagcxResult_t flagcxP2pSliceBatch(void *sendComm, struct ibv_qp *qp,
     WARN("NET/IB_P2P : invalid sliceBatch arguments (op=%s, count=%d, qp=%p, "
          "max=%d)",
          opLabel, count, (void *)qp, maxWrPerPost);
+    int failed = 0;
+    if (slices != NULL && count > 0) {
+      for (int i = 0; i < count; i++) {
+        if (slices[i] != NULL) {
+          if (slices[i]->qpDepth != NULL)
+            __sync_fetch_and_sub(slices[i]->qpDepth, 1);
+          slices[i]->markFailed();
+          failed++;
+        }
+      }
+    }
+    if (failedCount != NULL)
+      *failedCount = failed;
     return flagcxInternalError;
   }
 
-  // count can be up to flagcxP2pGlobalConfig().maxWrPerPost (default 256,
-  // bounded at 1024). Heap-allocate to keep the stack small.
-  std::vector<struct ibv_send_wr> wrs(count);
-  std::vector<struct ibv_sge> sges(count);
+  static thread_local std::vector<struct ibv_send_wr> wrScratch;
+  static thread_local std::vector<struct ibv_sge> sgeScratch;
+  if ((int)wrScratch.size() < maxWrPerPost) {
+    wrScratch.resize(maxWrPerPost);
+    sgeScratch.resize(maxWrPerPost);
+  }
+  struct ibv_send_wr *wrs = wrScratch.data();
+  struct ibv_sge *sges = sgeScratch.data();
+  memset(wrs, 0, sizeof(*wrs) * count);
 
   for (int i = 0; i < count; i++) {
     FlagcxSlice *s = slices[i];
     if (s == NULL) {
       WARN("NET/IB_P2P : sliceBatch slice[%d] is NULL", i);
-      for (int k = 0; k < i; k++)
+      for (int k = 0; k < i; k++) {
+        if (slices[k]->qpDepth != NULL)
+          __sync_fetch_and_sub(slices[k]->qpDepth, 1);
         slices[k]->markFailed();
-      for (int k = i; k < count; k++)
-        if (slices[k])
+      }
+      for (int k = i; k < count; k++) {
+        if (slices[k]) {
+          if (slices[k]->qpDepth != NULL)
+            __sync_fetch_and_sub(slices[k]->qpDepth, 1);
           slices[k]->markFailed();
+        }
+      }
+      if (failedCount != NULL)
+        *failedCount = count;
       return flagcxInternalError;
     }
 
@@ -797,11 +824,11 @@ extern "C" flagcxResult_t flagcxP2pSliceBatch(void *sendComm, struct ibv_qp *qp,
   }
 
   struct ibv_send_wr *bad_wr = NULL;
-  flagcxResult_t res = flagcxWrapIbvPostSend(qp, &wrs[0], &bad_wr);
+  flagcxResult_t res = flagcxWrapIbvPostSend(qp, wrs, &bad_wr);
   if (res != flagcxSuccess) {
     int failedFrom = 0;
     if (bad_wr != NULL) {
-      ptrdiff_t off = bad_wr - &wrs[0];
+      ptrdiff_t off = bad_wr - wrs;
       if (off >= 0 && off < count)
         failedFrom = (int)off;
     }
@@ -812,6 +839,8 @@ extern "C" flagcxResult_t flagcxP2pSliceBatch(void *sendComm, struct ibv_qp *qp,
         __sync_fetch_and_sub(slices[k]->qpDepth, 1);
       slices[k]->markFailed();
     }
+    if (failedCount != NULL)
+      *failedCount = count - failedFrom;
     WARN("NET/IB_P2P : sliceBatch ibv_post_send failed (op=%s, count=%d, "
          "failedFrom=%d)",
          opLabel, count, failedFrom);

--- a/flagcx/core/flagcx_p2p.cc
+++ b/flagcx/core/flagcx_p2p.cc
@@ -577,15 +577,6 @@ FlagcxWorkerPool::FlagcxWorkerPool(int ibDevN, struct ibv_context *ctx)
   maxWrPerPost_ = C.maxWrPerPost;
   batchPollSize_ = C.batchPollSize;
 
-  if (numWorkers_ > 0 && numShards_ % numWorkers_ != 0) {
-    int rounded = ((numShards_ + numWorkers_ - 1) / numWorkers_) * numWorkers_;
-    INFO(FLAGCX_INIT,
-         "NET/IB_P2P : pool[%d] rounded shardCount %d → %d for even "
-         "worker assignment (W=%d)",
-         ibDevN_, numShards_, rounded, numWorkers_);
-    numShards_ = rounded;
-  }
-
   if (numWorkers_ > 0 && C.qpsPerConn % numWorkers_ != 0) {
     WARN("NET/IB_P2P : pool[%d] qpsPerEngine=%d not divisible by "
          "workersPerPool=%d — QPs spread per connection but unevenly; some "
@@ -779,30 +770,27 @@ flagcxResult_t FlagcxWorkerPool::submitPostSend(void *sendComm,
     std::this_thread::yield();
   }
 
-  std::vector<std::vector<FlagcxSlice *>> perShard(numShards_);
-  int enqueued = 0;
-  for (int i = 0; i < count; i++) {
-    if (slices[i] == nullptr)
-      continue;
-    const int shard = static_cast<int>(
-        shardRoundRobin_.fetch_add(1, std::memory_order_relaxed) %
-        static_cast<uint64_t>(numShards_));
-    perShard[shard].push_back(slices[i]);
-    enqueued++;
+  const int fanout = std::min(numShards_, count);
+  int shard = 0;
+  if (fanout != numShards_) {
+    shard = static_cast<int>(shardRoundRobin_.fetch_add(
+                                 fanout, std::memory_order_relaxed) %
+                             static_cast<uint64_t>(numShards_));
   }
-  if (enqueued == 0)
-    return flagcxSuccess;
-
-  for (int s = 0; s < numShards_; s++) {
-    if (perShard[s].empty())
-      continue;
-    std::lock_guard<std::mutex> lk(slice_locks_[s]);
-    auto &vec = slice_queues_[s][sendComm];
-    vec.insert(vec.end(), perShard[s].begin(), perShard[s].end());
-    slice_queue_count_[s].fetch_add((int)perShard[s].size(),
-                                    std::memory_order_relaxed);
+  int offset = 0;
+  for (int i = 0; i < fanout; i++) {
+    const int remaining = count - offset;
+    const int shardsLeft = fanout - i;
+    const int take = (remaining + shardsLeft - 1) / shardsLeft;
+    std::lock_guard<std::mutex> lk(slice_locks_[shard]);
+    auto &vec = slice_queues_[shard][sendComm];
+    vec.insert(vec.end(), slices + offset, slices + offset + take);
+    slice_queue_count_[shard].fetch_add(take, std::memory_order_relaxed);
+    offset += take;
+    if (++shard == numShards_)
+      shard = 0;
   }
-  submitted_.fetch_add(enqueued, std::memory_order_release);
+  submitted_.fetch_add(count, std::memory_order_release);
 
   if (suspended_flag_.load(std::memory_order_acquire) > 0) {
     std::lock_guard<std::mutex> lk(cv_mu_);

--- a/flagcx/core/flagcx_p2p.cc
+++ b/flagcx/core/flagcx_p2p.cc
@@ -773,9 +773,9 @@ flagcxResult_t FlagcxWorkerPool::submitPostSend(void *sendComm,
   const int fanout = std::min(numShards_, count);
   int shard = 0;
   if (fanout != numShards_) {
-    shard = static_cast<int>(shardRoundRobin_.fetch_add(
-                                 fanout, std::memory_order_relaxed) %
-                             static_cast<uint64_t>(numShards_));
+    shard = static_cast<int>(
+        shardRoundRobin_.fetch_add(fanout, std::memory_order_relaxed) %
+        static_cast<uint64_t>(numShards_));
   }
   int offset = 0;
   for (int i = 0; i < fanout; i++) {

--- a/flagcx/core/flagcx_p2p.cc
+++ b/flagcx/core/flagcx_p2p.cc
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -469,13 +470,11 @@ public:
   FlagcxWorkerPool(const FlagcxWorkerPool &) = delete;
   FlagcxWorkerPool &operator=(const FlagcxWorkerPool &) = delete;
 
-  struct ibv_cq *cqForSlot(int slot) const {
-    if (cqs_.empty())
-      return nullptr;
-    return cqs_[(size_t)slot % cqs_.size()];
+  struct ibv_cq *getSharedCq() const {
+    return shared_cq_;
   }
   int workerCount() const { return numWorkers_; }
-  void registerQp(void *sendComm, struct ibv_qp *qp, int slot);
+  void registerQp(void *sendComm, struct ibv_qp *qp);
   void unregisterQp(struct ibv_qp *qp);
 
   flagcxResult_t submitPostSend(void *sendComm, FlagcxSlice **slices,
@@ -487,15 +486,19 @@ public:
 private:
   void transferWorkerLoop(int tid);
   void performPostSend(int tid);
-  void performPollCq(int tid);
+  void performPollCq();
   void notifWorkerLoop();
 
   void pinToNicCpus(const char *role, int id);
+  static uint64_t nowNs() {
+    using clk = std::chrono::steady_clock;
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               clk::now().time_since_epoch())
+        .count();
+  }
 
   int ibDevN_;
-  std::vector<struct ibv_cq *>
-      cqs_; // one CQ per worker; worker t polls cqs_[t]
-
+  struct ibv_cq *shared_cq_ = nullptr;
   cpu_set_t cpuAffinity_;
   bool hasCpuAffinity_ = false;
 
@@ -506,22 +509,24 @@ private:
   int maxWrDepth_ = 0;
 
   std::mutex qp_mu_;
-  std::atomic<uint64_t> qpGen_{1};
   std::vector<std::unique_ptr<PoolQpEntry>> qpEntries_;
   std::unordered_map<uint32_t, int> qpNumToIdx_;
+  std::vector<std::vector<int>> workerQpIdx_;
   std::vector<size_t> workerQpCursor_;
-  std::vector<std::vector<PoolQpEntry *>> workerQpCache_;
-  std::vector<uint64_t> workerQpCacheGen_;
-  std::vector<int> workerQpMaxDepth_;
+  std::unordered_map<void *, int> connQpRegCount_;
   std::vector<std::unordered_map<void *, std::vector<FlagcxSlice *>>>
       slice_queues_;
   std::unique_ptr<std::mutex[]> slice_locks_;
   std::unique_ptr<std::atomic<int>[]> slice_queue_count_;
+  std::atomic<uint64_t> shardRoundRobin_{0};
   std::vector<std::unordered_map<void *, PendingSliceQueue>>
       collective_slice_queue_;
 
   std::atomic<uint64_t> submitted_{0};
   std::atomic<uint64_t> processed_{0};
+  std::atomic<int> suspended_flag_{0};
+  std::condition_variable cv_;
+  std::mutex cv_mu_;
 
   std::atomic<bool> running_{true};
   std::vector<std::thread> transferThreads_;
@@ -588,21 +593,17 @@ FlagcxWorkerPool::FlagcxWorkerPool(int ibDevN, struct ibv_context *ctx)
          ibDevN_, C.qpsPerConn, numWorkers_);
   }
 
-  cqs_.resize(numWorkers_, nullptr);
-  for (int t = 0; t < numWorkers_; t++) {
-    flagcxResult_t res = flagcxWrapIbvCreateCq(
-        &cqs_[t], ctx, (int)C.sharedCqDepth, NULL, NULL, 0);
-    if (res != flagcxSuccess || cqs_[t] == nullptr) {
-      WARN("NET/IB_P2P : pool[%d] failed to create CQ %d/%d", ibDevN_, t,
-           numWorkers_);
-      cqs_.clear();
-      return;
-    }
+  flagcxResult_t res = flagcxWrapIbvCreateCq(
+      &shared_cq_, ctx, (int)C.sharedCqDepth, NULL, NULL, 0);
+  if (res != flagcxSuccess) {
+    WARN("NET/IB_P2P : pool[%d] failed to create shared CQ", ibDevN_);
+    shared_cq_ = nullptr;
+    return;
   }
   INFO(FLAGCX_INIT,
-       "NET/IB_P2P : pool[%d] %d per-worker CQs created (depth=%zu, "
+       "NET/IB_P2P : pool[%d] shared CQ created (depth=%zu, workers=%d, "
        "shards=%d, qpsPerConn=%d)",
-       ibDevN_, numWorkers_, C.sharedCqDepth, numShards_, C.qpsPerConn);
+       ibDevN_, C.sharedCqDepth, numWorkers_, numShards_, C.qpsPerConn);
 
   slice_queues_.resize(numShards_);
   slice_locks_.reset(new std::mutex[numShards_]);
@@ -610,10 +611,8 @@ FlagcxWorkerPool::FlagcxWorkerPool(int ibDevN, struct ibv_context *ctx)
   for (int s = 0; s < numShards_; s++)
     slice_queue_count_[s].store(0, std::memory_order_relaxed);
 
+  workerQpIdx_.resize(numWorkers_);
   workerQpCursor_.assign(numWorkers_, 0);
-  workerQpCache_.resize(numWorkers_);
-  workerQpCacheGen_.assign(numWorkers_, 0);
-  workerQpMaxDepth_.assign(numWorkers_, 0);
   collective_slice_queue_.resize(numWorkers_);
 
   hasCpuAffinity_ = flagcxP2pGetNicCpuset(ctx, &cpuAffinity_);
@@ -626,6 +625,7 @@ FlagcxWorkerPool::FlagcxWorkerPool(int ibDevN, struct ibv_context *ctx)
 
 FlagcxWorkerPool::~FlagcxWorkerPool() {
   running_.store(false, std::memory_order_release);
+  cv_.notify_all();
   for (auto &t : transferThreads_) {
     if (t.joinable())
       t.join();
@@ -702,7 +702,7 @@ void FlagcxWorkerPool::notifWorkerLoop() {
   notifPollThreadFunc(engine_);
 }
 
-void FlagcxWorkerPool::registerQp(void *sendComm, struct ibv_qp *qp, int slot) {
+void FlagcxWorkerPool::registerQp(void *sendComm, struct ibv_qp *qp) {
   if (!qp || numWorkers_ <= 0)
     return;
 
@@ -733,10 +733,9 @@ void FlagcxWorkerPool::registerQp(void *sendComm, struct ibv_qp *qp, int slot) {
   qpEntries_.emplace_back(new PoolQpEntry(qp, sendComm));
   qpNumToIdx_[qp->qp_num] = idx;
 
-  // The slot still selects this QP's CQ at creation time. Posting ownership is
-  // endpoint-affine, so the owner worker may post any QP of the connection.
-  (void)slot;
-  qpGen_.fetch_add(1, std::memory_order_release);
+  int connIdx = connQpRegCount_[sendComm]++;
+  int slot = connIdx % numWorkers_;
+  workerQpIdx_[slot].push_back(idx);
 }
 
 void FlagcxWorkerPool::unregisterQp(struct ibv_qp *qp) {
@@ -748,11 +747,21 @@ void FlagcxWorkerPool::unregisterQp(struct ibv_qp *qp) {
     return;
   int idx = it->second;
   qpNumToIdx_.erase(it);
+  void *sc = qpEntries_[idx]->sendComm;
+  for (auto &shard : workerQpIdx_) {
+    auto vit = std::find(shard.begin(), shard.end(), idx);
+    if (vit != shard.end()) {
+      shard.erase(vit);
+      break;
+    }
+  }
+  auto cit = connQpRegCount_.find(sc);
+  if (cit != connQpRegCount_.end() && --cit->second <= 0)
+    connQpRegCount_.erase(cit);
   // Slot kept alive (NULL'd) so any in-flight slice's qpDepth pointer stays
   // valid.
   qpEntries_[idx]->qp = nullptr;
   qpEntries_[idx]->sendComm = nullptr;
-  qpGen_.fetch_add(1, std::memory_order_release);
 }
 
 flagcxResult_t FlagcxWorkerPool::submitPostSend(void *sendComm,
@@ -761,33 +770,73 @@ flagcxResult_t FlagcxWorkerPool::submitPostSend(void *sendComm,
   if (count <= 0 || slices == nullptr)
     return flagcxSuccess;
 
-  const uintptr_t endpointKey = reinterpret_cast<uintptr_t>(sendComm) >> 4;
-  const int shard = static_cast<int>((endpointKey * 10007ull) %
-                                     static_cast<uint64_t>(numShards_));
-
-  {
-    std::lock_guard<std::mutex> lk(slice_locks_[shard]);
-    auto &vec = slice_queues_[shard][sendComm];
-    vec.insert(vec.end(), slices, slices + count);
-    slice_queue_count_[shard].fetch_add(count, std::memory_order_relaxed);
+  // Backpressure: spin-yield until in-flight count drops below threshold.
+  // Prevents unbounded queue growth under sustained submission bursts.
+  const size_t maxPending = flagcxP2pGlobalConfig().maxRequests * 4;
+  while (submitted_.load(std::memory_order_acquire) -
+             processed_.load(std::memory_order_acquire) >
+         maxPending) {
+    std::this_thread::yield();
   }
-  submitted_.fetch_add(count, std::memory_order_release);
+
+  std::vector<std::vector<FlagcxSlice *>> perShard(numShards_);
+  int enqueued = 0;
+  for (int i = 0; i < count; i++) {
+    if (slices[i] == nullptr)
+      continue;
+    const int shard = static_cast<int>(
+        shardRoundRobin_.fetch_add(1, std::memory_order_relaxed) %
+        static_cast<uint64_t>(numShards_));
+    perShard[shard].push_back(slices[i]);
+    enqueued++;
+  }
+  if (enqueued == 0)
+    return flagcxSuccess;
+
+  for (int s = 0; s < numShards_; s++) {
+    if (perShard[s].empty())
+      continue;
+    std::lock_guard<std::mutex> lk(slice_locks_[s]);
+    auto &vec = slice_queues_[s][sendComm];
+    vec.insert(vec.end(), perShard[s].begin(), perShard[s].end());
+    slice_queue_count_[s].fetch_add((int)perShard[s].size(),
+                                    std::memory_order_relaxed);
+  }
+  submitted_.fetch_add(enqueued, std::memory_order_release);
+
+  if (suspended_flag_.load(std::memory_order_acquire) > 0) {
+    std::lock_guard<std::mutex> lk(cv_mu_);
+    cv_.notify_all();
+  }
   return flagcxSuccess;
 }
 
 void FlagcxWorkerPool::transferWorkerLoop(int tid) {
   pinToNicCpus("transferWorker", tid);
+  const static uint64_t kWaitPeriodInNano = 100ull * 1000 * 1000; // 100ms
+  uint64_t last_wait_ts = nowNs();
 
   while (running_.load(std::memory_order_relaxed)) {
     auto processed_slice_count = processed_.load(std::memory_order_relaxed);
     auto submitted_slice_count = submitted_.load(std::memory_order_relaxed);
 
     if (processed_slice_count == submitted_slice_count) {
+      uint64_t curr_wait_ts = nowNs();
+      if (curr_wait_ts - last_wait_ts > kWaitPeriodInNano) {
+        std::unique_lock<std::mutex> lock(cv_mu_);
+        suspended_flag_.fetch_add(1);
+        if (processed_.load(std::memory_order_relaxed) ==
+            submitted_.load(std::memory_order_relaxed)) {
+          cv_.wait_for(lock, std::chrono::seconds(1));
+        }
+        suspended_flag_.fetch_sub(1);
+        last_wait_ts = curr_wait_ts;
+      }
       continue;
     }
 
     performPostSend(tid);
-    performPollCq(tid);
+    performPollCq();
   }
 }
 
@@ -810,19 +859,15 @@ void FlagcxWorkerPool::performPostSend(int tid) {
     slice_queue_count_[s].store(0, std::memory_order_relaxed);
   }
 
-  const uint64_t gen = qpGen_.load(std::memory_order_acquire);
-  if (workerQpCacheGen_[tid] != gen) {
+  std::vector<PoolQpEntry *> myQpEntries;
+  int curMaxDepth;
+  {
     std::lock_guard<std::mutex> lk(qp_mu_);
-    auto &cache = workerQpCache_[tid];
-    cache.clear();
-    cache.reserve(qpEntries_.size());
-    for (auto &entry : qpEntries_)
-      cache.push_back(entry.get());
-    workerQpMaxDepth_[tid] = maxWrDepth_;
-    workerQpCacheGen_[tid] = gen;
+    myQpEntries.reserve(workerQpIdx_[tid].size());
+    for (int idx : workerQpIdx_[tid])
+      myQpEntries.push_back(qpEntries_[idx].get());
+    curMaxDepth = maxWrDepth_;
   }
-  std::vector<PoolQpEntry *> &myQpEntries = workerQpCache_[tid];
-  const int curMaxDepth = workerQpMaxDepth_[tid];
 
   size_t &cursor = workerQpCursor_[tid];
   for (auto &entry : local) {
@@ -897,17 +942,16 @@ void FlagcxWorkerPool::performPostSend(int tid) {
   }
 }
 
-void FlagcxWorkerPool::performPollCq(int tid) {
-  if (tid < 0 || tid >= (int)cqs_.size() || cqs_[tid] == nullptr)
+void FlagcxWorkerPool::performPollCq() {
+  if (shared_cq_ == nullptr)
     return;
-  struct ibv_cq *cq = cqs_[tid];
 
   constexpr int kMaxPollBatch = 256;
   struct ibv_wc wcs[kMaxPollBatch];
   int batch = (int)std::min<size_t>(batchPollSize_, kMaxPollBatch);
   int n = 0;
-  if (flagcxWrapIbvPollCq(cq, batch, wcs, &n) != flagcxSuccess) {
-    WARN("NET/IB_P2P : ibv_poll_cq failed on CQ %p (worker %d)", cq, tid);
+  if (flagcxWrapIbvPollCq(shared_cq_, batch, wcs, &n) != flagcxSuccess) {
+    WARN("NET/IB_P2P : ibv_poll_cq failed on shared CQ %p", shared_cq_);
     return;
   }
   if (n == 0)
@@ -963,24 +1007,17 @@ static FlagcxWorkerPool *lookupPool(int ibDevN) {
 } // namespace
 
 // ---- Hooks consumed by ibrc_p2p_adaptor.cc (forward-declared there). ----
-struct ibv_cq *flagcxP2pPoolGetCq(int ibDevN, struct ibv_context *ctx,
-                                  int slot) {
+struct ibv_cq *flagcxP2pPoolGetSharedCq(int ibDevN, struct ibv_context *ctx) {
   FlagcxWorkerPool *pool = getOrCreatePool(ibDevN, ctx);
-  return pool ? pool->cqForSlot(slot) : NULL;
+  return pool ? pool->getSharedCq() : NULL;
 }
 
-int flagcxP2pPoolGetWorkerCount(int ibDevN, struct ibv_context *ctx) {
-  FlagcxWorkerPool *pool = getOrCreatePool(ibDevN, ctx);
-  return pool ? pool->workerCount() : 0;
-}
-
-void flagcxP2pPoolRegisterQp(int ibDevN, void *sendComm, struct ibv_qp *qp,
-                             int slot) {
+void flagcxP2pPoolRegisterQp(int ibDevN, void *sendComm, struct ibv_qp *qp) {
   if (qp == nullptr)
     return;
   FlagcxWorkerPool *pool = lookupPool(ibDevN);
   if (pool)
-    pool->registerQp(sendComm, qp, slot);
+    pool->registerQp(sendComm, qp);
 }
 
 void flagcxP2pPoolUnregisterQp(int ibDevN, struct ibv_qp *qp) {

--- a/flagcx/core/flagcx_p2p.cc
+++ b/flagcx/core/flagcx_p2p.cc
@@ -47,9 +47,9 @@
 extern struct flagcxNetAdaptor flagcxNetIbP2p;
 extern flagcxResult_t flagcxNetIbP2pAbortListen(void *listenComm);
 
-extern "C" flagcxResult_t
-flagcxP2pSliceBatch(void *sendComm, struct ibv_qp *qp, int count,
-                    FlagcxSlice **slices, int *failedCount);
+extern "C" flagcxResult_t flagcxP2pSliceBatch(void *sendComm, struct ibv_qp *qp,
+                                              int count, FlagcxSlice **slices,
+                                              int *failedCount);
 
 namespace {
 
@@ -493,7 +493,8 @@ private:
   void pinToNicCpus(const char *role, int id);
 
   int ibDevN_;
-  std::vector<struct ibv_cq *> cqs_; // one CQ per worker; worker t polls cqs_[t]
+  std::vector<struct ibv_cq *>
+      cqs_; // one CQ per worker; worker t polls cqs_[t]
 
   cpu_set_t cpuAffinity_;
   bool hasCpuAffinity_ = false;
@@ -764,9 +765,8 @@ flagcxResult_t FlagcxWorkerPool::submitPostSend(void *sendComm,
   // endpoint (sendComm) goes to one stable shard, hence one posting worker.
   // Shift away allocator alignment bits before applying Mooncake's multiplier.
   const uintptr_t endpointKey = reinterpret_cast<uintptr_t>(sendComm) >> 4;
-  const int shard =
-      static_cast<int>((endpointKey * 10007ull) %
-                       static_cast<uint64_t>(numShards_));
+  const int shard = static_cast<int>((endpointKey * 10007ull) %
+                                     static_cast<uint64_t>(numShards_));
 
   {
     std::lock_guard<std::mutex> lk(slice_locks_[shard]);
@@ -887,9 +887,8 @@ void FlagcxWorkerPool::performPostSend(int tid) {
       }
 
       int failedCount = 0;
-      flagcxResult_t rc =
-          flagcxP2pSliceBatch(sc, chosen->qp, (int)take,
-                              pending.slices.data() + i, &failedCount);
+      flagcxResult_t rc = flagcxP2pSliceBatch(
+          sc, chosen->qp, (int)take, pending.slices.data() + i, &failedCount);
 
       if (rc != flagcxSuccess && failedCount > 0)
         processed_.fetch_add(failedCount, std::memory_order_release);
@@ -1038,7 +1037,6 @@ struct PoolTransferTask {
   }
 };
 
-
 static FlagcxP2pCommView *getCommView(void *comm) {
   return reinterpret_cast<FlagcxP2pCommView *>(comm);
 }
@@ -1063,9 +1061,9 @@ buildAndSubmitToPool(PoolTransferTask *task, const std::vector<void *> &dataVec,
         reinterpret_cast<FlagcxP2pMrHandleView *>(localEntries[i].mhandle);
     uint64_t localVa = (uintptr_t)dataVec[i];
     uint64_t remoteVa = descs[i].addr;
-    flagcxBuildSlicesRuntime(
-        &task->fx, localVa, remoteVa, sizeVec[i], localMr->lkey, descs[i].rkey,
-        opcode, sliceCfg.sliceSize, sliceCfg.fragmentLimit);
+    flagcxBuildSlicesRuntime(&task->fx, localVa, remoteVa, sizeVec[i],
+                             localMr->lkey, descs[i].rkey, opcode,
+                             sliceCfg.sliceSize, sliceCfg.fragmentLimit);
   }
 
   if (task->fx.sliceList.empty()) {
@@ -1127,7 +1125,6 @@ static void finalizePoolTask(PoolTransferTask *task) {
     sliceCache().deallocate(s);
   task->fx.sliceList.clear();
 }
-
 
 static bool findMemReg(uintptr_t addr, FlagcxP2pMemRegEntry *out) {
   for (std::unordered_map<uintptr_t, FlagcxP2pMemRegEntry>::const_iterator it =
@@ -2580,12 +2577,11 @@ int flagcxP2pEngineReadVector(FlagcxP2pConn *conn,
   const int connIbDevN = getCommView(conn->sendComm)->ibDevN;
   PoolTransferTask *task = acquirePoolTask();
 
-  if (!buildAndSubmitToPool(task, dstVec, sizeVec, descs, localEntries,
-                            numIovs, conn->sendComm, connIbDevN,
-                            FLAGCX_SLICE_OP_READ)) {
+  if (!buildAndSubmitToPool(task, dstVec, sizeVec, descs, localEntries, numIovs,
+                            conn->sendComm, connIbDevN, FLAGCX_SLICE_OP_READ)) {
     // sentinel so isAllDone() converges (needs total>0)
-    auto *sentinel = new FlagcxSlice{0, 0, 0, 0, 0, FLAGCX_SLICE_OP_READ,
-                                    &task->fx, nullptr};
+    auto *sentinel = new FlagcxSlice{
+        0, 0, 0, 0, 0, FLAGCX_SLICE_OP_READ, &task->fx, nullptr};
     task->fx.sliceList.push_back(sentinel);
     task->fx.sliceCount.fetch_add(1, std::memory_order_release);
     sentinel->markFailed();
@@ -2697,11 +2693,11 @@ int flagcxP2pEngineWriteVector(FlagcxP2pConn *conn,
   const int connIbDevN = getCommView(conn->sendComm)->ibDevN;
   PoolTransferTask *task = acquirePoolTask();
 
-  if (!buildAndSubmitToPool(task, dstVec, sizeVec, descs, localEntries,
-                            numIovs, conn->sendComm, connIbDevN,
+  if (!buildAndSubmitToPool(task, dstVec, sizeVec, descs, localEntries, numIovs,
+                            conn->sendComm, connIbDevN,
                             FLAGCX_SLICE_OP_WRITE)) {
-    auto *sentinel = new FlagcxSlice{0, 0, 0, 0, 0, FLAGCX_SLICE_OP_WRITE,
-                                    &task->fx, nullptr};
+    auto *sentinel = new FlagcxSlice{
+        0, 0, 0, 0, 0, FLAGCX_SLICE_OP_WRITE, &task->fx, nullptr};
     task->fx.sliceList.push_back(sentinel);
     task->fx.sliceCount.fetch_add(1, std::memory_order_release);
     sentinel->markFailed();
@@ -2941,11 +2937,10 @@ int flagcxP2pEngineMakeDesc(FlagcxP2pConn *conn, uint64_t remoteVa,
   return -1;
 }
 
-int flagcxP2pEngineWriteVectorSync(FlagcxP2pConn *conn,
-                                   const std::vector<FlagcxP2pMr> &mrIds,
-                                   const std::vector<void *> &srcVec,
-                                   const std::vector<size_t> &sizeVec,
-                                   const std::vector<FlagcxP2pRdmaDesc> &descs) {
+int flagcxP2pEngineWriteVectorSync(
+    FlagcxP2pConn *conn, const std::vector<FlagcxP2pMr> &mrIds,
+    const std::vector<void *> &srcVec, const std::vector<size_t> &sizeVec,
+    const std::vector<FlagcxP2pRdmaDesc> &descs) {
   if (conn == NULL)
     return -1;
   const int numIovs = static_cast<int>(srcVec.size());
@@ -3089,11 +3084,11 @@ int flagcxP2pRpcBatchWriteSync(void *connPtr, int count, const uint64_t *srcVa,
 
   const int connIbDevN = getCommView(conn->sendComm)->ibDevN;
   PoolTransferTask *task = acquirePoolTask();
-  if (!buildAndSubmitToPool(task, srcVec, sizeVec, descs, localEntries,
-                            count, conn->sendComm, connIbDevN,
+  if (!buildAndSubmitToPool(task, srcVec, sizeVec, descs, localEntries, count,
+                            conn->sendComm, connIbDevN,
                             FLAGCX_SLICE_OP_WRITE)) {
-    auto *sentinel = new FlagcxSlice{0, 0, 0, 0, 0, FLAGCX_SLICE_OP_WRITE,
-                                    &task->fx, nullptr};
+    auto *sentinel = new FlagcxSlice{
+        0, 0, 0, 0, 0, FLAGCX_SLICE_OP_WRITE, &task->fx, nullptr};
     task->fx.sliceList.push_back(sentinel);
     task->fx.sliceCount.fetch_add(1, std::memory_order_release);
     sentinel->markFailed();

--- a/flagcx/core/flagcx_p2p.cc
+++ b/flagcx/core/flagcx_p2p.cc
@@ -797,25 +797,12 @@ flagcxResult_t FlagcxWorkerPool::submitPostSend(void *sendComm,
 
 void FlagcxWorkerPool::transferWorkerLoop(int tid) {
   pinToNicCpus("transferWorker", tid);
-  const static uint64_t kWaitPeriodInNano = 100ull * 1000 * 1000; // 100ms
-  uint64_t last_wait_ts = nowNs();
 
   while (running_.load(std::memory_order_relaxed)) {
     auto processed_slice_count = processed_.load(std::memory_order_relaxed);
     auto submitted_slice_count = submitted_.load(std::memory_order_relaxed);
 
     if (processed_slice_count == submitted_slice_count) {
-      uint64_t curr_wait_ts = nowNs();
-      if (curr_wait_ts - last_wait_ts > kWaitPeriodInNano) {
-        std::unique_lock<std::mutex> lock(cv_mu_);
-        suspended_flag_.fetch_add(1);
-        if (processed_.load(std::memory_order_relaxed) ==
-            submitted_.load(std::memory_order_relaxed)) {
-          cv_.wait_for(lock, std::chrono::seconds(1));
-        }
-        suspended_flag_.fetch_sub(1);
-        last_wait_ts = curr_wait_ts;
-      }
       continue;
     }
 
@@ -905,6 +892,14 @@ void FlagcxWorkerPool::performPostSend(int tid) {
       volatile int *depthPtr = &chosen->wrDepth;
       __sync_fetch_and_add(depthPtr, (int)take);
 
+      FlagcxTransferTask *fxTask = pending[i]->task;
+      if (fxTask != nullptr) {
+        uint64_t expected = 0;
+        const uint64_t startNs = nowNs();
+        fxTask->postSendStartNs.compare_exchange_strong(
+            expected, startNs, std::memory_order_relaxed);
+      }
+
       std::vector<FlagcxSlice *> chunk;
       chunk.reserve(take);
       for (size_t k = 0; k < take; k++) {
@@ -913,8 +908,21 @@ void FlagcxWorkerPool::performPostSend(int tid) {
         chunk.push_back(sl);
       }
 
+      const uint64_t postSendBeginNs = nowNs();
       flagcxResult_t rc =
           flagcxP2pSliceBatch(sc, chosen->qp, (int)take, chunk.data());
+      const uint64_t postSendEndNs = nowNs();
+
+      if (fxTask != nullptr) {
+        uint64_t expected = 0;
+        fxTask->postSendEndNs.compare_exchange_strong(
+            expected, postSendEndNs, std::memory_order_relaxed);
+        if (fxTask->postSendStartNs.load(std::memory_order_relaxed) == 0) {
+          fxTask->postSendStartNs.compare_exchange_strong(
+              expected, postSendBeginNs, std::memory_order_relaxed);
+        }
+      }
+
       if (rc != flagcxSuccess)
         processed_.fetch_add(take, std::memory_order_release);
       i += take;
@@ -943,6 +951,7 @@ void FlagcxWorkerPool::performPollCq(int tid) {
 
   uint64_t sliceProgressed = 0;
   std::unordered_map<volatile int *, int> qpDepthSet;
+  const uint64_t pollNs = nowNs();
   for (int i = 0; i < n; i++) {
     uintptr_t raw = (uintptr_t)wcs[i].wr_id;
     if (raw == 0 || (raw & 1ull) == 0)
@@ -950,6 +959,7 @@ void FlagcxWorkerPool::performPollCq(int tid) {
 
     FlagcxSlice *slice =
         reinterpret_cast<FlagcxSlice *>(raw & ~(uintptr_t)1ull);
+    FlagcxTransferTask *taskPtr = slice->task;
     if (slice->qpDepth != NULL)
       qpDepthSet[slice->qpDepth]++;
     if (wcs[i].status != IBV_WC_SUCCESS) {
@@ -958,6 +968,17 @@ void FlagcxWorkerPool::performPollCq(int tid) {
       slice->markFailed();
     } else {
       slice->markSuccess();
+    }
+    // Record CQ completion timestamp when the last slice of a task finishes.
+    if (taskPtr != nullptr) {
+      uint64_t done = taskPtr->doneSliceCount.load(std::memory_order_acquire);
+      uint64_t total = taskPtr->sliceCount.load(std::memory_order_acquire);
+      if (total > 0 && done >= total &&
+          taskPtr->cqDoneNs.load(std::memory_order_relaxed) == 0) {
+        uint64_t expected = 0;
+        taskPtr->cqDoneNs.compare_exchange_strong(expected, pollNs,
+                                                  std::memory_order_relaxed);
+      }
     }
     sliceProgressed++;
   }
@@ -989,6 +1010,13 @@ static FlagcxWorkerPool *lookupPool(int ibDevN) {
 }
 
 } // namespace
+
+static inline uint64_t nowNs() {
+  using clk = std::chrono::steady_clock;
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             clk::now().time_since_epoch())
+      .count();
+}
 
 // ---- Hooks consumed by ibrc_p2p_adaptor.cc (forward-declared there). ----
 struct ibv_cq *flagcxP2pPoolGetCq(int ibDevN, struct ibv_context *ctx,
@@ -1059,6 +1087,9 @@ static FlagcxP2pCommView *getCommView(void *comm) {
   return reinterpret_cast<FlagcxP2pCommView *>(comm);
 }
 
+static thread_local uint64_t gWriteVectorSyncStartNs = 0;
+static std::atomic<uint64_t> gWriteVectorSyncTimingSamples{0};
+
 static bool
 buildAndSubmitToPool(PoolTransferTask *task, const std::vector<void *> &dataVec,
                      const std::vector<size_t> &sizeVec,
@@ -1087,6 +1118,14 @@ buildAndSubmitToPool(PoolTransferTask *task, const std::vector<void *> &dataVec,
   if (task->fx.sliceList.empty()) {
     return false;
   }
+
+  // Stamp the submit time so XferStatus can report the queue-wait segment.
+  // The blocking WriteVectorSync path passes the API entry time through
+  // gWriteVectorSyncStartNs; the async WriteVector/ReadVector path (what
+  // Mooncake uses) stamps now — slices are built, about to be submitted.
+  task->fx.syncStartNs.store(
+      gWriteVectorSyncStartNs != 0 ? gWriteVectorSyncStartNs : nowNs(),
+      std::memory_order_relaxed);
 
   flagcxResult_t rc =
       flagcxP2pPoolSubmit(connIbDevN, sendComm, task->fx.sliceList.data(),
@@ -2752,6 +2791,37 @@ bool flagcxP2pEngineXferStatus(FlagcxP2pConn *conn, uint64_t transferId) {
                (unsigned long)task->fx.failedCount.load(
                    std::memory_order_relaxed));
         }
+        const uint64_t t0 = task->fx.syncStartNs.load(std::memory_order_relaxed);
+        const uint64_t t1 =
+            task->fx.postSendStartNs.load(std::memory_order_relaxed);
+        const uint64_t t2 =
+            task->fx.postSendEndNs.load(std::memory_order_relaxed);
+        const uint64_t t3 = task->fx.cqDoneNs.load(std::memory_order_relaxed);
+        if (t0 > 0 && t1 >= t0 && t2 >= t1 && t3 >= t2) {
+          // Only profile the 8KB-block workload: every slice must be 8192B.
+          constexpr uint32_t kTargetBlockBytes = 8192;
+          bool isTargetBlock = !task->fx.sliceList.empty();
+          for (auto *s : task->fx.sliceList) {
+            if (s == nullptr || s->length != kTargetBlockBytes) {
+              isTargetBlock = false;
+              break;
+            }
+          }
+          if (isTargetBlock) {
+            const uint64_t sample = gWriteVectorSyncTimingSamples.fetch_add(
+                1, std::memory_order_relaxed);
+            // Log the first kLogSamples 8KB transfers.
+            constexpr uint64_t kLogSamples = 64;
+            if (sample < kLogSamples) {
+              INFO(FLAGCX_NET,
+                   "[FlagCX P2P] xfer timing sample=%lu slices=%zu: "
+                   "queue_us=%.3f postsend_us=%.3f cq_us=%.3f total_us=%.3f",
+                   (unsigned long)sample, task->fx.sliceList.size(),
+                   (double)(t1 - t0) / 1000.0, (double)(t2 - t1) / 1000.0,
+                   (double)(t3 - t2) / 1000.0, (double)(t3 - t0) / 1000.0);
+            }
+          }
+        }
         for (auto *s : task->fx.sliceList)
           sliceCache().deallocate(s);
         task->fx.sliceList.clear();
@@ -2955,8 +3025,12 @@ int flagcxP2pEngineWriteVectorSync(FlagcxP2pConn *conn,
     return 0;
 
   uint64_t transferId = 0;
+  const uint64_t syncStartNs = nowNs();
+  const uint64_t prevSyncStartNs = gWriteVectorSyncStartNs;
+  gWriteVectorSyncStartNs = syncStartNs;
   const int rc = flagcxP2pEngineWriteVector(conn, mrIds, srcVec, sizeVec, descs,
                                             numIovs, &transferId);
+  gWriteVectorSyncStartNs = prevSyncStartNs;
   if (rc != 0)
     return rc;
 
@@ -2980,7 +3054,6 @@ int flagcxP2pEngineWriteVectorSync(FlagcxP2pConn *conn,
       __builtin_ia32_pause();
 #endif
     }
-    // One-shot cleanup: frees slices and erases the map entry.
     flagcxP2pEngineXferStatus(conn, transferId);
     return 0;
   }

--- a/flagcx/core/flagcx_p2p.cc
+++ b/flagcx/core/flagcx_p2p.cc
@@ -13,6 +13,7 @@
 
 #include "adaptor.h"
 #include "bootstrap.h"
+#include "cpuset.h"
 #include "debug.h"
 #include "flagcx_net.h"
 #include "flagcx_net_adaptor.h"
@@ -34,6 +35,7 @@
 #include <mutex>
 #include <poll.h>
 #include <pthread.h>
+#include <sched.h>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -344,6 +346,57 @@ static std::unordered_map<uint64_t, FlagcxP2pXfer> gXferMap;
 static std::mutex gXferMutex;
 static uint64_t gNextXferId = 1;
 
+struct FlagcxSliceCache {
+  static constexpr size_t kCap = 4096;
+  std::vector<FlagcxSlice *> ring;
+  uint64_t head = 0, tail = 0;
+  FlagcxSliceCache() { ring.resize(kCap, nullptr); }
+  ~FlagcxSliceCache() {
+    for (uint64_t i = tail; i != head; i++)
+      delete ring[i % kCap];
+  }
+  FlagcxSlice *allocate() {
+    if (head == tail)
+      return new FlagcxSlice();
+    FlagcxSlice *s = ring[tail % kCap];
+    tail++;
+    return s;
+  }
+  void deallocate(FlagcxSlice *s) {
+    if (s == nullptr)
+      return;
+    if (head - tail == kCap) { // ring full: fall back to free
+      delete s;
+      return;
+    }
+    ring[head % kCap] = s;
+    head++;
+  }
+};
+
+static FlagcxSliceCache &sliceCache() {
+  static thread_local FlagcxSliceCache cache;
+  return cache;
+}
+
+static inline FlagcxSlice *acquireSlice(uint64_t srcVa, uint64_t dstVa,
+                                        uint32_t length, uint32_t lkey,
+                                        uint32_t rkey, uint8_t opcode,
+                                        const std::string &peerNicPath,
+                                        FlagcxTransferTask *task) {
+  FlagcxSlice *s = sliceCache().allocate();
+  s->srcVa = srcVa;
+  s->dstVa = dstVa;
+  s->length = length;
+  s->lkey = lkey;
+  s->rkey = rkey;
+  s->opcode = opcode;
+  s->peerNicPath = peerNicPath;
+  s->task = task;
+  s->qpDepth = nullptr;
+  return s;
+}
+
 inline void flagcxBuildSlicesRuntime(FlagcxTransferTask *task, uint64_t srcVa,
                                      uint64_t dstVa, size_t totalLen,
                                      uint32_t lkey, uint32_t rkey,
@@ -351,9 +404,8 @@ inline void flagcxBuildSlicesRuntime(FlagcxTransferTask *task, uint64_t srcVa,
                                      const std::string &peerNicPath,
                                      size_t blockSize, size_t fragmentSize) {
   if (blockSize == 0 || totalLen <= blockSize) {
-    auto *s = new FlagcxSlice{srcVa,       dstVa, (uint32_t)totalLen,
-                              lkey,        rkey,  opcode,
-                              peerNicPath, task,  nullptr};
+    FlagcxSlice *s = acquireSlice(srcVa, dstVa, (uint32_t)totalLen, lkey, rkey,
+                                  opcode, peerNicPath, task);
     task->sliceList.push_back(s);
     task->sliceCount.fetch_add(1, std::memory_order_release);
     return;
@@ -363,9 +415,8 @@ inline void flagcxBuildSlicesRuntime(FlagcxTransferTask *task, uint64_t srcVa,
   while (off < totalLen) {
     bool merge = (totalLen - off) <= blockSize + fragmentSize;
     size_t len = merge ? (totalLen - off) : blockSize;
-    auto *s =
-        new FlagcxSlice{srcVa + off, dstVa + off, (uint32_t)len, lkey,   rkey,
-                        opcode,      peerNicPath, task,          nullptr};
+    FlagcxSlice *s = acquireSlice(srcVa + off, dstVa + off, (uint32_t)len, lkey,
+                                  rkey, opcode, peerNicPath, task);
     task->sliceList.push_back(s);
     task->sliceCount.fetch_add(1, std::memory_order_release);
     off += len;
@@ -395,10 +446,13 @@ public:
   FlagcxWorkerPool(const FlagcxWorkerPool &) = delete;
   FlagcxWorkerPool &operator=(const FlagcxWorkerPool &) = delete;
 
-  struct ibv_cq *getSharedCq() const {
-    return shared_cq_;
+  struct ibv_cq *cqForSlot(int slot) const {
+    if (cqs_.empty())
+      return nullptr;
+    return cqs_[(size_t)slot % cqs_.size()];
   }
-  void registerQp(void *sendComm, struct ibv_qp *qp);
+  int workerCount() const { return numWorkers_; }
+  void registerQp(void *sendComm, struct ibv_qp *qp, int slot);
   void unregisterQp(struct ibv_qp *qp);
 
   flagcxResult_t submitPostSend(void *sendComm, FlagcxSlice **slices,
@@ -410,8 +464,10 @@ public:
 private:
   void transferWorkerLoop(int tid);
   void performPostSend(int tid);
-  void performPollCq();
+  void performPollCq(int tid);
   void notifWorkerLoop();
+
+  void pinToNicCpus(const char *role, int id);
 
   static uint64_t nowNs() {
     using clk = std::chrono::steady_clock;
@@ -421,7 +477,10 @@ private:
   }
 
   int ibDevN_;
-  struct ibv_cq *shared_cq_ = nullptr;
+  std::vector<struct ibv_cq *> cqs_; // one CQ per worker; worker t polls cqs_[t]
+
+  cpu_set_t cpuAffinity_;
+  bool hasCpuAffinity_ = false;
 
   int numWorkers_;
   int numShards_;
@@ -457,6 +516,39 @@ private:
   std::atomic<bool> notifSpawned_{false};
 };
 
+static bool flagcxP2pGetNicCpuset(struct ibv_context *ctx, cpu_set_t *mask) {
+  if (ctx == nullptr || ctx->device == nullptr || mask == nullptr)
+    return false;
+  const char *devName = flagcxWrapIbvGetDeviceName(ctx->device);
+  if (devName == nullptr)
+    return false;
+  char path[256];
+  snprintf(path, sizeof(path), "/sys/class/infiniband/%s/device/local_cpus",
+           devName);
+  FILE *fp = fopen(path, "r");
+  if (fp == nullptr)
+    return false;
+  char buf[1024];
+  char *line = fgets(buf, sizeof(buf), fp);
+  fclose(fp);
+  if (line == nullptr)
+    return false;
+  // Strip trailing newline/CR before parsing.
+  size_t n = strlen(buf);
+  while (n > 0 && (buf[n - 1] == '\n' || buf[n - 1] == '\r'))
+    buf[--n] = '\0';
+  CPU_ZERO(mask);
+  if (flagcxStrToCpuset(buf, mask) != flagcxSuccess)
+    return false;
+  int set = CPU_COUNT(mask);
+  if (set == 0)
+    return false;
+  long online = sysconf(_SC_NPROCESSORS_ONLN);
+  if (online > 0 && set >= online)
+    return false;
+  return true;
+}
+
 FlagcxWorkerPool::FlagcxWorkerPool(int ibDevN, struct ibv_context *ctx)
     : ibDevN_(ibDevN) {
   const auto &C = flagcxP2pGlobalConfig();
@@ -481,17 +573,21 @@ FlagcxWorkerPool::FlagcxWorkerPool(int ibDevN, struct ibv_context *ctx)
          ibDevN_, C.qpsPerConn, numWorkers_);
   }
 
-  flagcxResult_t res = flagcxWrapIbvCreateCq(
-      &shared_cq_, ctx, (int)C.sharedCqDepth, NULL, NULL, 0);
-  if (res != flagcxSuccess) {
-    WARN("NET/IB_P2P : pool[%d] failed to create shared CQ", ibDevN_);
-    shared_cq_ = nullptr;
-    return;
+  cqs_.resize(numWorkers_, nullptr);
+  for (int t = 0; t < numWorkers_; t++) {
+    flagcxResult_t res = flagcxWrapIbvCreateCq(
+        &cqs_[t], ctx, (int)C.sharedCqDepth, NULL, NULL, 0);
+    if (res != flagcxSuccess || cqs_[t] == nullptr) {
+      WARN("NET/IB_P2P : pool[%d] failed to create CQ %d/%d", ibDevN_, t,
+           numWorkers_);
+      cqs_.clear();
+      return;
+    }
   }
   INFO(FLAGCX_INIT,
-       "NET/IB_P2P : pool[%d] shared CQ created (depth=%zu, workers=%d, "
+       "NET/IB_P2P : pool[%d] %d per-worker CQs created (depth=%zu, "
        "shards=%d, qpsPerConn=%d)",
-       ibDevN_, C.sharedCqDepth, numWorkers_, numShards_, C.qpsPerConn);
+       ibDevN_, numWorkers_, C.sharedCqDepth, numShards_, C.qpsPerConn);
 
   slice_queues_.resize(numShards_);
   slice_locks_.reset(new std::mutex[numShards_]);
@@ -502,6 +598,8 @@ FlagcxWorkerPool::FlagcxWorkerPool(int ibDevN, struct ibv_context *ctx)
   workerQpIdx_.resize(numWorkers_);
   workerQpCursor_.assign(numWorkers_, 0);
   collective_slice_queue_.resize(numWorkers_);
+
+  hasCpuAffinity_ = flagcxP2pGetNicCpuset(ctx, &cpuAffinity_);
 
   transferThreads_.reserve(numWorkers_);
   for (int t = 0; t < numWorkers_; t++) {
@@ -550,15 +648,45 @@ void FlagcxWorkerPool::stopNotif() {
   notifSpawned_.store(false, std::memory_order_release);
 }
 
+void FlagcxWorkerPool::pinToNicCpus(const char *role, int id) {
+  if (!hasCpuAffinity_)
+    return;
+  cpu_set_t inherited, target;
+  if (sched_getaffinity(0, sizeof(cpu_set_t), &inherited) != 0) {
+    WARN("NET/IB_P2P : pool[%d] %s %d sched_getaffinity failed (errno=%d); "
+         "leaving thread unpinned",
+         ibDevN_, role, id, errno);
+    return;
+  }
+  CPU_AND(&target, &cpuAffinity_, &inherited);
+  if (CPU_COUNT(&target) == 0) {
+    INFO(FLAGCX_INIT,
+         "NET/IB_P2P : pool[%d] %s %d NIC-local set disjoint from inherited "
+         "affinity (%d cpus); leaving thread on inherited affinity",
+         ibDevN_, role, id, CPU_COUNT(&inherited));
+    return;
+  }
+  if (sched_setaffinity(0, sizeof(cpu_set_t), &target) != 0) {
+    WARN("NET/IB_P2P : pool[%d] %s %d sched_setaffinity failed (errno=%d)",
+         ibDevN_, role, id, errno);
+  } else {
+    INFO(FLAGCX_INIT,
+         "NET/IB_P2P : pool[%d] %s %d pinned to %d CPUs (NIC-local ∩ "
+         "inherited)",
+         ibDevN_, role, id, CPU_COUNT(&target));
+  }
+}
+
 void FlagcxWorkerPool::notifWorkerLoop() {
   if (engine_ == nullptr)
     return;
+  pinToNicCpus("notifWorker", 0);
   // Reuse the original engine-side body — same behavior, just owned by
   // the pool's thread.
   notifPollThreadFunc(engine_);
 }
 
-void FlagcxWorkerPool::registerQp(void *sendComm, struct ibv_qp *qp) {
+void FlagcxWorkerPool::registerQp(void *sendComm, struct ibv_qp *qp, int slot) {
   if (!qp || numWorkers_ <= 0)
     return;
 
@@ -589,8 +717,9 @@ void FlagcxWorkerPool::registerQp(void *sendComm, struct ibv_qp *qp) {
   qpEntries_.emplace_back(new PoolQpEntry(qp, sendComm));
   qpNumToIdx_[qp->qp_num] = idx;
 
-  int connIdx = connQpRegCount_[sendComm]++;
-  int slot = connIdx % numWorkers_;
+  connQpRegCount_[sendComm]++;
+  if (slot < 0 || slot >= numWorkers_)
+    slot = 0;
   workerQpIdx_[slot].push_back(idx);
 }
 
@@ -667,6 +796,7 @@ flagcxResult_t FlagcxWorkerPool::submitPostSend(void *sendComm,
 }
 
 void FlagcxWorkerPool::transferWorkerLoop(int tid) {
+  pinToNicCpus("transferWorker", tid);
   const static uint64_t kWaitPeriodInNano = 100ull * 1000 * 1000; // 100ms
   uint64_t last_wait_ts = nowNs();
 
@@ -690,7 +820,7 @@ void FlagcxWorkerPool::transferWorkerLoop(int tid) {
     }
 
     performPostSend(tid);
-    performPollCq();
+    performPollCq(tid);
   }
 }
 
@@ -795,16 +925,17 @@ void FlagcxWorkerPool::performPostSend(int tid) {
   }
 }
 
-void FlagcxWorkerPool::performPollCq() {
-  if (shared_cq_ == nullptr)
+void FlagcxWorkerPool::performPollCq(int tid) {
+  if (tid < 0 || tid >= (int)cqs_.size() || cqs_[tid] == nullptr)
     return;
+  struct ibv_cq *cq = cqs_[tid];
 
   constexpr int kMaxPollBatch = 256;
   struct ibv_wc wcs[kMaxPollBatch];
   int batch = (int)std::min<size_t>(batchPollSize_, kMaxPollBatch);
   int n = 0;
-  if (flagcxWrapIbvPollCq(shared_cq_, batch, wcs, &n) != flagcxSuccess) {
-    WARN("NET/IB_P2P : ibv_poll_cq failed on shared CQ %p", shared_cq_);
+  if (flagcxWrapIbvPollCq(cq, batch, wcs, &n) != flagcxSuccess) {
+    WARN("NET/IB_P2P : ibv_poll_cq failed on CQ %p (worker %d)", cq, tid);
     return;
   }
   if (n == 0)
@@ -860,17 +991,24 @@ static FlagcxWorkerPool *lookupPool(int ibDevN) {
 } // namespace
 
 // ---- Hooks consumed by ibrc_p2p_adaptor.cc (forward-declared there). ----
-struct ibv_cq *flagcxP2pPoolGetSharedCq(int ibDevN, struct ibv_context *ctx) {
+struct ibv_cq *flagcxP2pPoolGetCq(int ibDevN, struct ibv_context *ctx,
+                                  int slot) {
   FlagcxWorkerPool *pool = getOrCreatePool(ibDevN, ctx);
-  return pool ? pool->getSharedCq() : NULL;
+  return pool ? pool->cqForSlot(slot) : NULL;
 }
 
-void flagcxP2pPoolRegisterQp(int ibDevN, void *sendComm, struct ibv_qp *qp) {
+int flagcxP2pPoolGetWorkerCount(int ibDevN, struct ibv_context *ctx) {
+  FlagcxWorkerPool *pool = getOrCreatePool(ibDevN, ctx);
+  return pool ? pool->workerCount() : 0;
+}
+
+void flagcxP2pPoolRegisterQp(int ibDevN, void *sendComm, struct ibv_qp *qp,
+                             int slot) {
   if (qp == nullptr)
     return;
   FlagcxWorkerPool *pool = lookupPool(ibDevN);
   if (pool)
-    pool->registerQp(sendComm, qp);
+    pool->registerQp(sendComm, qp, slot);
 }
 
 void flagcxP2pPoolUnregisterQp(int ibDevN, struct ibv_qp *qp) {
@@ -2615,7 +2753,7 @@ bool flagcxP2pEngineXferStatus(FlagcxP2pConn *conn, uint64_t transferId) {
                    std::memory_order_relaxed));
         }
         for (auto *s : task->fx.sliceList)
-          delete s;
+          sliceCache().deallocate(s);
         task->fx.sliceList.clear();
         gPoolXferMap.erase(it);
         return true;
@@ -2906,26 +3044,12 @@ int flagcxP2pRpcBatchWriteSync(void *connPtr, int count, const uint64_t *srcVa,
   if (srcVa == NULL || dstVa == NULL || sizes == NULL)
     return -1;
 
-  std::vector<FlagcxP2pMr> mrVec(count);
   std::vector<void *> srcVec(count);
   std::vector<size_t> sizeVec(count);
   std::vector<FlagcxP2pRdmaDesc> descs(count);
 
-  // Resolve the local MR for each source VA from the global region table
-  // (gMemRegInfo), mirroring how MakeDesc resolves the remote rkey.
-  {
-    std::lock_guard<std::mutex> memLock(gMemMutex);
-    for (int i = 0; i < count; i++) {
-      FlagcxP2pMemRegEntry localEntry;
-      if (!findMemReg(static_cast<uintptr_t>(srcVa[i]), &localEntry)) {
-        WARN("NET/IB_P2P : BatchWriteSync no local MR for source VA 0x%llx",
-             (unsigned long long)srcVa[i]);
-        return -1;
-      }
-      mrVec[i] = localEntry.mrId;
-    }
-  }
-
+  // Resolve every remote rkey/desc up front. No global lock here: MakeDesc
+  // scans the per-conn remoteRegions table, not gMemRegInfo.
   for (int i = 0; i < count; i++) {
     srcVec[i] = reinterpret_cast<void *>(static_cast<uintptr_t>(srcVa[i]));
     sizeVec[i] = static_cast<size_t>(sizes[i]);
@@ -2938,7 +3062,77 @@ int flagcxP2pRpcBatchWriteSync(void *connPtr, int count, const uint64_t *srcVa,
     }
   }
 
-  return flagcxP2pEngineWriteVectorSync(conn, mrVec, srcVec, sizeVec, descs);
+  if (conn->isLocal && conn->sameProcess) {
+    std::vector<FlagcxP2pMr> mrVec(count);
+    {
+      std::lock_guard<std::mutex> memLock(gMemMutex);
+      for (int i = 0; i < count; i++) {
+        FlagcxP2pMemRegEntry localEntry;
+        if (!findMemReg(static_cast<uintptr_t>(srcVa[i]), &localEntry)) {
+          WARN("NET/IB_P2P : BatchWriteSync no local MR for source VA 0x%llx",
+               (unsigned long long)srcVa[i]);
+          return -1;
+        }
+        mrVec[i] = localEntry.mrId;
+      }
+    }
+    return flagcxP2pEngineWriteVectorSync(conn, mrVec, srcVec, sizeVec, descs);
+  }
+
+  std::vector<FlagcxP2pMemRegEntry> localEntries(count);
+  {
+    std::lock_guard<std::mutex> memLock(gMemMutex);
+    for (int i = 0; i < count; i++) {
+      if (!findMemReg(static_cast<uintptr_t>(srcVa[i]), &localEntries[i])) {
+        WARN("NET/IB_P2P : BatchWriteSync no local MR for source VA 0x%llx",
+             (unsigned long long)srcVa[i]);
+        return -1;
+      }
+      if (!memRegContains(localEntries[i], static_cast<uintptr_t>(srcVa[i]),
+                          static_cast<size_t>(sizes[i]))) {
+        WARN("NET/IB_P2P : BatchWriteSync source VA 0x%llx size %llu out of MR "
+             "bounds",
+             (unsigned long long)srcVa[i], (unsigned long long)sizes[i]);
+        return -1;
+      }
+    }
+  }
+
+  const int connIbDevN = getCommView(conn->sendComm)->ibDevN;
+  auto task = std::make_shared<PoolTransferTask>();
+  task->conn = conn;
+  if (!buildAndSubmitToPool(task.get(), srcVec, sizeVec, descs, localEntries,
+                            count, conn->sendComm, connIbDevN,
+                            FLAGCX_SLICE_OP_WRITE)) {
+    auto *sentinel = new FlagcxSlice{
+        0,         0,      0, 0, 0, FLAGCX_SLICE_OP_WRITE, std::string(),
+        &task->fx, nullptr};
+    task->fx.sliceList.push_back(sentinel);
+    task->fx.sliceCount.fetch_add(1, std::memory_order_release);
+    sentinel->markFailed();
+    task->postOk.store(false, std::memory_order_release);
+  }
+
+  uint64_t xferId;
+  {
+    std::lock_guard<std::mutex> lock(gPoolXferMutex);
+    xferId = gNextXferId++;
+    gPoolXferMap[xferId] = task;
+  }
+
+  // Synchronously wait for completion (mirror flagcxP2pEngineWriteVectorSync).
+  uint64_t spins = 0;
+  while (!task->fx.isAllDone()) {
+    if ((++spins & 0xFFF) == 0) {
+      std::this_thread::yield();
+      continue;
+    }
+#if defined(__x86_64__) || defined(__i386__)
+    __builtin_ia32_pause();
+#endif
+  }
+  flagcxP2pEngineXferStatus(conn, xferId);
+  return 0;
 }
 
 } // extern "C"

--- a/flagcx/core/flagcx_p2p.cc
+++ b/flagcx/core/flagcx_p2p.cc
@@ -26,7 +26,6 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
-#include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -48,8 +47,9 @@
 extern struct flagcxNetAdaptor flagcxNetIbP2p;
 extern flagcxResult_t flagcxNetIbP2pAbortListen(void *listenComm);
 
-extern "C" flagcxResult_t flagcxP2pSliceBatch(void *sendComm, struct ibv_qp *qp,
-                                              int count, FlagcxSlice **slices);
+extern "C" flagcxResult_t
+flagcxP2pSliceBatch(void *sendComm, struct ibv_qp *qp, int count,
+                    FlagcxSlice **slices, int *failedCount);
 
 namespace {
 
@@ -382,7 +382,6 @@ static FlagcxSliceCache &sliceCache() {
 static inline FlagcxSlice *acquireSlice(uint64_t srcVa, uint64_t dstVa,
                                         uint32_t length, uint32_t lkey,
                                         uint32_t rkey, uint8_t opcode,
-                                        const std::string &peerNicPath,
                                         FlagcxTransferTask *task) {
   FlagcxSlice *s = sliceCache().allocate();
   s->srcVa = srcVa;
@@ -391,7 +390,6 @@ static inline FlagcxSlice *acquireSlice(uint64_t srcVa, uint64_t dstVa,
   s->lkey = lkey;
   s->rkey = rkey;
   s->opcode = opcode;
-  s->peerNicPath = peerNicPath;
   s->task = task;
   s->qpDepth = nullptr;
   return s;
@@ -400,12 +398,11 @@ static inline FlagcxSlice *acquireSlice(uint64_t srcVa, uint64_t dstVa,
 inline void flagcxBuildSlicesRuntime(FlagcxTransferTask *task, uint64_t srcVa,
                                      uint64_t dstVa, size_t totalLen,
                                      uint32_t lkey, uint32_t rkey,
-                                     uint8_t opcode,
-                                     const std::string &peerNicPath,
-                                     size_t blockSize, size_t fragmentSize) {
+                                     uint8_t opcode, size_t blockSize,
+                                     size_t fragmentSize) {
   if (blockSize == 0 || totalLen <= blockSize) {
     FlagcxSlice *s = acquireSlice(srcVa, dstVa, (uint32_t)totalLen, lkey, rkey,
-                                  opcode, peerNicPath, task);
+                                  opcode, task);
     task->sliceList.push_back(s);
     task->sliceCount.fetch_add(1, std::memory_order_release);
     return;
@@ -416,7 +413,7 @@ inline void flagcxBuildSlicesRuntime(FlagcxTransferTask *task, uint64_t srcVa,
     bool merge = (totalLen - off) <= blockSize + fragmentSize;
     size_t len = merge ? (totalLen - off) : blockSize;
     FlagcxSlice *s = acquireSlice(srcVa + off, dstVa + off, (uint32_t)len, lkey,
-                                  rkey, opcode, peerNicPath, task);
+                                  rkey, opcode, task);
     task->sliceList.push_back(s);
     task->sliceCount.fetch_add(1, std::memory_order_release);
     off += len;
@@ -437,6 +434,32 @@ struct PoolQpEntry {
   PoolQpEntry(struct ibv_qp *q, void *sc) : qp(q), sendComm(sc), wrDepth(0) {}
   PoolQpEntry(const PoolQpEntry &) = delete;
   PoolQpEntry &operator=(const PoolQpEntry &) = delete;
+};
+
+struct PendingSliceQueue {
+  std::vector<FlagcxSlice *> slices;
+  size_t head = 0;
+
+  bool empty() const { return head >= slices.size(); }
+  size_t size() const { return slices.size() - head; }
+
+  void append(const std::vector<FlagcxSlice *> &src) {
+    if (src.empty())
+      return;
+    if (empty()) {
+      slices.clear();
+      head = 0;
+    } else if (head >= 4096 && head * 2 >= slices.size()) {
+      slices.erase(slices.begin(), slices.begin() + head);
+      head = 0;
+    }
+    slices.insert(slices.end(), src.begin(), src.end());
+  }
+
+  void clear() {
+    slices.clear();
+    head = 0;
+  }
 };
 
 class FlagcxWorkerPool {
@@ -469,13 +492,6 @@ private:
 
   void pinToNicCpus(const char *role, int id);
 
-  static uint64_t nowNs() {
-    using clk = std::chrono::steady_clock;
-    return std::chrono::duration_cast<std::chrono::nanoseconds>(
-               clk::now().time_since_epoch())
-        .count();
-  }
-
   int ibDevN_;
   std::vector<struct ibv_cq *> cqs_; // one CQ per worker; worker t polls cqs_[t]
 
@@ -489,24 +505,22 @@ private:
   int maxWrDepth_ = 0;
 
   std::mutex qp_mu_;
+  std::atomic<uint64_t> qpGen_{1};
   std::vector<std::unique_ptr<PoolQpEntry>> qpEntries_;
   std::unordered_map<uint32_t, int> qpNumToIdx_;
-  std::vector<std::vector<int>> workerQpIdx_;
   std::vector<size_t> workerQpCursor_;
-  std::unordered_map<void *, int> connQpRegCount_;
+  std::vector<std::vector<PoolQpEntry *>> workerQpCache_;
+  std::vector<uint64_t> workerQpCacheGen_;
+  std::vector<int> workerQpMaxDepth_;
   std::vector<std::unordered_map<void *, std::vector<FlagcxSlice *>>>
       slice_queues_;
   std::unique_ptr<std::mutex[]> slice_locks_;
   std::unique_ptr<std::atomic<int>[]> slice_queue_count_;
-  std::atomic<uint64_t> shardRoundRobin_{0};
-  std::vector<std::unordered_map<void *, std::vector<FlagcxSlice *>>>
+  std::vector<std::unordered_map<void *, PendingSliceQueue>>
       collective_slice_queue_;
 
   std::atomic<uint64_t> submitted_{0};
   std::atomic<uint64_t> processed_{0};
-  std::atomic<int> suspended_flag_{0};
-  std::condition_variable cv_;
-  std::mutex cv_mu_;
 
   std::atomic<bool> running_{true};
   std::vector<std::thread> transferThreads_;
@@ -595,8 +609,10 @@ FlagcxWorkerPool::FlagcxWorkerPool(int ibDevN, struct ibv_context *ctx)
   for (int s = 0; s < numShards_; s++)
     slice_queue_count_[s].store(0, std::memory_order_relaxed);
 
-  workerQpIdx_.resize(numWorkers_);
   workerQpCursor_.assign(numWorkers_, 0);
+  workerQpCache_.resize(numWorkers_);
+  workerQpCacheGen_.assign(numWorkers_, 0);
+  workerQpMaxDepth_.assign(numWorkers_, 0);
   collective_slice_queue_.resize(numWorkers_);
 
   hasCpuAffinity_ = flagcxP2pGetNicCpuset(ctx, &cpuAffinity_);
@@ -609,7 +625,6 @@ FlagcxWorkerPool::FlagcxWorkerPool(int ibDevN, struct ibv_context *ctx)
 
 FlagcxWorkerPool::~FlagcxWorkerPool() {
   running_.store(false, std::memory_order_release);
-  cv_.notify_all();
   for (auto &t : transferThreads_) {
     if (t.joinable())
       t.join();
@@ -717,10 +732,10 @@ void FlagcxWorkerPool::registerQp(void *sendComm, struct ibv_qp *qp, int slot) {
   qpEntries_.emplace_back(new PoolQpEntry(qp, sendComm));
   qpNumToIdx_[qp->qp_num] = idx;
 
-  connQpRegCount_[sendComm]++;
-  if (slot < 0 || slot >= numWorkers_)
-    slot = 0;
-  workerQpIdx_[slot].push_back(idx);
+  // The slot still selects this QP's CQ at creation time. Posting ownership is
+  // endpoint-affine, so the owner worker may post any QP of the connection.
+  (void)slot;
+  qpGen_.fetch_add(1, std::memory_order_release);
 }
 
 void FlagcxWorkerPool::unregisterQp(struct ibv_qp *qp) {
@@ -732,21 +747,11 @@ void FlagcxWorkerPool::unregisterQp(struct ibv_qp *qp) {
     return;
   int idx = it->second;
   qpNumToIdx_.erase(it);
-  void *sc = qpEntries_[idx]->sendComm;
-  for (auto &shard : workerQpIdx_) {
-    auto vit = std::find(shard.begin(), shard.end(), idx);
-    if (vit != shard.end()) {
-      shard.erase(vit);
-      break;
-    }
-  }
-  auto cit = connQpRegCount_.find(sc);
-  if (cit != connQpRegCount_.end() && --cit->second <= 0)
-    connQpRegCount_.erase(cit);
   // Slot kept alive (NULL'd) so any in-flight slice's qpDepth pointer stays
   // valid.
   qpEntries_[idx]->qp = nullptr;
   qpEntries_[idx]->sendComm = nullptr;
+  qpGen_.fetch_add(1, std::memory_order_release);
 }
 
 flagcxResult_t FlagcxWorkerPool::submitPostSend(void *sendComm,
@@ -755,43 +760,21 @@ flagcxResult_t FlagcxWorkerPool::submitPostSend(void *sendComm,
   if (count <= 0 || slices == nullptr)
     return flagcxSuccess;
 
-  // Backpressure: spin-yield until in-flight count drops below threshold.
-  // Prevents unbounded queue growth under sustained submission bursts.
-  const size_t maxPending = flagcxP2pGlobalConfig().maxRequests * 4;
-  while (submitted_.load(std::memory_order_acquire) -
-             processed_.load(std::memory_order_acquire) >
-         maxPending) {
-    std::this_thread::yield();
-  }
+  // Match Mooncake's endpoint-affine dispatch: every slice for the same
+  // endpoint (sendComm) goes to one stable shard, hence one posting worker.
+  // Shift away allocator alignment bits before applying Mooncake's multiplier.
+  const uintptr_t endpointKey = reinterpret_cast<uintptr_t>(sendComm) >> 4;
+  const int shard =
+      static_cast<int>((endpointKey * 10007ull) %
+                       static_cast<uint64_t>(numShards_));
 
-  std::vector<std::vector<FlagcxSlice *>> perShard(numShards_);
-  int enqueued = 0;
-  for (int i = 0; i < count; i++) {
-    if (slices[i] == nullptr)
-      continue;
-    int shard = (int)(shardRoundRobin_.fetch_add(1, std::memory_order_relaxed) %
-                      numShards_);
-    perShard[shard].push_back(slices[i]);
-    enqueued++;
+  {
+    std::lock_guard<std::mutex> lk(slice_locks_[shard]);
+    auto &vec = slice_queues_[shard][sendComm];
+    vec.insert(vec.end(), slices, slices + count);
+    slice_queue_count_[shard].fetch_add(count, std::memory_order_relaxed);
   }
-  if (enqueued == 0)
-    return flagcxSuccess;
-
-  for (int s = 0; s < numShards_; s++) {
-    if (perShard[s].empty())
-      continue;
-    std::lock_guard<std::mutex> lk(slice_locks_[s]);
-    auto &vec = slice_queues_[s][sendComm];
-    vec.insert(vec.end(), perShard[s].begin(), perShard[s].end());
-    slice_queue_count_[s].fetch_add((int)perShard[s].size(),
-                                    std::memory_order_relaxed);
-  }
-  submitted_.fetch_add(enqueued, std::memory_order_release);
-
-  if (suspended_flag_.load(std::memory_order_acquire) > 0) {
-    std::lock_guard<std::mutex> lk(cv_mu_);
-    cv_.notify_all();
-  }
+  submitted_.fetch_add(count, std::memory_order_release);
   return flagcxSuccess;
 }
 
@@ -824,21 +807,25 @@ void FlagcxWorkerPool::performPostSend(int tid) {
       if (entry.second.empty())
         continue;
       auto &dst = local[entry.first];
-      dst.insert(dst.end(), entry.second.begin(), entry.second.end());
+      dst.append(entry.second);
       entry.second.clear();
     }
     slice_queue_count_[s].store(0, std::memory_order_relaxed);
   }
 
-  std::vector<PoolQpEntry *> myQpEntries;
-  int curMaxDepth;
-  {
+  const uint64_t gen = qpGen_.load(std::memory_order_acquire);
+  if (workerQpCacheGen_[tid] != gen) {
     std::lock_guard<std::mutex> lk(qp_mu_);
-    myQpEntries.reserve(workerQpIdx_[tid].size());
-    for (int idx : workerQpIdx_[tid])
-      myQpEntries.push_back(qpEntries_[idx].get());
-    curMaxDepth = maxWrDepth_;
+    auto &cache = workerQpCache_[tid];
+    cache.clear();
+    cache.reserve(qpEntries_.size());
+    for (auto &entry : qpEntries_)
+      cache.push_back(entry.get());
+    workerQpMaxDepth_[tid] = maxWrDepth_;
+    workerQpCacheGen_[tid] = gen;
   }
+  std::vector<PoolQpEntry *> &myQpEntries = workerQpCache_[tid];
+  const int curMaxDepth = workerQpMaxDepth_[tid];
 
   size_t &cursor = workerQpCursor_[tid];
   for (auto &entry : local) {
@@ -847,26 +834,27 @@ void FlagcxWorkerPool::performPostSend(int tid) {
     if (pending.empty())
       continue;
 
-    std::vector<PoolQpEntry *> myQpOnComm;
+    static thread_local std::vector<PoolQpEntry *> myQpOnComm;
+    myQpOnComm.clear();
     myQpOnComm.reserve(myQpEntries.size());
     for (PoolQpEntry *e : myQpEntries) {
       if (e && e->qp != nullptr && e->sendComm == sc)
         myQpOnComm.push_back(e);
     }
     if (myQpOnComm.empty()) {
-      WARN("NET/IB_P2P : pool[%d] worker %d owns no QP for Engine %p; "
+      WARN("NET/IB_P2P : pool[%d] worker %d has no QP for Engine %p; "
            "failing %zu slices",
            ibDevN_, tid, sc, pending.size());
-      for (auto *sl : pending)
-        sl->markFailed();
+      for (size_t idx = pending.head; idx < pending.slices.size(); idx++)
+        pending.slices[idx]->markFailed();
       processed_.fetch_add(pending.size(), std::memory_order_release);
       pending.clear();
       continue;
     }
 
     const size_t ringSz = myQpOnComm.size();
-    size_t i = 0;
-    while (i < pending.size()) {
+    size_t i = pending.head;
+    while (i < pending.slices.size()) {
       PoolQpEntry *chosen = nullptr;
       size_t take = 0;
       for (size_t k = 0; k < ringSz; k++) {
@@ -874,13 +862,14 @@ void FlagcxWorkerPool::performPostSend(int tid) {
         int cur = e->wrDepth;
         size_t room;
         if (curMaxDepth == 0) {
-          room = pending.size() - i; // depth unknown: no gate
+          room = pending.slices.size() - i; // depth unknown: no gate
         } else if (cur >= curMaxDepth) {
           continue; // this QP is full, try the next one
         } else {
           room = (size_t)(curMaxDepth - cur);
         }
-        take = std::min<size_t>({room, maxWrPerPost_, pending.size() - i});
+        take =
+            std::min<size_t>({room, maxWrPerPost_, pending.slices.size() - i});
         chosen = e;
         cursor = (cursor + k + 1) % ringSz;
         break;
@@ -892,44 +881,23 @@ void FlagcxWorkerPool::performPostSend(int tid) {
       volatile int *depthPtr = &chosen->wrDepth;
       __sync_fetch_and_add(depthPtr, (int)take);
 
-      FlagcxTransferTask *fxTask = pending[i]->task;
-      if (fxTask != nullptr) {
-        uint64_t expected = 0;
-        const uint64_t startNs = nowNs();
-        fxTask->postSendStartNs.compare_exchange_strong(
-            expected, startNs, std::memory_order_relaxed);
-      }
-
-      std::vector<FlagcxSlice *> chunk;
-      chunk.reserve(take);
       for (size_t k = 0; k < take; k++) {
-        FlagcxSlice *sl = pending[i + k];
+        FlagcxSlice *sl = pending.slices[i + k];
         sl->qpDepth = depthPtr;
-        chunk.push_back(sl);
       }
 
-      const uint64_t postSendBeginNs = nowNs();
+      int failedCount = 0;
       flagcxResult_t rc =
-          flagcxP2pSliceBatch(sc, chosen->qp, (int)take, chunk.data());
-      const uint64_t postSendEndNs = nowNs();
+          flagcxP2pSliceBatch(sc, chosen->qp, (int)take,
+                              pending.slices.data() + i, &failedCount);
 
-      if (fxTask != nullptr) {
-        uint64_t expected = 0;
-        fxTask->postSendEndNs.compare_exchange_strong(
-            expected, postSendEndNs, std::memory_order_relaxed);
-        if (fxTask->postSendStartNs.load(std::memory_order_relaxed) == 0) {
-          fxTask->postSendStartNs.compare_exchange_strong(
-              expected, postSendBeginNs, std::memory_order_relaxed);
-        }
-      }
-
-      if (rc != flagcxSuccess)
-        processed_.fetch_add(take, std::memory_order_release);
+      if (rc != flagcxSuccess && failedCount > 0)
+        processed_.fetch_add(failedCount, std::memory_order_release);
       i += take;
     }
-    // Drop the posted prefix; anything left stays for the next iteration.
-    if (i > 0)
-      pending.erase(pending.begin(), pending.begin() + i);
+    pending.head = i;
+    if (pending.empty())
+      pending.clear();
   }
 }
 
@@ -951,7 +919,6 @@ void FlagcxWorkerPool::performPollCq(int tid) {
 
   uint64_t sliceProgressed = 0;
   std::unordered_map<volatile int *, int> qpDepthSet;
-  const uint64_t pollNs = nowNs();
   for (int i = 0; i < n; i++) {
     uintptr_t raw = (uintptr_t)wcs[i].wr_id;
     if (raw == 0 || (raw & 1ull) == 0)
@@ -959,7 +926,6 @@ void FlagcxWorkerPool::performPollCq(int tid) {
 
     FlagcxSlice *slice =
         reinterpret_cast<FlagcxSlice *>(raw & ~(uintptr_t)1ull);
-    FlagcxTransferTask *taskPtr = slice->task;
     if (slice->qpDepth != NULL)
       qpDepthSet[slice->qpDepth]++;
     if (wcs[i].status != IBV_WC_SUCCESS) {
@@ -968,17 +934,6 @@ void FlagcxWorkerPool::performPollCq(int tid) {
       slice->markFailed();
     } else {
       slice->markSuccess();
-    }
-    // Record CQ completion timestamp when the last slice of a task finishes.
-    if (taskPtr != nullptr) {
-      uint64_t done = taskPtr->doneSliceCount.load(std::memory_order_acquire);
-      uint64_t total = taskPtr->sliceCount.load(std::memory_order_acquire);
-      if (total > 0 && done >= total &&
-          taskPtr->cqDoneNs.load(std::memory_order_relaxed) == 0) {
-        uint64_t expected = 0;
-        taskPtr->cqDoneNs.compare_exchange_strong(expected, pollNs,
-                                                  std::memory_order_relaxed);
-      }
     }
     sliceProgressed++;
   }
@@ -1010,13 +965,6 @@ static FlagcxWorkerPool *lookupPool(int ibDevN) {
 }
 
 } // namespace
-
-static inline uint64_t nowNs() {
-  using clk = std::chrono::steady_clock;
-  return std::chrono::duration_cast<std::chrono::nanoseconds>(
-             clk::now().time_since_epoch())
-      .count();
-}
 
 // ---- Hooks consumed by ibrc_p2p_adaptor.cc (forward-declared there). ----
 struct ibv_cq *flagcxP2pPoolGetCq(int ibDevN, struct ibv_context *ctx,
@@ -1079,16 +1027,21 @@ void flagcxP2pPoolStopNotif() {
 
 struct PoolTransferTask {
   FlagcxTransferTask fx;
-  FlagcxP2pConn *conn;
-  std::atomic<bool> postOk{true};
+  PoolTransferTask *poolNext = nullptr;
+
+  void reset() {
+    fx.sliceCount.store(0, std::memory_order_relaxed);
+    fx.doneSliceCount.store(0, std::memory_order_relaxed);
+    fx.failedCount.store(0, std::memory_order_relaxed);
+    fx.sliceList.clear();
+    poolNext = nullptr;
+  }
 };
+
 
 static FlagcxP2pCommView *getCommView(void *comm) {
   return reinterpret_cast<FlagcxP2pCommView *>(comm);
 }
-
-static thread_local uint64_t gWriteVectorSyncStartNs = 0;
-static std::atomic<uint64_t> gWriteVectorSyncTimingSamples{0};
 
 static bool
 buildAndSubmitToPool(PoolTransferTask *task, const std::vector<void *> &dataVec,
@@ -1097,6 +1050,7 @@ buildAndSubmitToPool(PoolTransferTask *task, const std::vector<void *> &dataVec,
                      const std::vector<FlagcxP2pMemRegEntry> &localEntries,
                      int numIovs, void *sendComm, int connIbDevN,
                      uint8_t opcode) {
+  const auto &sliceCfg = flagcxP2pGlobalConfig();
   for (int i = 0; i < numIovs; i++) {
     if (localEntries[i].ibDevN != connIbDevN) {
       WARN("NET/IB_P2P : iov[%d] ibDevN mismatch (%d vs conn %d)", i,
@@ -1109,29 +1063,19 @@ buildAndSubmitToPool(PoolTransferTask *task, const std::vector<void *> &dataVec,
         reinterpret_cast<FlagcxP2pMrHandleView *>(localEntries[i].mhandle);
     uint64_t localVa = (uintptr_t)dataVec[i];
     uint64_t remoteVa = descs[i].addr;
-    const auto &sliceCfg = flagcxP2pGlobalConfig();
     flagcxBuildSlicesRuntime(
         &task->fx, localVa, remoteVa, sizeVec[i], localMr->lkey, descs[i].rkey,
-        opcode, std::string(), sliceCfg.sliceSize, sliceCfg.fragmentLimit);
+        opcode, sliceCfg.sliceSize, sliceCfg.fragmentLimit);
   }
 
   if (task->fx.sliceList.empty()) {
     return false;
   }
 
-  // Stamp the submit time so XferStatus can report the queue-wait segment.
-  // The blocking WriteVectorSync path passes the API entry time through
-  // gWriteVectorSyncStartNs; the async WriteVector/ReadVector path (what
-  // Mooncake uses) stamps now — slices are built, about to be submitted.
-  task->fx.syncStartNs.store(
-      gWriteVectorSyncStartNs != 0 ? gWriteVectorSyncStartNs : nowNs(),
-      std::memory_order_relaxed);
-
   flagcxResult_t rc =
       flagcxP2pPoolSubmit(connIbDevN, sendComm, task->fx.sliceList.data(),
                           (int)task->fx.sliceList.size());
   if (rc != flagcxSuccess) {
-    task->postOk.store(false, std::memory_order_release);
     for (auto *s : task->fx.sliceList)
       s->markFailed();
     return false;
@@ -1139,9 +1083,51 @@ buildAndSubmitToPool(PoolTransferTask *task, const std::vector<void *> &dataVec,
   return true;
 }
 
-static std::unordered_map<uint64_t, std::shared_ptr<PoolTransferTask>>
-    gPoolXferMap;
-static std::mutex gPoolXferMutex;
+static constexpr uint64_t kPoolXferTag = 1ull << 63;
+
+static std::mutex gPoolTaskFreeMu;
+static PoolTransferTask *gPoolTaskFreeHead = nullptr;
+
+static PoolTransferTask *acquirePoolTask() {
+  {
+    std::lock_guard<std::mutex> lk(gPoolTaskFreeMu);
+    if (gPoolTaskFreeHead != nullptr) {
+      PoolTransferTask *t = gPoolTaskFreeHead;
+      gPoolTaskFreeHead = t->poolNext;
+      t->reset();
+      return t;
+    }
+  }
+  PoolTransferTask *t = new PoolTransferTask();
+  t->reset();
+  return t;
+}
+
+static void releasePoolTask(PoolTransferTask *t) {
+  if (t == nullptr)
+    return;
+  std::lock_guard<std::mutex> lk(gPoolTaskFreeMu);
+  t->poolNext = gPoolTaskFreeHead;
+  gPoolTaskFreeHead = t;
+}
+
+static inline uint64_t encodePoolXfer(PoolTransferTask *t) {
+  return (uint64_t)(uintptr_t)t | kPoolXferTag;
+}
+
+static inline PoolTransferTask *decodePoolXfer(uint64_t transferId) {
+  if ((transferId & kPoolXferTag) == 0)
+    return nullptr;
+  return reinterpret_cast<PoolTransferTask *>(
+      (uintptr_t)(transferId & ~kPoolXferTag));
+}
+
+static void finalizePoolTask(PoolTransferTask *task) {
+  for (auto *s : task->fx.sliceList)
+    sliceCache().deallocate(s);
+  task->fx.sliceList.clear();
+}
+
 
 static bool findMemReg(uintptr_t addr, FlagcxP2pMemRegEntry *out) {
   for (std::unordered_map<uintptr_t, FlagcxP2pMemRegEntry>::const_iterator it =
@@ -2592,28 +2578,20 @@ int flagcxP2pEngineReadVector(FlagcxP2pConn *conn,
   }
 
   const int connIbDevN = getCommView(conn->sendComm)->ibDevN;
-  auto task = std::make_shared<PoolTransferTask>();
-  task->conn = conn;
+  PoolTransferTask *task = acquirePoolTask();
 
-  if (!buildAndSubmitToPool(task.get(), dstVec, sizeVec, descs, localEntries,
+  if (!buildAndSubmitToPool(task, dstVec, sizeVec, descs, localEntries,
                             numIovs, conn->sendComm, connIbDevN,
                             FLAGCX_SLICE_OP_READ)) {
     // sentinel so isAllDone() converges (needs total>0)
-    auto *sentinel = new FlagcxSlice{
-        0, 0, 0, 0, 0, FLAGCX_SLICE_OP_READ, std::string(), &task->fx, nullptr};
+    auto *sentinel = new FlagcxSlice{0, 0, 0, 0, 0, FLAGCX_SLICE_OP_READ,
+                                    &task->fx, nullptr};
     task->fx.sliceList.push_back(sentinel);
     task->fx.sliceCount.fetch_add(1, std::memory_order_release);
     sentinel->markFailed();
-    task->postOk.store(false, std::memory_order_release);
   }
 
-  uint64_t xferId;
-  {
-    std::lock_guard<std::mutex> lock(gPoolXferMutex);
-    xferId = gNextXferId++;
-    gPoolXferMap[xferId] = task;
-  }
-  *transferId = xferId;
+  *transferId = encodePoolXfer(task);
   return 0;
 }
 
@@ -2678,12 +2656,12 @@ int flagcxP2pEngineWrite(FlagcxP2pConn *conn, FlagcxP2pMr mr, const void *data,
 }
 
 int flagcxP2pEngineWriteVector(FlagcxP2pConn *conn,
-                               std::vector<FlagcxP2pMr> mrIds,
-                               std::vector<void *> dstVec,
-                               std::vector<size_t> sizeVec,
-                               std::vector<FlagcxP2pRdmaDesc> descs,
+                               const std::vector<FlagcxP2pMr> &mrIds,
+                               const std::vector<void *> &dstVec,
+                               const std::vector<size_t> &sizeVec,
+                               const std::vector<FlagcxP2pRdmaDesc> &descs,
                                int numIovs, uint64_t *transferId,
-                               std::vector<char *> ipcBufs) {
+                               const std::vector<char *> &ipcBufs) {
   if (conn == NULL || numIovs <= 0 || transferId == NULL)
     return -1;
 
@@ -2717,28 +2695,19 @@ int flagcxP2pEngineWriteVector(FlagcxP2pConn *conn,
   }
 
   const int connIbDevN = getCommView(conn->sendComm)->ibDevN;
-  auto task = std::make_shared<PoolTransferTask>();
-  task->conn = conn;
+  PoolTransferTask *task = acquirePoolTask();
 
-  if (!buildAndSubmitToPool(task.get(), dstVec, sizeVec, descs, localEntries,
+  if (!buildAndSubmitToPool(task, dstVec, sizeVec, descs, localEntries,
                             numIovs, conn->sendComm, connIbDevN,
                             FLAGCX_SLICE_OP_WRITE)) {
-    auto *sentinel = new FlagcxSlice{
-        0,         0,      0, 0, 0, FLAGCX_SLICE_OP_WRITE, std::string(),
-        &task->fx, nullptr};
+    auto *sentinel = new FlagcxSlice{0, 0, 0, 0, 0, FLAGCX_SLICE_OP_WRITE,
+                                    &task->fx, nullptr};
     task->fx.sliceList.push_back(sentinel);
     task->fx.sliceCount.fetch_add(1, std::memory_order_release);
     sentinel->markFailed();
-    task->postOk.store(false, std::memory_order_release);
   }
 
-  uint64_t xferId;
-  {
-    std::lock_guard<std::mutex> lock(gPoolXferMutex);
-    xferId = gNextXferId++;
-    gPoolXferMap[xferId] = task;
-  }
-  *transferId = xferId;
+  *transferId = encodePoolXfer(task);
   return 0;
 }
 
@@ -2779,57 +2748,16 @@ bool flagcxP2pEngineXferStatus(FlagcxP2pConn *conn, uint64_t transferId) {
   if (conn == NULL)
     return true;
 
-  {
-    std::lock_guard<std::mutex> lock(gPoolXferMutex);
-    auto it = gPoolXferMap.find(transferId);
-    if (it != gPoolXferMap.end()) {
-      auto &task = it->second;
-      if (task->fx.isAllDone()) {
-        if (task->fx.hasErrors()) {
-          WARN("NET/IB_P2P : transfer %lu completed with %lu failed slices",
-               (unsigned long)transferId,
-               (unsigned long)task->fx.failedCount.load(
-                   std::memory_order_relaxed));
-        }
-        const uint64_t t0 = task->fx.syncStartNs.load(std::memory_order_relaxed);
-        const uint64_t t1 =
-            task->fx.postSendStartNs.load(std::memory_order_relaxed);
-        const uint64_t t2 =
-            task->fx.postSendEndNs.load(std::memory_order_relaxed);
-        const uint64_t t3 = task->fx.cqDoneNs.load(std::memory_order_relaxed);
-        if (t0 > 0 && t1 >= t0 && t2 >= t1 && t3 >= t2) {
-          // Only profile the 8KB-block workload: every slice must be 8192B.
-          constexpr uint32_t kTargetBlockBytes = 8192;
-          bool isTargetBlock = !task->fx.sliceList.empty();
-          for (auto *s : task->fx.sliceList) {
-            if (s == nullptr || s->length != kTargetBlockBytes) {
-              isTargetBlock = false;
-              break;
-            }
-          }
-          if (isTargetBlock) {
-            const uint64_t sample = gWriteVectorSyncTimingSamples.fetch_add(
-                1, std::memory_order_relaxed);
-            // Log the first kLogSamples 8KB transfers.
-            constexpr uint64_t kLogSamples = 64;
-            if (sample < kLogSamples) {
-              INFO(FLAGCX_NET,
-                   "[FlagCX P2P] xfer timing sample=%lu slices=%zu: "
-                   "queue_us=%.3f postsend_us=%.3f cq_us=%.3f total_us=%.3f",
-                   (unsigned long)sample, task->fx.sliceList.size(),
-                   (double)(t1 - t0) / 1000.0, (double)(t2 - t1) / 1000.0,
-                   (double)(t3 - t2) / 1000.0, (double)(t3 - t0) / 1000.0);
-            }
-          }
-        }
-        for (auto *s : task->fx.sliceList)
-          sliceCache().deallocate(s);
-        task->fx.sliceList.clear();
-        gPoolXferMap.erase(it);
-        return true;
-      }
+  if (PoolTransferTask *task = decodePoolXfer(transferId)) {
+    if (!task->fx.isAllDone())
       return false;
+    if (task->fx.hasErrors()) {
+      WARN("NET/IB_P2P : transfer completed with %lu failed slices",
+           (unsigned long)task->fx.failedCount.load(std::memory_order_relaxed));
     }
+    finalizePoolTask(task);
+    releasePoolTask(task);
+    return true;
   }
 
   // Fall through to legacy synchronous xfer map (for single Read/Write)
@@ -3014,10 +2942,10 @@ int flagcxP2pEngineMakeDesc(FlagcxP2pConn *conn, uint64_t remoteVa,
 }
 
 int flagcxP2pEngineWriteVectorSync(FlagcxP2pConn *conn,
-                                   std::vector<FlagcxP2pMr> mrIds,
-                                   std::vector<void *> srcVec,
-                                   std::vector<size_t> sizeVec,
-                                   std::vector<FlagcxP2pRdmaDesc> descs) {
+                                   const std::vector<FlagcxP2pMr> &mrIds,
+                                   const std::vector<void *> &srcVec,
+                                   const std::vector<size_t> &sizeVec,
+                                   const std::vector<FlagcxP2pRdmaDesc> &descs) {
   if (conn == NULL)
     return -1;
   const int numIovs = static_cast<int>(srcVec.size());
@@ -3025,24 +2953,12 @@ int flagcxP2pEngineWriteVectorSync(FlagcxP2pConn *conn,
     return 0;
 
   uint64_t transferId = 0;
-  const uint64_t syncStartNs = nowNs();
-  const uint64_t prevSyncStartNs = gWriteVectorSyncStartNs;
-  gWriteVectorSyncStartNs = syncStartNs;
   const int rc = flagcxP2pEngineWriteVector(conn, mrIds, srcVec, sizeVec, descs,
                                             numIovs, &transferId);
-  gWriteVectorSyncStartNs = prevSyncStartNs;
   if (rc != 0)
     return rc;
 
-  std::shared_ptr<PoolTransferTask> task;
-  {
-    std::lock_guard<std::mutex> lock(gPoolXferMutex);
-    std::unordered_map<uint64_t, std::shared_ptr<PoolTransferTask>>::iterator
-        it = gPoolXferMap.find(transferId);
-    if (it != gPoolXferMap.end())
-      task = it->second;
-  }
-
+  PoolTransferTask *task = decodePoolXfer(transferId);
   if (task) {
     uint64_t spins = 0;
     while (!task->fx.isAllDone()) {
@@ -3172,26 +3088,18 @@ int flagcxP2pRpcBatchWriteSync(void *connPtr, int count, const uint64_t *srcVa,
   }
 
   const int connIbDevN = getCommView(conn->sendComm)->ibDevN;
-  auto task = std::make_shared<PoolTransferTask>();
-  task->conn = conn;
-  if (!buildAndSubmitToPool(task.get(), srcVec, sizeVec, descs, localEntries,
+  PoolTransferTask *task = acquirePoolTask();
+  if (!buildAndSubmitToPool(task, srcVec, sizeVec, descs, localEntries,
                             count, conn->sendComm, connIbDevN,
                             FLAGCX_SLICE_OP_WRITE)) {
-    auto *sentinel = new FlagcxSlice{
-        0,         0,      0, 0, 0, FLAGCX_SLICE_OP_WRITE, std::string(),
-        &task->fx, nullptr};
+    auto *sentinel = new FlagcxSlice{0, 0, 0, 0, 0, FLAGCX_SLICE_OP_WRITE,
+                                    &task->fx, nullptr};
     task->fx.sliceList.push_back(sentinel);
     task->fx.sliceCount.fetch_add(1, std::memory_order_release);
     sentinel->markFailed();
-    task->postOk.store(false, std::memory_order_release);
   }
 
-  uint64_t xferId;
-  {
-    std::lock_guard<std::mutex> lock(gPoolXferMutex);
-    xferId = gNextXferId++;
-    gPoolXferMap[xferId] = task;
-  }
+  const uint64_t xferId = encodePoolXfer(task);
 
   // Synchronously wait for completion (mirror flagcxP2pEngineWriteVectorSync).
   uint64_t spins = 0;

--- a/flagcx/core/flagcx_p2p.cc
+++ b/flagcx/core/flagcx_p2p.cc
@@ -761,9 +761,6 @@ flagcxResult_t FlagcxWorkerPool::submitPostSend(void *sendComm,
   if (count <= 0 || slices == nullptr)
     return flagcxSuccess;
 
-  // Match Mooncake's endpoint-affine dispatch: every slice for the same
-  // endpoint (sendComm) goes to one stable shard, hence one posting worker.
-  // Shift away allocator alignment bits before applying Mooncake's multiplier.
   const uintptr_t endpointKey = reinterpret_cast<uintptr_t>(sendComm) >> 4;
   const int shard = static_cast<int>((endpointKey * 10007ull) %
                                      static_cast<uint64_t>(numShards_));

--- a/flagcx/include/flagcx_p2p.h
+++ b/flagcx/include/flagcx_p2p.h
@@ -99,6 +99,10 @@ struct FlagcxTransferTask {
   std::atomic<uint64_t> sliceCount{0};
   std::atomic<uint64_t> doneSliceCount{0};
   std::atomic<uint64_t> failedCount{0};
+  std::atomic<uint64_t> syncStartNs{0};
+  std::atomic<uint64_t> postSendStartNs{0};
+  std::atomic<uint64_t> postSendEndNs{0};
+  std::atomic<uint64_t> cqDoneNs{0};
   std::vector<struct FlagcxSlice *> sliceList;
 
   bool isAllDone() const {

--- a/flagcx/include/flagcx_p2p.h
+++ b/flagcx/include/flagcx_p2p.h
@@ -17,7 +17,6 @@
 #include <cstring>
 #include <stddef.h>
 #include <stdint.h>
-#include <string>
 #include <vector>
 
 /* ------------------------------------------------------------------ */
@@ -99,10 +98,6 @@ struct FlagcxTransferTask {
   std::atomic<uint64_t> sliceCount{0};
   std::atomic<uint64_t> doneSliceCount{0};
   std::atomic<uint64_t> failedCount{0};
-  std::atomic<uint64_t> syncStartNs{0};
-  std::atomic<uint64_t> postSendStartNs{0};
-  std::atomic<uint64_t> postSendEndNs{0};
-  std::atomic<uint64_t> cqDoneNs{0};
   std::vector<struct FlagcxSlice *> sliceList;
 
   bool isAllDone() const {
@@ -130,7 +125,6 @@ struct FlagcxSlice {
   uint32_t lkey = 0;
   uint32_t rkey = 0;
   uint8_t opcode = FLAGCX_SLICE_OP_WRITE;
-  std::string peerNicPath;
   FlagcxTransferTask *task = nullptr;
   volatile int *qpDepth = nullptr;
 
@@ -418,12 +412,12 @@ int flagcxP2pEngineWrite(FlagcxP2pConn *conn, FlagcxP2pMr mr, const void *data,
  * @return              0 on success, non-zero on failure.
  */
 int flagcxP2pEngineWriteVector(FlagcxP2pConn *conn,
-                               std::vector<FlagcxP2pMr> mrIds,
-                               std::vector<void *> dstVec,
-                               std::vector<size_t> sizeVec,
-                               std::vector<FlagcxP2pRdmaDesc> descs,
+                               const std::vector<FlagcxP2pMr> &mrIds,
+                               const std::vector<void *> &dstVec,
+                               const std::vector<size_t> &sizeVec,
+                               const std::vector<FlagcxP2pRdmaDesc> &descs,
                                int numIovs, uint64_t *transferId,
-                               std::vector<char *> ipcBufs = {});
+                               const std::vector<char *> &ipcBufs = {});
 
 /**
  * Blocking vectored write. Submits a WriteVector and polls completion via
@@ -438,10 +432,10 @@ int flagcxP2pEngineWriteVector(FlagcxP2pConn *conn,
  * @return              0 on success, non-zero on failure.
  */
 int flagcxP2pEngineWriteVectorSync(FlagcxP2pConn *conn,
-                                   std::vector<FlagcxP2pMr> mrIds,
-                                   std::vector<void *> srcVec,
-                                   std::vector<size_t> sizeVec,
-                                   std::vector<FlagcxP2pRdmaDesc> descs);
+                                   const std::vector<FlagcxP2pMr> &mrIds,
+                                   const std::vector<void *> &srcVec,
+                                   const std::vector<size_t> &sizeVec,
+                                   const std::vector<FlagcxP2pRdmaDesc> &descs);
 
 /* ================================================================== */
 /*  Two-sided send / recv                                             */

--- a/test/unittest/p2p/test_p2p_slice_task.cpp
+++ b/test/unittest/p2p/test_p2p_slice_task.cpp
@@ -187,7 +187,6 @@ TEST(SliceTest, AggregateInitializationWorks) {
       0xAABB,               // lkey
       0xCCDD,               // rkey
       FLAGCX_SLICE_OP_READ, // opcode
-      std::string(),        // peerNicPath
       &task,                // task
       nullptr               // qpDepth
   };


### PR DESCRIPTION
### PR Category
CRL (Communication Runtime Layer)

### PR Types
Optimizations | Bug Fixes

### PR Description

This PR reworks the IB P2P `FlagcxWorkerPool` along two axes: parallelizing
completion handling across workers, and pinning pool threads to NIC-local CPUs
without violating inherited affinity.
