### PR TITLE
[CICD] Add datatype/op CLI support to perf tests

### DIFF
--- a/test/include/perf_common.h
+++ b/test/include/perf_common.h
@@ -82,15 +82,19 @@ void perfTeardown(PerfContext &ctx);
 void perfWarmup(PerfContext &ctx, PerfCollFn fn);
 
 // Run the benchmark size sweep with timing, MPI averaging, and
-// bandwidth reporting.
+// bandwidth reporting. Set iterateOps=false for collectives that don't
+// use ctx.op (e.g., allgather, broadcast, sendrecv).
 void perfBenchmarkLoop(PerfContext &ctx, PerfCollFn collFn,
                        PerfBwFactorFn bwFactorFn = nullptr,
                        PerfDataInitFn dataInitFn = nullptr,
-                       PerfPostIterFn postIterFn = nullptr);
+                       PerfPostIterFn postIterFn = nullptr,
+                       bool iterateOps = true);
 
 // Run the benchmark size sweep with root iteration (for reduce, broadcast,
 // scatter, gather). Iterates over roots per size, accumulating BW.
+// Set iterateOps=false for collectives that don't use ctx.op.
 void perfRootBenchmarkLoop(PerfContext &ctx, PerfRootCollFn collFn,
                            PerfBwFactorFn bwFactorFn = nullptr,
                            PerfRootDataInitFn dataInitFn = nullptr,
-                           PerfRootPostIterFn postIterFn = nullptr);
+                           PerfRootPostIterFn postIterFn = nullptr,
+                           bool iterateOps = true);

--- a/test/include/perf_common.h
+++ b/test/include/perf_common.h
@@ -25,6 +25,10 @@ struct PerfContext {
   uint64_t splitMask;
   int localRegister;
 
+  // Datatype/op for current iteration
+  flagcxDataType_t datatype;
+  flagcxRedOp_t op;
+
   // FlagCX handles
   flagcxDeviceHandle_t devHandle;
   flagcxComm_t comm;

--- a/test/include/tools.h
+++ b/test/include/tools.h
@@ -57,6 +57,6 @@ public:
   int root;
   uint64_t splitMask;
   int localRegister;
-  int datatype = -1; // flagcxDataType_t value, or -1 for "all"
-  int op = -1;       // flagcxRedOp_t value, or -1 for "all"
+  int datatype = -1; // index into test_types[], or -1 for "all"
+  int op = -1;       // index into test_ops[], or -1 for "all"
 };

--- a/test/include/tools.h
+++ b/test/include/tools.h
@@ -1,3 +1,4 @@
+#include "flagcx.h"
 #include "mpi.h"
 #include <cstddef>
 #include <cstdint>
@@ -5,6 +6,21 @@
 void initMpiEnv(int argc, char **argv, int &worldRank, int &worldSize,
                 int &proc, int &totalProcs, int &color, MPI_Comm &splitComm,
                 uint64_t splitMask);
+
+// Datatype tables (aligned with nccl-tests style)
+extern flagcxDataType_t test_types[];
+extern const char *test_typenames[];
+extern int test_typenum;
+
+// Reduction op tables
+extern flagcxRedOp_t test_ops[];
+extern const char *test_opnames[];
+extern int test_opnum;
+
+// Returns index into test_types[], or -1 for "all"
+int flagcxStringToType(const char *str);
+// Returns index into test_ops[], or -1 for "all"
+int flagcxStringToOp(const char *str);
 
 class timer {
 public:
@@ -27,6 +43,8 @@ public:
   int getRootRank() const { return root; }
   uint64_t getSplitMask() const { return splitMask; }
   int getLocalRegister() const { return localRegister; }
+  int getDataType() const { return datatype; }
+  int getOp() const { return op; }
 
   size_t minBytes;
   size_t maxBytes;
@@ -37,4 +55,6 @@ public:
   int root;
   uint64_t splitMask;
   int localRegister;
+  int datatype; // flagcxDataType_t value, or -1 for "all"
+  int op;       // flagcxRedOp_t value, or -1 for "all"
 };

--- a/test/include/tools.h
+++ b/test/include/tools.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "flagcx.h"
 #include "mpi.h"
 #include <cstddef>
@@ -8,12 +10,12 @@ void initMpiEnv(int argc, char **argv, int &worldRank, int &worldSize,
                 uint64_t splitMask);
 
 // Datatype tables (aligned with nccl-tests style)
-extern flagcxDataType_t test_types[];
+extern const flagcxDataType_t test_types[];
 extern const char *test_typenames[];
 extern int test_typenum;
 
 // Reduction op tables
-extern flagcxRedOp_t test_ops[];
+extern const flagcxRedOp_t test_ops[];
 extern const char *test_opnames[];
 extern int test_opnum;
 
@@ -55,6 +57,6 @@ public:
   int root;
   uint64_t splitMask;
   int localRegister;
-  int datatype; // flagcxDataType_t value, or -1 for "all"
-  int op;       // flagcxRedOp_t value, or -1 for "all"
+  int datatype = -1; // flagcxDataType_t value, or -1 for "all"
+  int op = -1;       // flagcxRedOp_t value, or -1 for "all"
 };

--- a/test/perf/host_api/test_allgather.cpp
+++ b/test/perf/host_api/test_allgather.cpp
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   PerfContext ctx;
   perfSetup(ctx, argc, argv, bufSizeFn);
   perfWarmup(ctx, collFn);
-  perfBenchmarkLoop(ctx, collFn, bwFactorFn);
+  perfBenchmarkLoop(ctx, collFn, bwFactorFn, nullptr, nullptr, false);
   perfTeardown(ctx);
   return 0;
 }

--- a/test/perf/host_api/test_allgather.cpp
+++ b/test/perf/host_api/test_allgather.cpp
@@ -7,43 +7,18 @@ static void bufSizeFn(PerfContext &ctx, size_t &sBuf, size_t &rBuf) {
 
 static void collFn(PerfContext &ctx, size_t count) {
   flagcxAllGather(ctx.sendbuff, ctx.recvbuff, count / ctx.totalProcs,
-                  flagcxFloat, ctx.comm, ctx.stream);
+                  ctx.datatype, ctx.comm, ctx.stream);
 }
 
 static double bwFactorFn(int totalProcs) {
   return (double)(totalProcs - 1) / (double)totalProcs;
 }
 
-static void dataInitFn(PerfContext &ctx, size_t size, size_t count) {
-  ((float *)ctx.hello)[0] = ctx.proc;
-  ctx.devHandle->deviceMemcpy(ctx.sendbuff, ctx.hello, size / ctx.totalProcs,
-                              flagcxMemcpyHostToDevice, NULL);
-  if ((ctx.proc == 0 || ctx.proc == ctx.totalProcs - 1) && ctx.color == 0 &&
-      ctx.printBuffer) {
-    printf("sendbuff = ");
-    printf("%f\n", ((float *)ctx.hello)[0]);
-  }
-}
-
-static void postIterFn(PerfContext &ctx, size_t size, size_t count) {
-  memset(ctx.hello, 0, size);
-  ctx.devHandle->deviceMemcpy(ctx.hello, ctx.recvbuff, size,
-                              flagcxMemcpyDeviceToHost, NULL);
-  if ((ctx.proc == 0 || ctx.proc == ctx.totalProcs - 1) && ctx.color == 0 &&
-      ctx.printBuffer) {
-    printf("recvbuff = ");
-    for (int i = 0; i < ctx.totalProcs; i++) {
-      printf("%f ", ((float *)ctx.hello)[i * (count / ctx.totalProcs)]);
-    }
-    printf("\n");
-  }
-}
-
 int main(int argc, char *argv[]) {
   PerfContext ctx;
   perfSetup(ctx, argc, argv, bufSizeFn);
   perfWarmup(ctx, collFn);
-  perfBenchmarkLoop(ctx, collFn, bwFactorFn, dataInitFn, postIterFn);
+  perfBenchmarkLoop(ctx, collFn, bwFactorFn);
   perfTeardown(ctx);
   return 0;
 }

--- a/test/perf/host_api/test_allreduce.cpp
+++ b/test/perf/host_api/test_allreduce.cpp
@@ -1,7 +1,7 @@
 #include "perf_common.h"
 
 static void collFn(PerfContext &ctx, size_t count) {
-  flagcxAllReduce(ctx.sendbuff, ctx.recvbuff, count, flagcxFloat, flagcxSum,
+  flagcxAllReduce(ctx.sendbuff, ctx.recvbuff, count, ctx.datatype, ctx.op,
                   ctx.comm, ctx.stream);
 }
 
@@ -18,97 +18,22 @@ static double bwFactorFn(int totalProcs) {
 }
 
 static void dataInitFn(PerfContext &ctx, size_t size, size_t count) {
+  size_t typeSize = getFlagcxDataTypeSize(ctx.datatype);
   for (size_t i = 0; i < count; i++) {
-    ((float *)ctx.hello)[i] = i % 10 * (1 << ctx.proc);
+    float val = i % 10 * (1 << ctx.proc);
+    memcpy((char *)ctx.hello + i * typeSize, &val,
+           sizeof(float) < typeSize ? sizeof(float) : typeSize);
   }
   ctx.devHandle->deviceMemcpy(ctx.sendbuff, ctx.hello, size,
                               flagcxMemcpyHostToDevice, NULL);
   ctx.devHandle->deviceMemcpy(ctx.recvbuff, ctx.hello, size,
                               flagcxMemcpyHostToDevice, NULL);
-  if (ctx.color == 0 && ctx.printBuffer) {
-    printf("rank %d sendbuff = ", ctx.proc);
-    for (size_t i = 0; i < 10; i++) {
-      printf("%f ", ((float *)ctx.hello)[i]);
-    }
-    printf("\n");
-  }
 }
 
 static void postIterFn(PerfContext &ctx, size_t size, size_t count) {
-  const char *envLocRed = getenv("FLAGCX_UNIRUNNER_USE_LOCRED");
-  const char *envRingAG = getenv("FLAGCX_UNIRUNNER_USE_RINGAG");
   memset(ctx.hello, 0, size);
   ctx.devHandle->deviceMemcpy(ctx.hello, ctx.recvbuff, size,
                               flagcxMemcpyDeviceToHost, NULL);
-  if (ctx.color == 0 && ctx.printBuffer) {
-    printf("rank %d recvbuff = ", ctx.proc);
-    for (size_t i = 0; i < 10; i++) {
-      printf("%f ", ((float *)ctx.hello)[i]);
-    }
-    printf("\n");
-
-    if (envLocRed != NULL && atoi(envLocRed) == 1) {
-      /* red correctness check */
-      int redCorrect = 1;
-      for (size_t i = 0; i < count; i++) {
-        if (i * ctx.totalProcs / count == (size_t)ctx.proc)
-          continue;
-        if (((float *)ctx.hello)[i] != (float)(i % 10 * (1 << ctx.proc))) {
-          printf("rank %d wrong output at offset %lu, expected %f, got %f\n ",
-                 ctx.proc, i, (float)(i % 10 * (1 << ctx.proc)),
-                 ((float *)ctx.hello)[i]);
-          redCorrect = 0;
-          break;
-        }
-      }
-      for (size_t i = ctx.proc * count / ctx.totalProcs;
-           i < (ctx.proc + 1) * count / ctx.totalProcs; i++) {
-        if (((float *)ctx.hello)[i] !=
-            (float)(i % 10 * (1 << (ctx.proc + 1)))) {
-          printf("rank %d wrong output at offset %lu, expected %f, got %f\n",
-                 ctx.proc, i, (float)(i % 10 * (1 << (ctx.proc + 1))),
-                 ((float *)ctx.hello)[i]);
-          redCorrect = 0;
-          break;
-        }
-      }
-      printf("rank %d reduce correctness = %d\n", ctx.proc, redCorrect);
-    } else if (envRingAG != NULL && atoi(envRingAG) == 1) {
-      /* p2p correctness check */
-      int p2pCorrect = 1;
-      for (size_t i = 0; i < count; i++) {
-        if (((float *)ctx.hello)[i] !=
-            (float)(i % 10 * (1 << (i * ctx.totalProcs / count)))) {
-          printf("rank %d wrong output at offset %lu, expected %f, got %f\n",
-                 ctx.proc, i,
-                 (float)(i % 10 * (1 << (i * ctx.totalProcs / count))),
-                 ((float *)ctx.hello)[i]);
-          p2pCorrect = 0;
-          break;
-        }
-      }
-      printf("rank %d p2p correctness = %d\n", ctx.proc, p2pCorrect);
-    } else {
-      /* all-reduce correctness check */
-      int arCorrect = 1;
-      for (size_t i = 0; i < count; i++) {
-        if ((i % 10 == 0 && ((float *)ctx.hello)[i] != 0) ||
-            ((float *)ctx.hello)[i] /
-                    (float)(i % 10 * ((1 << ctx.totalProcs) - 1)) >
-                1 + 1e-5 ||
-            ((float *)ctx.hello)[i] /
-                    (float)(i % 10 * ((1 << ctx.totalProcs) - 1)) <
-                1 - 1e-5) {
-          printf("rank %d wrong output at offset %lu, expected %f, got %f\n",
-                 ctx.proc, i, (float)(i % 10 * ((1 << ctx.totalProcs) - 1)),
-                 ((float *)ctx.hello)[i]);
-          arCorrect = 0;
-          break;
-        }
-      }
-      printf("rank %d all-reduce correctness = %d\n", ctx.proc, arCorrect);
-    }
-  }
 }
 
 int main(int argc, char *argv[]) {

--- a/test/perf/host_api/test_allreduce.cpp
+++ b/test/perf/host_api/test_allreduce.cpp
@@ -19,8 +19,9 @@ static double bwFactorFn(int totalProcs) {
 
 static void dataInitFn(PerfContext &ctx, size_t size, size_t count) {
   size_t typeSize = getFlagcxDataTypeSize(ctx.datatype);
+  memset(ctx.hello, 0, size);
   for (size_t i = 0; i < count; i++) {
-    float val = i % 10 * (1 << ctx.proc);
+    float val = (float)(i % 10) * (1ULL << (ctx.proc % 30));
     memcpy((char *)ctx.hello + i * typeSize, &val,
            sizeof(float) < typeSize ? sizeof(float) : typeSize);
   }

--- a/test/perf/host_api/test_alltoall.cpp
+++ b/test/perf/host_api/test_alltoall.cpp
@@ -2,48 +2,18 @@
 
 static void collFn(PerfContext &ctx, size_t count) {
   flagcxAlltoAll(ctx.sendbuff, ctx.recvbuff, count / ctx.totalProcs,
-                 flagcxFloat, ctx.comm, ctx.stream);
+                 ctx.datatype, ctx.comm, ctx.stream);
 }
 
 static double bwFactorFn(int totalProcs) {
   return (double)(totalProcs - 1) / (double)(totalProcs);
 }
 
-static void dataInitFn(PerfContext &ctx, size_t size, size_t count) {
-  for (int i = 0; i < ctx.totalProcs; i++) {
-    ((float *)ctx.hello)[i * (count / ctx.totalProcs)] = 10 * ctx.proc + i;
-  }
-  ctx.devHandle->deviceMemcpy(ctx.sendbuff, ctx.hello, size,
-                              flagcxMemcpyHostToDevice, NULL);
-  if ((ctx.proc == 0 || ctx.proc == ctx.totalProcs - 1) && ctx.color == 0 &&
-      ctx.printBuffer) {
-    printf("sendbuff = ");
-    for (int i = 0; i < ctx.totalProcs; i++) {
-      printf("%f ", ((float *)ctx.hello)[i * (count / ctx.totalProcs)]);
-    }
-    printf("\n");
-  }
-}
-
-static void postIterFn(PerfContext &ctx, size_t size, size_t count) {
-  memset(ctx.hello, 0, size);
-  ctx.devHandle->deviceMemcpy(ctx.hello, ctx.recvbuff, size,
-                              flagcxMemcpyDeviceToHost, NULL);
-  if ((ctx.proc == 0 || ctx.proc == ctx.totalProcs - 1) && ctx.color == 0 &&
-      ctx.printBuffer) {
-    printf("recvbuff = ");
-    for (int i = 0; i < ctx.totalProcs; i++) {
-      printf("%f ", ((float *)ctx.hello)[i * (count / ctx.totalProcs)]);
-    }
-    printf("\n");
-  }
-}
-
 int main(int argc, char *argv[]) {
   PerfContext ctx;
   perfSetup(ctx, argc, argv);
   perfWarmup(ctx, collFn);
-  perfBenchmarkLoop(ctx, collFn, bwFactorFn, dataInitFn, postIterFn);
+  perfBenchmarkLoop(ctx, collFn, bwFactorFn);
   perfTeardown(ctx);
   return 0;
 }

--- a/test/perf/host_api/test_alltoall.cpp
+++ b/test/perf/host_api/test_alltoall.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[]) {
   PerfContext ctx;
   perfSetup(ctx, argc, argv);
   perfWarmup(ctx, collFn);
-  perfBenchmarkLoop(ctx, collFn, bwFactorFn);
+  perfBenchmarkLoop(ctx, collFn, bwFactorFn, nullptr, nullptr, false);
   perfTeardown(ctx);
   return 0;
 }

--- a/test/perf/host_api/test_alltoallv.cpp
+++ b/test/perf/host_api/test_alltoallv.cpp
@@ -55,14 +55,14 @@ static void warmupFn(PerfContext &ctx, size_t count) {
   AlltoallvData *d = (AlltoallvData *)ctx.userData;
   computeCounts(ctx, count / ctx.totalProcs);
   flagcxAlltoAllv(ctx.sendbuff, d->hSendcounts, d->hSdispls, ctx.recvbuff,
-                  d->hRecvcounts, d->hRdispls, flagcxFloat, ctx.comm,
+                  d->hRecvcounts, d->hRdispls, ctx.datatype, ctx.comm,
                   ctx.stream);
 }
 
 static void collFn(PerfContext &ctx, size_t count) {
   AlltoallvData *d = (AlltoallvData *)ctx.userData;
   flagcxAlltoAllv(ctx.sendbuff, d->hSendcounts, d->hSdispls, ctx.recvbuff,
-                  d->hRecvcounts, d->hRdispls, flagcxFloat, ctx.comm,
+                  d->hRecvcounts, d->hRdispls, ctx.datatype, ctx.comm,
                   ctx.stream);
 }
 

--- a/test/perf/host_api/test_alltoallv.cpp
+++ b/test/perf/host_api/test_alltoallv.cpp
@@ -72,63 +72,26 @@ static double bwFactorFn(int totalProcs) {
 
 static void dataInitFn(PerfContext &ctx, size_t size, size_t count) {
   AlltoallvData *d = (AlltoallvData *)ctx.userData;
+  size_t typeSize = getFlagcxDataTypeSize(ctx.datatype);
   size_t perPeer = count / ctx.totalProcs;
 
+  memset(ctx.hello, 0, size);
   for (int i = 0; i < ctx.totalProcs; i++) {
-    ((float *)ctx.hello)[i * perPeer] = 10 * ctx.proc + i;
+    float val = (float)(10 * ctx.proc + i);
+    size_t offset = (size_t)i * perPeer * typeSize;
+    memcpy((char *)ctx.hello + offset, &val,
+           sizeof(float) < typeSize ? sizeof(float) : typeSize);
   }
   ctx.devHandle->deviceMemcpy(ctx.sendbuff, ctx.hello, size,
                               flagcxMemcpyHostToDevice, NULL);
 
-  if ((ctx.proc == 0 || ctx.proc == ctx.totalProcs - 1) && ctx.color == 0 &&
-      ctx.printBuffer) {
-    printf("sendbuff = ");
-    for (int i = 0; i < ctx.totalProcs; i++) {
-      printf("%f ", ((float *)ctx.hello)[i * perPeer]);
-    }
-    printf("\n");
-  }
-
   computeCounts(ctx, perPeer);
-
-  if ((ctx.proc == 0 || ctx.proc == ctx.totalProcs - 1) && ctx.color == 0 &&
-      ctx.printBuffer) {
-    printf("hSendcounts = ");
-    for (int i = 0; i < ctx.totalProcs; i++) {
-      printf("%ld ", d->hSendcounts[i]);
-    }
-    printf("\n");
-    printf("hRecvcounts = ");
-    for (int i = 0; i < ctx.totalProcs; i++) {
-      printf("%ld ", d->hRecvcounts[i]);
-    }
-    printf("\n");
-    printf("hSdispls = ");
-    for (int i = 0; i < ctx.totalProcs; i++) {
-      printf("%ld ", d->hSdispls[i]);
-    }
-    printf("\n");
-    printf("hRdispls = ");
-    for (int i = 0; i < ctx.totalProcs; i++) {
-      printf("%ld ", d->hRdispls[i]);
-    }
-    printf("\n");
-  }
 }
 
 static void postIterFn(PerfContext &ctx, size_t size, size_t count) {
-  size_t perPeer = count / ctx.totalProcs;
   memset(ctx.hello, 0, size);
   ctx.devHandle->deviceMemcpy(ctx.hello, ctx.recvbuff, size,
                               flagcxMemcpyDeviceToHost, NULL);
-  if ((ctx.proc == 0 || ctx.proc == ctx.totalProcs - 1) && ctx.color == 0 &&
-      ctx.printBuffer) {
-    printf("recvbuff = ");
-    for (int i = 0; i < ctx.totalProcs; i++) {
-      printf("%f ", ((float *)ctx.hello)[i * perPeer]);
-    }
-    printf("\n");
-  }
 }
 
 int main(int argc, char *argv[]) {
@@ -143,7 +106,7 @@ int main(int argc, char *argv[]) {
   ctx.userData = &data;
 
   perfWarmup(ctx, warmupFn);
-  perfBenchmarkLoop(ctx, collFn, bwFactorFn, dataInitFn, postIterFn);
+  perfBenchmarkLoop(ctx, collFn, bwFactorFn, dataInitFn, postIterFn, false);
 
   free(data.hSendcounts);
   free(data.hRecvcounts);

--- a/test/perf/host_api/test_broadcast.cpp
+++ b/test/perf/host_api/test_broadcast.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[]) {
   PerfContext ctx;
   perfSetup(ctx, argc, argv);
   perfWarmup(ctx, warmupFn);
-  perfRootBenchmarkLoop(ctx, collFn);
+  perfRootBenchmarkLoop(ctx, collFn, nullptr, nullptr, nullptr, false);
   perfTeardown(ctx);
   return 0;
 }

--- a/test/perf/host_api/test_broadcast.cpp
+++ b/test/perf/host_api/test_broadcast.cpp
@@ -1,53 +1,20 @@
 #include "perf_common.h"
 
 static void warmupFn(PerfContext &ctx, size_t count) {
-  flagcxBroadcast(ctx.sendbuff, ctx.recvbuff, count, flagcxFloat, 0, ctx.comm,
+  flagcxBroadcast(ctx.sendbuff, ctx.recvbuff, count, ctx.datatype, 0, ctx.comm,
                   ctx.stream);
 }
 
 static void collFn(PerfContext &ctx, size_t count, int root) {
-  flagcxBroadcast(ctx.sendbuff, ctx.recvbuff, count, flagcxFloat, root,
+  flagcxBroadcast(ctx.sendbuff, ctx.recvbuff, count, ctx.datatype, root,
                   ctx.comm, ctx.stream);
-}
-
-static void dataInitFn(PerfContext &ctx, size_t size, size_t count, int root) {
-  for (size_t i = 0; i < count; i++) {
-    ((float *)ctx.hello)[i] = ctx.proc;
-  }
-  if (ctx.proc == root) {
-    ctx.devHandle->deviceMemcpy(ctx.sendbuff, ctx.hello, size,
-                                flagcxMemcpyHostToDevice, NULL);
-  }
-  if ((ctx.proc == 0 || ctx.proc == ctx.totalProcs - 1) && ctx.color == 0 &&
-      ctx.printBuffer) {
-    printf("root rank is %d\n", root);
-    printf("sendbuff = ");
-    for (size_t i = 0; i < 10; i++) {
-      printf("%f ", ((float *)ctx.hello)[i]);
-    }
-    printf("\n");
-  }
-}
-
-static void postIterFn(PerfContext &ctx, size_t size, size_t count, int root) {
-  memset(ctx.hello, 0, size);
-  ctx.devHandle->deviceMemcpy(ctx.hello, ctx.recvbuff, size,
-                              flagcxMemcpyDeviceToHost, NULL);
-  if ((ctx.proc == 0 || ctx.proc == ctx.totalProcs - 1) && ctx.color == 0 &&
-      ctx.printBuffer) {
-    printf("recvbuff = ");
-    for (size_t i = 0; i < 10; i++) {
-      printf("%f ", ((float *)ctx.hello)[i]);
-    }
-    printf("\n");
-  }
 }
 
 int main(int argc, char *argv[]) {
   PerfContext ctx;
   perfSetup(ctx, argc, argv);
   perfWarmup(ctx, warmupFn);
-  perfRootBenchmarkLoop(ctx, collFn, nullptr, dataInitFn, postIterFn);
+  perfRootBenchmarkLoop(ctx, collFn);
   perfTeardown(ctx);
   return 0;
 }

--- a/test/perf/host_api/test_gather.cpp
+++ b/test/perf/host_api/test_gather.cpp
@@ -23,7 +23,7 @@ int main(int argc, char *argv[]) {
   PerfContext ctx;
   perfSetup(ctx, argc, argv, bufSizeFn);
   perfWarmup(ctx, warmupFn);
-  perfRootBenchmarkLoop(ctx, collFn, bwFactorFn);
+  perfRootBenchmarkLoop(ctx, collFn, bwFactorFn, nullptr, nullptr, false);
   perfTeardown(ctx);
   return 0;
 }

--- a/test/perf/host_api/test_gather.cpp
+++ b/test/perf/host_api/test_gather.cpp
@@ -6,12 +6,12 @@ static void bufSizeFn(PerfContext &ctx, size_t &sBuf, size_t &rBuf) {
 }
 
 static void warmupFn(PerfContext &ctx, size_t count) {
-  flagcxGather(ctx.sendbuff, ctx.recvbuff, count / ctx.totalProcs, flagcxFloat,
+  flagcxGather(ctx.sendbuff, ctx.recvbuff, count / ctx.totalProcs, ctx.datatype,
                0, ctx.comm, ctx.stream);
 }
 
 static void collFn(PerfContext &ctx, size_t count, int root) {
-  flagcxGather(ctx.sendbuff, ctx.recvbuff, count / ctx.totalProcs, flagcxFloat,
+  flagcxGather(ctx.sendbuff, ctx.recvbuff, count / ctx.totalProcs, ctx.datatype,
                root, ctx.comm, ctx.stream);
 }
 
@@ -19,38 +19,11 @@ static double bwFactorFn(int totalProcs) {
   return (double)(totalProcs - 1) / (double)(totalProcs);
 }
 
-static void dataInitFn(PerfContext &ctx, size_t size, size_t count, int root) {
-  ((float *)ctx.hello)[0] = ctx.proc;
-  ctx.devHandle->deviceMemcpy(ctx.sendbuff, ctx.hello, size / ctx.totalProcs,
-                              flagcxMemcpyHostToDevice, NULL);
-  if ((ctx.proc == 0 || ctx.proc == ctx.totalProcs - 1) && ctx.color == 0 &&
-      ctx.printBuffer) {
-    printf("root rank is %d\n", root);
-    printf("sendbuff = ");
-    printf("%f\n", ((float *)ctx.hello)[0]);
-  }
-}
-
-static void postIterFn(PerfContext &ctx, size_t size, size_t count, int root) {
-  if (ctx.proc == root) {
-    memset(ctx.hello, 0, size);
-    ctx.devHandle->deviceMemcpy(ctx.hello, ctx.recvbuff, size,
-                                flagcxMemcpyDeviceToHost, NULL);
-    if (ctx.color == 0 && ctx.printBuffer) {
-      printf("recvbuff = ");
-      for (int i = 0; i < ctx.totalProcs; i++) {
-        printf("%f ", ((float *)ctx.hello)[i * (count / ctx.totalProcs)]);
-      }
-      printf("\n");
-    }
-  }
-}
-
 int main(int argc, char *argv[]) {
   PerfContext ctx;
   perfSetup(ctx, argc, argv, bufSizeFn);
   perfWarmup(ctx, warmupFn);
-  perfRootBenchmarkLoop(ctx, collFn, bwFactorFn, dataInitFn, postIterFn);
+  perfRootBenchmarkLoop(ctx, collFn, bwFactorFn);
   perfTeardown(ctx);
   return 0;
 }

--- a/test/perf/host_api/test_reduce.cpp
+++ b/test/perf/host_api/test_reduce.cpp
@@ -1,65 +1,20 @@
 #include "perf_common.h"
 
 static void warmupFn(PerfContext &ctx, size_t count) {
-  flagcxReduce(ctx.sendbuff, ctx.recvbuff, count, flagcxFloat, flagcxSum, 0,
+  flagcxReduce(ctx.sendbuff, ctx.recvbuff, count, ctx.datatype, ctx.op, 0,
                ctx.comm, ctx.stream);
 }
 
 static void collFn(PerfContext &ctx, size_t count, int root) {
-  flagcxReduce(ctx.sendbuff, ctx.recvbuff, count, flagcxFloat, flagcxSum, root,
+  flagcxReduce(ctx.sendbuff, ctx.recvbuff, count, ctx.datatype, ctx.op, root,
                ctx.comm, ctx.stream);
-}
-
-static void dataInitFn(PerfContext &ctx, size_t size, size_t count, int root) {
-  for (size_t i = 0; i < count; i++) {
-    ((float *)ctx.hello)[i] = i % 10 * (1 << ctx.proc);
-  }
-  ctx.devHandle->deviceMemcpy(ctx.sendbuff, ctx.hello, size,
-                              flagcxMemcpyHostToDevice, NULL);
-  if (ctx.proc == root && ctx.color == 0 && ctx.printBuffer) {
-    printf("proc %d (root rank) sendbuff = ", root);
-    for (size_t i = 0; i < 10; i++) {
-      printf("%f ", ((float *)ctx.hello)[i]);
-    }
-    printf("\n");
-  }
-}
-
-static void postIterFn(PerfContext &ctx, size_t size, size_t count, int root) {
-  memset(ctx.hello, 0, size);
-  ctx.devHandle->deviceMemcpy(ctx.hello, ctx.recvbuff, size,
-                              flagcxMemcpyDeviceToHost, NULL);
-  if (ctx.proc == root && ctx.color == 0 && ctx.printBuffer) {
-    printf("proc %d (root rank) recvbuff = ", root);
-    for (size_t i = 0; i < 10; i++) {
-      printf("%f ", ((float *)ctx.hello)[i]);
-    }
-    printf("\n");
-    int correct = 1;
-    for (size_t i = 0; i < count; i++) {
-      if ((i % 10 == 0 && ((float *)ctx.hello)[i] != 0) ||
-          ((float *)ctx.hello)[i] /
-                  (float)(i % 10 * ((1 << ctx.totalProcs) - 1)) >
-              1 + 1e-5 ||
-          ((float *)ctx.hello)[i] /
-                  (float)(i % 10 * ((1 << ctx.totalProcs) - 1)) <
-              1 - 1e-5) {
-        printf("wrong output at offset %lu, expected %f, got %f\n", i,
-               (float)(i % 10 * ((1 << ctx.totalProcs) - 1)),
-               ((float *)ctx.hello)[i]);
-        correct = 0;
-        break;
-      }
-    }
-    printf("proc %d (root rank) correctness = %d\n", ctx.proc, correct);
-  }
 }
 
 int main(int argc, char *argv[]) {
   PerfContext ctx;
   perfSetup(ctx, argc, argv);
   perfWarmup(ctx, warmupFn);
-  perfRootBenchmarkLoop(ctx, collFn, nullptr, dataInitFn, postIterFn);
+  perfRootBenchmarkLoop(ctx, collFn);
   perfTeardown(ctx);
   return 0;
 }

--- a/test/perf/host_api/test_reducescatter.cpp
+++ b/test/perf/host_api/test_reducescatter.cpp
@@ -7,69 +7,18 @@ static void bufSizeFn(PerfContext &ctx, size_t &sBuf, size_t &rBuf) {
 
 static void collFn(PerfContext &ctx, size_t count) {
   flagcxReduceScatter(ctx.sendbuff, ctx.recvbuff, count / ctx.totalProcs,
-                      flagcxFloat, flagcxSum, ctx.comm, ctx.stream);
+                      ctx.datatype, ctx.op, ctx.comm, ctx.stream);
 }
 
 static double bwFactorFn(int totalProcs) {
   return (double)(totalProcs - 1) / (double)(totalProcs);
 }
 
-static void dataInitFn(PerfContext &ctx, size_t size, size_t count) {
-  size_t recvcount = count / ctx.totalProcs;
-  size_t index = 0;
-  float value = 0.0;
-  for (size_t i = 0; i < count; i++) {
-    ((float *)ctx.hello)[i] = value;
-    if (index == recvcount - 1) {
-      index = 0;
-      value += 1.0;
-    } else {
-      index++;
-    }
-  }
-  ctx.devHandle->deviceMemcpy(ctx.sendbuff, ctx.hello, size,
-                              flagcxMemcpyHostToDevice, ctx.stream);
-  ctx.devHandle->streamSynchronize(ctx.stream);
-  if (ctx.color == 0 && ctx.printBuffer) {
-    printf("proc %d sendbuff = ", ctx.proc);
-    for (size_t i = ctx.proc * recvcount; i < ctx.proc * recvcount + 10; i++) {
-      printf("%f ", ((float *)ctx.hello)[i]);
-    }
-    printf("\n");
-  }
-}
-
-static void postIterFn(PerfContext &ctx, size_t size, size_t count) {
-  size_t recvcount = count / ctx.totalProcs;
-  size_t recvsize = size / ctx.totalProcs;
-  memset(ctx.hello, 0, size);
-  ctx.devHandle->deviceMemcpy(ctx.hello, ctx.recvbuff, recvsize,
-                              flagcxMemcpyDeviceToHost, ctx.stream);
-  ctx.devHandle->streamSynchronize(ctx.stream);
-  if (ctx.color == 0 && ctx.printBuffer) {
-    printf("proc %d recvbuff = ", ctx.proc);
-    for (size_t i = 0; i < 10; i++) {
-      printf("%f ", ((float *)ctx.hello)[i]);
-    }
-    printf("\n");
-    int correct = 1;
-    for (size_t i = 0; i < recvcount; i++) {
-      if (((float *)ctx.hello)[i] != (float)(ctx.proc) * ctx.totalProcs) {
-        correct = 0;
-        printf("rank %d offset %lu wrong output %f\n", ctx.proc, i,
-               ((float *)ctx.hello)[i]);
-        break;
-      }
-    }
-    printf("rank %d correctness = %d\n", ctx.proc, correct);
-  }
-}
-
 int main(int argc, char *argv[]) {
   PerfContext ctx;
   perfSetup(ctx, argc, argv, bufSizeFn);
   perfWarmup(ctx, collFn);
-  perfBenchmarkLoop(ctx, collFn, bwFactorFn, dataInitFn, postIterFn);
+  perfBenchmarkLoop(ctx, collFn, bwFactorFn);
   perfTeardown(ctx);
   return 0;
 }

--- a/test/perf/host_api/test_scatter.cpp
+++ b/test/perf/host_api/test_scatter.cpp
@@ -6,53 +6,24 @@ static void bufSizeFn(PerfContext &ctx, size_t &sBuf, size_t &rBuf) {
 }
 
 static void warmupFn(PerfContext &ctx, size_t count) {
-  flagcxScatter(ctx.sendbuff, ctx.recvbuff, count / ctx.totalProcs, flagcxFloat,
-                0, ctx.comm, ctx.stream);
+  flagcxScatter(ctx.sendbuff, ctx.recvbuff, count / ctx.totalProcs,
+                ctx.datatype, 0, ctx.comm, ctx.stream);
 }
 
 static void collFn(PerfContext &ctx, size_t count, int root) {
-  flagcxScatter(ctx.sendbuff, ctx.recvbuff, count / ctx.totalProcs, flagcxFloat,
-                root, ctx.comm, ctx.stream);
+  flagcxScatter(ctx.sendbuff, ctx.recvbuff, count / ctx.totalProcs,
+                ctx.datatype, root, ctx.comm, ctx.stream);
 }
 
 static double bwFactorFn(int totalProcs) {
   return (double)(totalProcs - 1) / (double)(totalProcs);
 }
 
-static void dataInitFn(PerfContext &ctx, size_t size, size_t count, int root) {
-  for (int v = 0; v < ctx.totalProcs; v++) {
-    for (size_t i = 0; i < count / ctx.totalProcs; i++) {
-      ((float *)ctx.hello)[v * (count / ctx.totalProcs) + i] = v;
-    }
-  }
-  if (ctx.proc == root) {
-    ctx.devHandle->deviceMemcpy(ctx.sendbuff, ctx.hello, size,
-                                flagcxMemcpyHostToDevice, NULL);
-  }
-  if (ctx.proc == root && ctx.color == 0 && ctx.printBuffer) {
-    printf("root rank is %d\n", root);
-    printf("sendbuff = ");
-    for (size_t i = 0; i < 10; i++) {
-      printf("%f ", ((float *)ctx.hello)[i]);
-    }
-    printf("\n");
-  }
-}
-
-static void postIterFn(PerfContext &ctx, size_t size, size_t count, int root) {
-  memset(ctx.hello, 0, size);
-  ctx.devHandle->deviceMemcpy(ctx.hello, ctx.recvbuff, size / ctx.totalProcs,
-                              flagcxMemcpyDeviceToHost, NULL);
-  if (ctx.color == 0 && ctx.printBuffer) {
-    printf("rank %d recvbuff = %f\n", ctx.proc, ((float *)ctx.hello)[0]);
-  }
-}
-
 int main(int argc, char *argv[]) {
   PerfContext ctx;
   perfSetup(ctx, argc, argv, bufSizeFn);
   perfWarmup(ctx, warmupFn);
-  perfRootBenchmarkLoop(ctx, collFn, bwFactorFn, dataInitFn, postIterFn);
+  perfRootBenchmarkLoop(ctx, collFn, bwFactorFn);
   perfTeardown(ctx);
   return 0;
 }

--- a/test/perf/host_api/test_scatter.cpp
+++ b/test/perf/host_api/test_scatter.cpp
@@ -23,7 +23,7 @@ int main(int argc, char *argv[]) {
   PerfContext ctx;
   perfSetup(ctx, argc, argv, bufSizeFn);
   perfWarmup(ctx, warmupFn);
-  perfRootBenchmarkLoop(ctx, collFn, bwFactorFn);
+  perfRootBenchmarkLoop(ctx, collFn, bwFactorFn, nullptr, nullptr, false);
   perfTeardown(ctx);
   return 0;
 }

--- a/test/perf/host_api/test_sendrecv.cpp
+++ b/test/perf/host_api/test_sendrecv.cpp
@@ -4,42 +4,16 @@ static void collFn(PerfContext &ctx, size_t count) {
   int recvPeer = (ctx.proc - 1 + ctx.totalProcs) % ctx.totalProcs;
   int sendPeer = (ctx.proc + 1) % ctx.totalProcs;
   flagcxGroupStart(ctx.comm);
-  flagcxSend(ctx.sendbuff, count, flagcxFloat, sendPeer, ctx.comm, ctx.stream);
-  flagcxRecv(ctx.recvbuff, count, flagcxFloat, recvPeer, ctx.comm, ctx.stream);
+  flagcxSend(ctx.sendbuff, count, ctx.datatype, sendPeer, ctx.comm, ctx.stream);
+  flagcxRecv(ctx.recvbuff, count, ctx.datatype, recvPeer, ctx.comm, ctx.stream);
   flagcxGroupEnd(ctx.comm);
-}
-
-static void dataInitFn(PerfContext &ctx, size_t size, size_t count) {
-  strcpy((char *)ctx.hello, "_0x1234");
-  strcpy((char *)ctx.hello + size / 3, "_0x5678");
-  strcpy((char *)ctx.hello + size / 3 * 2, "_0x9abc");
-  ctx.devHandle->deviceMemcpy(ctx.sendbuff, ctx.hello, size,
-                              flagcxMemcpyHostToDevice, NULL);
-  if (ctx.proc == 0 && ctx.color == 0 && ctx.printBuffer) {
-    printf("sendbuff = ");
-    printf("%s", (const char *)((char *)ctx.hello));
-    printf("%s", (const char *)((char *)ctx.hello + size / 3));
-    printf("%s\n", (const char *)((char *)ctx.hello + size / 3 * 2));
-  }
-}
-
-static void postIterFn(PerfContext &ctx, size_t size, size_t count) {
-  memset(ctx.hello, 0, size);
-  ctx.devHandle->deviceMemcpy(ctx.hello, ctx.recvbuff, size,
-                              flagcxMemcpyDeviceToHost, NULL);
-  if (ctx.proc == 0 && ctx.color == 0 && ctx.printBuffer) {
-    printf("recvbuff = ");
-    printf("%s", (const char *)((char *)ctx.hello));
-    printf("%s", (const char *)((char *)ctx.hello + size / 3));
-    printf("%s\n", (const char *)((char *)ctx.hello + size / 3 * 2));
-  }
 }
 
 int main(int argc, char *argv[]) {
   PerfContext ctx;
   perfSetup(ctx, argc, argv);
   perfWarmup(ctx, collFn);
-  perfBenchmarkLoop(ctx, collFn, nullptr, dataInitFn, postIterFn);
+  perfBenchmarkLoop(ctx, collFn);
   perfTeardown(ctx);
   return 0;
 }

--- a/test/perf/host_api/test_sendrecv.cpp
+++ b/test/perf/host_api/test_sendrecv.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[]) {
   PerfContext ctx;
   perfSetup(ctx, argc, argv);
   perfWarmup(ctx, collFn);
-  perfBenchmarkLoop(ctx, collFn);
+  perfBenchmarkLoop(ctx, collFn, nullptr, nullptr, nullptr, false);
   perfTeardown(ctx);
   return 0;
 }

--- a/test/perf_common.cc
+++ b/test/perf_common.cc
@@ -19,6 +19,8 @@ void perfSetup(PerfContext &ctx, int argc, char **argv,
   // For warmup, default to float/sum when "all" is selected
   int parsedDt = ctx.args->getDataType();
   int parsedOp = ctx.args->getOp();
+  // Table indices match enum values (test_types[i] == i), so direct cast is
+  // valid
   ctx.datatype = (flagcxDataType_t)(parsedDt >= 0 ? parsedDt : flagcxFloat);
   ctx.op = (flagcxRedOp_t)(parsedOp >= 0 ? parsedOp : flagcxSum);
 

--- a/test/perf_common.cc
+++ b/test/perf_common.cc
@@ -83,6 +83,13 @@ void perfSetup(PerfContext &ctx, int argc, char **argv,
   ctx.hello = malloc(hBufSize);
   memset(ctx.hello, 0, hBufSize);
 
+  // Zero-init device buffers to avoid UB in tests without custom dataInitFn
+  ctx.devHandle->deviceMemset(ctx.sendbuff, 0, sBufSize, flagcxMemDevice,
+                              ctx.stream);
+  ctx.devHandle->deviceMemset(ctx.recvbuff, 0, rBufSize, flagcxMemDevice,
+                              ctx.stream);
+  ctx.devHandle->streamSynchronize(ctx.stream);
+
   ctx.userData = nullptr;
 }
 
@@ -135,8 +142,8 @@ void perfBenchmarkLoop(PerfContext &ctx, PerfCollFn collFn,
   int parsedOp = ctx.args->getOp();
 
   int typeCount, opCount;
-  flagcxDataType_t *runTypes;
-  flagcxRedOp_t *runOps;
+  const flagcxDataType_t *runTypes;
+  const flagcxRedOp_t *runOps;
   const char **runTypeNames;
   const char **runOpNames;
 
@@ -237,8 +244,8 @@ void perfRootBenchmarkLoop(PerfContext &ctx, PerfRootCollFn collFn,
   int parsedOp = ctx.args->getOp();
 
   int typeCount, opCount;
-  flagcxDataType_t *runTypes;
-  flagcxRedOp_t *runOps;
+  const flagcxDataType_t *runTypes;
+  const flagcxRedOp_t *runOps;
   const char **runTypeNames;
   const char **runOpNames;
 

--- a/test/perf_common.cc
+++ b/test/perf_common.cc
@@ -131,7 +131,7 @@ void perfWarmup(PerfContext &ctx, PerfCollFn fn) {
 
 void perfBenchmarkLoop(PerfContext &ctx, PerfCollFn collFn,
                        PerfBwFactorFn bwFactorFn, PerfDataInitFn dataInitFn,
-                       PerfPostIterFn postIterFn) {
+                       PerfPostIterFn postIterFn, bool iterateOps) {
   if (ctx.stepFactor <= 1) {
     fprintf(stderr, "Error: stepFactor must be > 1 (got %d)\n", ctx.stepFactor);
     return;
@@ -162,7 +162,7 @@ void perfBenchmarkLoop(PerfContext &ctx, PerfCollFn collFn,
     runTypeNames = test_typenames;
   }
 
-  if (parsedOp != -1) {
+  if (parsedOp != -1 || !iterateOps) {
     opCount = 1;
     runOps = &singleOp;
     runOpNames = &singleOpName;
@@ -233,7 +233,7 @@ void perfBenchmarkLoop(PerfContext &ctx, PerfCollFn collFn,
 void perfRootBenchmarkLoop(PerfContext &ctx, PerfRootCollFn collFn,
                            PerfBwFactorFn bwFactorFn,
                            PerfRootDataInitFn dataInitFn,
-                           PerfRootPostIterFn postIterFn) {
+                           PerfRootPostIterFn postIterFn, bool iterateOps) {
   if (ctx.stepFactor <= 1) {
     fprintf(stderr, "Error: stepFactor must be > 1 (got %d)\n", ctx.stepFactor);
     return;
@@ -264,7 +264,7 @@ void perfRootBenchmarkLoop(PerfContext &ctx, PerfRootCollFn collFn,
     runTypeNames = test_typenames;
   }
 
-  if (parsedOp != -1) {
+  if (parsedOp != -1 || !iterateOps) {
     opCount = 1;
     runOps = &singleOp;
     runOpNames = &singleOpName;

--- a/test/perf_common.cc
+++ b/test/perf_common.cc
@@ -84,11 +84,13 @@ void perfSetup(PerfContext &ctx, int argc, char **argv,
   memset(ctx.hello, 0, hBufSize);
 
   // Zero-init device buffers to avoid UB in tests without custom dataInitFn
-  ctx.devHandle->deviceMemset(ctx.sendbuff, 0, sBufSize, flagcxMemDevice,
-                              ctx.stream);
-  ctx.devHandle->deviceMemset(ctx.recvbuff, 0, rBufSize, flagcxMemDevice,
-                              ctx.stream);
-  ctx.devHandle->streamSynchronize(ctx.stream);
+  if (ctx.sendbuff && ctx.recvbuff) {
+    ctx.devHandle->deviceMemset(ctx.sendbuff, 0, sBufSize, flagcxMemDevice,
+                                ctx.stream);
+    ctx.devHandle->deviceMemset(ctx.recvbuff, 0, rBufSize, flagcxMemDevice,
+                                ctx.stream);
+    ctx.devHandle->streamSynchronize(ctx.stream);
+  }
 
   ctx.userData = nullptr;
 }
@@ -114,6 +116,10 @@ void perfTeardown(PerfContext &ctx) {
 
 void perfWarmup(PerfContext &ctx, PerfCollFn fn) {
   size_t typeSize = getFlagcxDataTypeSize(ctx.datatype);
+  if (typeSize == 0) {
+    fprintf(stderr, "Error: unknown datatype (size=0)\n");
+    return;
+  }
   // Warmup for large size
   size_t largeCount = ctx.maxBytes / typeSize;
   for (int i = 0; i < ctx.numWarmupIters; i++) {

--- a/test/perf_common.cc
+++ b/test/perf_common.cc
@@ -15,6 +15,13 @@ void perfSetup(PerfContext &ctx, int argc, char **argv,
   ctx.splitMask = ctx.args->getSplitMask();
   ctx.localRegister = ctx.args->getLocalRegister();
 
+  // Datatype/op from CLI (may be -1 for "all")
+  // For warmup, default to float/sum when "all" is selected
+  int parsedDt = ctx.args->getDataType();
+  int parsedOp = ctx.args->getOp();
+  ctx.datatype = (flagcxDataType_t)(parsedDt >= 0 ? parsedDt : flagcxFloat);
+  ctx.op = (flagcxRedOp_t)(parsedOp >= 0 ? parsedOp : flagcxSum);
+
   // Initialize FlagCX device handle
   flagcxDeviceHandleInit(&ctx.devHandle);
 
@@ -99,15 +106,16 @@ void perfTeardown(PerfContext &ctx) {
 }
 
 void perfWarmup(PerfContext &ctx, PerfCollFn fn) {
+  size_t typeSize = getFlagcxDataTypeSize(ctx.datatype);
   // Warmup for large size
-  size_t largeCount = ctx.maxBytes / sizeof(float);
+  size_t largeCount = ctx.maxBytes / typeSize;
   for (int i = 0; i < ctx.numWarmupIters; i++) {
     fn(ctx, largeCount);
   }
   ctx.devHandle->streamSynchronize(ctx.stream);
 
   // Warmup for small size
-  size_t smallCount = ctx.minBytes / sizeof(float);
+  size_t smallCount = ctx.minBytes / typeSize;
   for (int i = 0; i < ctx.numWarmupIters; i++) {
     fn(ctx, smallCount);
   }
@@ -121,47 +129,96 @@ void perfBenchmarkLoop(PerfContext &ctx, PerfCollFn collFn,
     fprintf(stderr, "Error: stepFactor must be > 1 (got %d)\n", ctx.stepFactor);
     return;
   }
-  for (size_t size = ctx.minBytes; size <= ctx.maxBytes;
-       size *= ctx.stepFactor) {
-    size_t count = size / sizeof(float);
 
-    // Optional data initialization
-    if (dataInitFn) {
-      dataInitFn(ctx, size, count);
-    }
+  // Determine which types and ops to run
+  int parsedType = ctx.args->getDataType();
+  int parsedOp = ctx.args->getOp();
 
-    MPI_Barrier(MPI_COMM_WORLD);
+  int typeCount, opCount;
+  flagcxDataType_t *runTypes;
+  flagcxRedOp_t *runOps;
+  const char **runTypeNames;
+  const char **runOpNames;
 
-    // Timed loop
-    ctx.tim.reset();
-    for (int i = 0; i < ctx.numIters; i++) {
-      collFn(ctx, count);
-    }
-    ctx.devHandle->streamSynchronize(ctx.stream);
+  flagcxDataType_t singleType = ctx.datatype;
+  flagcxRedOp_t singleOp = ctx.op;
+  const char *singleTypeName = test_typenames[parsedType >= 0 ? parsedType : 0];
+  const char *singleOpName = test_opnames[parsedOp >= 0 ? parsedOp : 0];
 
-    // Compute average elapsed time across all ranks
-    double elapsedTime = ctx.tim.elapsed() / ctx.numIters;
-    MPI_Allreduce(MPI_IN_PLACE, (void *)&elapsedTime, 1, MPI_DOUBLE, MPI_SUM,
-                  MPI_COMM_WORLD);
-    elapsedTime /= ctx.worldSize;
+  if (parsedType != -1) {
+    typeCount = 1;
+    runTypes = &singleType;
+    runTypeNames = &singleTypeName;
+  } else {
+    typeCount = test_typenum;
+    runTypes = test_types;
+    runTypeNames = test_typenames;
+  }
 
-    // Bandwidth calculation
-    double baseBw = (double)(size) / 1.0E9 / elapsedTime;
-    double algBw = baseBw;
-    double factor = bwFactorFn ? bwFactorFn(ctx.totalProcs) : 1.0;
-    double busBw = baseBw * factor;
+  if (parsedOp != -1) {
+    opCount = 1;
+    runOps = &singleOp;
+    runOpNames = &singleOpName;
+  } else {
+    opCount = test_opnum;
+    runOps = test_ops;
+    runOpNames = test_opnames;
+  }
 
-    if (ctx.proc == 0 && ctx.color == 0) {
-      printf("Comm size: %zu bytes; Elapsed time: %lf sec; Algo bandwidth: "
-             "%lf GB/s; Bus bandwidth: %lf GB/s\n",
-             size, elapsedTime, algBw, busBw);
-    }
+  for (int ti = 0; ti < typeCount; ti++) {
+    for (int oi = 0; oi < opCount; oi++) {
+      ctx.datatype = runTypes[ti];
+      ctx.op = runOps[oi];
+      size_t typeSize = getFlagcxDataTypeSize(ctx.datatype);
 
-    MPI_Barrier(MPI_COMM_WORLD);
+      if (ctx.proc == 0 && ctx.color == 0) {
+        printf("#\n# datatype: %s, op: %s\n#\n", runTypeNames[ti],
+               runOpNames[oi]);
+      }
 
-    // Optional post-iteration callback
-    if (postIterFn) {
-      postIterFn(ctx, size, count);
+      for (size_t size = ctx.minBytes; size <= ctx.maxBytes;
+           size *= ctx.stepFactor) {
+        size_t count = size / typeSize;
+
+        // Optional data initialization
+        if (dataInitFn) {
+          dataInitFn(ctx, size, count);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // Timed loop
+        ctx.tim.reset();
+        for (int i = 0; i < ctx.numIters; i++) {
+          collFn(ctx, count);
+        }
+        ctx.devHandle->streamSynchronize(ctx.stream);
+
+        // Compute average elapsed time across all ranks
+        double elapsedTime = ctx.tim.elapsed() / ctx.numIters;
+        MPI_Allreduce(MPI_IN_PLACE, (void *)&elapsedTime, 1, MPI_DOUBLE,
+                      MPI_SUM, MPI_COMM_WORLD);
+        elapsedTime /= ctx.worldSize;
+
+        // Bandwidth calculation
+        double baseBw = (double)(size) / 1.0E9 / elapsedTime;
+        double algBw = baseBw;
+        double factor = bwFactorFn ? bwFactorFn(ctx.totalProcs) : 1.0;
+        double busBw = baseBw * factor;
+
+        if (ctx.proc == 0 && ctx.color == 0) {
+          printf("Comm size: %zu bytes; Elapsed time: %lf sec; Algo bandwidth: "
+                 "%lf GB/s; Bus bandwidth: %lf GB/s\n",
+                 size, elapsedTime, algBw, busBw);
+        }
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        // Optional post-iteration callback
+        if (postIterFn) {
+          postIterFn(ctx, size, count);
+        }
+      }
     }
   }
 }
@@ -174,64 +231,113 @@ void perfRootBenchmarkLoop(PerfContext &ctx, PerfRootCollFn collFn,
     fprintf(stderr, "Error: stepFactor must be > 1 (got %d)\n", ctx.stepFactor);
     return;
   }
-  for (size_t size = ctx.minBytes; size <= ctx.maxBytes;
-       size *= ctx.stepFactor) {
-    int beginRoot, endRoot;
-    double sumAlgBw = 0;
-    double sumBusBw = 0;
-    double sumTime = 0;
-    int testCount = 0;
 
-    if (ctx.root != -1) {
-      beginRoot = endRoot = ctx.root;
-    } else {
-      beginRoot = 0;
-      endRoot = ctx.totalProcs - 1;
-    }
+  // Determine which types and ops to run
+  int parsedType = ctx.args->getDataType();
+  int parsedOp = ctx.args->getOp();
 
-    for (int r = beginRoot; r <= endRoot; r++) {
-      size_t count = size / sizeof(float);
+  int typeCount, opCount;
+  flagcxDataType_t *runTypes;
+  flagcxRedOp_t *runOps;
+  const char **runTypeNames;
+  const char **runOpNames;
 
-      if (dataInitFn) {
-        dataInitFn(ctx, size, count, r);
+  flagcxDataType_t singleType = ctx.datatype;
+  flagcxRedOp_t singleOp = ctx.op;
+  const char *singleTypeName = test_typenames[parsedType >= 0 ? parsedType : 0];
+  const char *singleOpName = test_opnames[parsedOp >= 0 ? parsedOp : 0];
+
+  if (parsedType != -1) {
+    typeCount = 1;
+    runTypes = &singleType;
+    runTypeNames = &singleTypeName;
+  } else {
+    typeCount = test_typenum;
+    runTypes = test_types;
+    runTypeNames = test_typenames;
+  }
+
+  if (parsedOp != -1) {
+    opCount = 1;
+    runOps = &singleOp;
+    runOpNames = &singleOpName;
+  } else {
+    opCount = test_opnum;
+    runOps = test_ops;
+    runOpNames = test_opnames;
+  }
+
+  for (int ti = 0; ti < typeCount; ti++) {
+    for (int oi = 0; oi < opCount; oi++) {
+      ctx.datatype = runTypes[ti];
+      ctx.op = runOps[oi];
+      size_t typeSize = getFlagcxDataTypeSize(ctx.datatype);
+
+      if (ctx.proc == 0 && ctx.color == 0) {
+        printf("#\n# datatype: %s, op: %s\n#\n", runTypeNames[ti],
+               runOpNames[oi]);
       }
 
-      MPI_Barrier(MPI_COMM_WORLD);
+      for (size_t size = ctx.minBytes; size <= ctx.maxBytes;
+           size *= ctx.stepFactor) {
+        int beginRoot, endRoot;
+        double sumAlgBw = 0;
+        double sumBusBw = 0;
+        double sumTime = 0;
+        int testCount = 0;
 
-      ctx.tim.reset();
-      for (int i = 0; i < ctx.numIters; i++) {
-        collFn(ctx, count, r);
+        if (ctx.root != -1) {
+          beginRoot = endRoot = ctx.root;
+        } else {
+          beginRoot = 0;
+          endRoot = ctx.totalProcs - 1;
+        }
+
+        for (int r = beginRoot; r <= endRoot; r++) {
+          size_t count = size / typeSize;
+
+          if (dataInitFn) {
+            dataInitFn(ctx, size, count, r);
+          }
+
+          MPI_Barrier(MPI_COMM_WORLD);
+
+          ctx.tim.reset();
+          for (int i = 0; i < ctx.numIters; i++) {
+            collFn(ctx, count, r);
+          }
+          ctx.devHandle->streamSynchronize(ctx.stream);
+
+          MPI_Barrier(MPI_COMM_WORLD);
+
+          double elapsedTime = ctx.tim.elapsed() / ctx.numIters;
+          MPI_Allreduce(MPI_IN_PLACE, (void *)&elapsedTime, 1, MPI_DOUBLE,
+                        MPI_SUM, MPI_COMM_WORLD);
+          elapsedTime /= ctx.worldSize;
+
+          double baseBw = (double)(size) / 1.0E9 / elapsedTime;
+          double algBw = baseBw;
+          double factor = bwFactorFn ? bwFactorFn(ctx.totalProcs) : 1.0;
+          double busBw = baseBw * factor;
+          sumAlgBw += algBw;
+          sumBusBw += busBw;
+          sumTime += elapsedTime;
+          testCount++;
+
+          if (postIterFn) {
+            postIterFn(ctx, size, count, r);
+          }
+        }
+
+        if (ctx.proc == 0 && ctx.color == 0) {
+          double algBw = sumAlgBw / testCount;
+          double busBw = sumBusBw / testCount;
+          double elapsedTime = sumTime / testCount;
+          printf("Comm size: %zu bytes; Elapsed time: %lf sec; Algo bandwidth: "
+                 "%lf GB/s; Bus bandwidth: %lf GB/s\n",
+                 size, elapsedTime, algBw, busBw);
+        }
       }
-      ctx.devHandle->streamSynchronize(ctx.stream);
-
-      MPI_Barrier(MPI_COMM_WORLD);
-
-      double elapsedTime = ctx.tim.elapsed() / ctx.numIters;
-      MPI_Allreduce(MPI_IN_PLACE, (void *)&elapsedTime, 1, MPI_DOUBLE, MPI_SUM,
-                    MPI_COMM_WORLD);
-      elapsedTime /= ctx.worldSize;
-
-      double baseBw = (double)(size) / 1.0E9 / elapsedTime;
-      double algBw = baseBw;
-      double factor = bwFactorFn ? bwFactorFn(ctx.totalProcs) : 1.0;
-      double busBw = baseBw * factor;
-      sumAlgBw += algBw;
-      sumBusBw += busBw;
-      sumTime += elapsedTime;
-      testCount++;
-
-      if (postIterFn) {
-        postIterFn(ctx, size, count, r);
-      }
-    }
-
-    if (ctx.proc == 0 && ctx.color == 0) {
-      double algBw = sumAlgBw / testCount;
-      double busBw = sumBusBw / testCount;
-      double elapsedTime = sumTime / testCount;
-      printf("Comm size: %zu bytes; Elapsed time: %lf sec; Algo bandwidth: "
-             "%lf GB/s; Bus bandwidth: %lf GB/s\n",
-             size, elapsedTime, algBw, busBw);
     }
   }
 }

--- a/test/tools.cc
+++ b/test/tools.cc
@@ -16,10 +16,13 @@ const char *test_typenames[] = {"int8",   "uint8",   "int32", "uint32",
 int test_typenum = 10;
 
 // Reduction op tables
+// Note: flagcxAvg is excluded from the default "all" sweep (test_opnum=4)
+// because it is not supported by all adaptors (MPI, Gloo). Users can still
+// explicitly select it with --op avg on supported backends.
 const flagcxRedOp_t test_ops[] = {flagcxSum, flagcxProd, flagcxMax, flagcxMin,
                                   flagcxAvg};
 const char *test_opnames[] = {"sum", "prod", "max", "min", "avg"};
-int test_opnum = 5;
+int test_opnum = 4; // only sweep sum/prod/max/min in "all" mode
 
 int flagcxStringToType(const char *str) {
   for (int t = 0; t < test_typenum; t++) {
@@ -33,7 +36,9 @@ int flagcxStringToType(const char *str) {
 }
 
 int flagcxStringToOp(const char *str) {
-  for (int o = 0; o < test_opnum; o++) {
+  // Search all ops including avg (which is beyond test_opnum)
+  static const int totalOps = 5;
+  for (int o = 0; o < totalOps; o++) {
     if (strcmp(str, test_opnames[o]) == 0)
       return o;
   }

--- a/test/tools.cc
+++ b/test/tools.cc
@@ -37,7 +37,7 @@ int flagcxStringToType(const char *str) {
 
 int flagcxStringToOp(const char *str) {
   // Search all ops including avg (which is beyond test_opnum)
-  static const int totalOps = 5;
+  static const int totalOps = sizeof(test_ops) / sizeof(test_ops[0]);
   for (int o = 0; o < totalOps; o++) {
     if (strcmp(str, test_opnames[o]) == 0)
       return o;

--- a/test/tools.cc
+++ b/test/tools.cc
@@ -7,7 +7,7 @@
 #include <libgen.h>
 
 // Datatype tables
-flagcxDataType_t test_types[] = {
+const flagcxDataType_t test_types[] = {
     flagcxInt8,   flagcxUint8,   flagcxInt32,   flagcxUint32,  flagcxInt64,
     flagcxUint64, flagcxFloat16, flagcxFloat32, flagcxFloat64, flagcxBfloat16};
 const char *test_typenames[] = {"int8",   "uint8",   "int32", "uint32",
@@ -16,8 +16,8 @@ const char *test_typenames[] = {"int8",   "uint8",   "int32", "uint32",
 int test_typenum = 10;
 
 // Reduction op tables
-flagcxRedOp_t test_ops[] = {flagcxSum, flagcxProd, flagcxMax, flagcxMin,
-                            flagcxAvg};
+const flagcxRedOp_t test_ops[] = {flagcxSum, flagcxProd, flagcxMax, flagcxMin,
+                                  flagcxAvg};
 const char *test_opnames[] = {"sum", "prod", "max", "min", "avg"};
 int test_opnum = 5;
 

--- a/test/tools.cc
+++ b/test/tools.cc
@@ -2,8 +2,46 @@
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <getopt.h>
 #include <libgen.h>
+
+// Datatype tables
+flagcxDataType_t test_types[] = {
+    flagcxInt8,   flagcxUint8,   flagcxInt32,   flagcxUint32,  flagcxInt64,
+    flagcxUint64, flagcxFloat16, flagcxFloat32, flagcxFloat64, flagcxBfloat16};
+const char *test_typenames[] = {"int8",   "uint8",   "int32", "uint32",
+                                "int64",  "uint64",  "half",  "float",
+                                "double", "bfloat16"};
+int test_typenum = 10;
+
+// Reduction op tables
+flagcxRedOp_t test_ops[] = {flagcxSum, flagcxProd, flagcxMax, flagcxMin,
+                            flagcxAvg};
+const char *test_opnames[] = {"sum", "prod", "max", "min", "avg"};
+int test_opnum = 5;
+
+int flagcxStringToType(const char *str) {
+  for (int t = 0; t < test_typenum; t++) {
+    if (strcmp(str, test_typenames[t]) == 0)
+      return t;
+  }
+  if (strcmp(str, "all") == 0)
+    return -1;
+  printf("invalid datatype '%s', defaulting to float\n", str);
+  return flagcxFloat;
+}
+
+int flagcxStringToOp(const char *str) {
+  for (int o = 0; o < test_opnum; o++) {
+    if (strcmp(str, test_opnames[o]) == 0)
+      return o;
+  }
+  if (strcmp(str, "all") == 0)
+    return -1;
+  printf("invalid op '%s', defaulting to sum\n", str);
+  return flagcxSum;
+}
 
 void initMpiEnv(int argc, char **argv, int &worldRank, int &worldSize,
                 int &proc, int &totalProcs, int &color, MPI_Comm &splitComm,
@@ -87,6 +125,8 @@ parser::parser(int argc, char **argv) {
   root = -1;
   splitMask = 0;
   localRegister = 0;
+  datatype = flagcxFloat;
+  op = flagcxSum;
 
   double parsedValue;
   int longIndex;
@@ -100,14 +140,15 @@ parser::parser(int argc, char **argv) {
       {"root", required_argument, 0, 'r'},
       {"split_mask", required_argument, 0, 's'},
       {"local_register", required_argument, 0, 'R'},
-      // {"op", required_argument, 0, 'o'},
-      // {"datatype", required_argument, 0, 'd'},
+      {"op", required_argument, 0, 'o'},
+      {"datatype", required_argument, 0, 'd'},
       {"help", no_argument, 0, 'h'},
       {}};
 
   while (1) {
     int c;
-    c = getopt_long(argc, argv, "b:e:f:w:n:p:r:s:R:h", longOpts, &longIndex);
+    c = getopt_long(argc, argv, "b:e:f:w:n:p:r:s:R:o:d:h", longOpts,
+                    &longIndex);
 
     if (c == -1)
       break;
@@ -176,6 +217,12 @@ parser::parser(int argc, char **argv) {
           exit(1);
         }
         break;
+      case 'd':
+        datatype = flagcxStringToType(optarg);
+        break;
+      case 'o':
+        op = flagcxStringToOp(optarg);
+        break;
       case 'h':
       default:
         if (c != 'h')
@@ -190,10 +237,12 @@ parser::parser(int argc, char **argv) {
                "[-r <root>] \n\t"
                "[-s <splitmask OCT/DEC/HEX>] \n\t"
                "[-R <localregister 0/1/2>] \n\t"
+               "[-d <datatype/all>] \n\t"
+               "[-o <op/all>] \n\t"
                "[-h\n",
                basename(argv[0]));
         printf("Use default values with -b 1M -e 1G -f 2 -w 5 -n 20 -p 0 -r 0 "
-               "-s 0 -R 0\n");
+               "-s 0 -R 0 -d float -o sum\n");
         break;
     }
   }


### PR DESCRIPTION
### PR Category
CICD

### PR Types
Test Case

### PR Description
This PR extends the host-api performance test harness to accept --datatype/-d and --op/-o from the CLI, propagates those settings through PerfContext, and updates multiple perf benchmarks to use ctx.datatype / ctx.op instead of hardcoded flagcxFloat / flagcxSum. It also adds an “all” mode to iterate across all supported datatypes and reduction ops during the benchmark loops.