### PR TITLE
[ CRL] Kernel proxy bypass RMA Proxy with direct netAdaptor posting

### DIFF
--- a/flagcx/adaptor/device/cuda_adaptor.cc
+++ b/flagcx/adaptor/device/cuda_adaptor.cc
@@ -543,8 +543,6 @@ cudaAdaptorMemGetHandleForAddressRange(void *handleOut, void *buffer,
   CUresult err = cuMemGetHandleForAddressRange(
       handleOut, dptr, size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, flags);
   if (err != CUDA_SUCCESS) {
-    // Clear the sticky CUDA error so downstream kernel launches aren't affected
-    (void)cudaGetLastError();
     return flagcxUnhandledDeviceError;
   }
   return flagcxSuccess;

--- a/flagcx/adaptor/device/cuda_adaptor.cc
+++ b/flagcx/adaptor/device/cuda_adaptor.cc
@@ -540,8 +540,13 @@ flagcxResult_t
 cudaAdaptorMemGetHandleForAddressRange(void *handleOut, void *buffer,
                                        size_t size, unsigned long long flags) {
   CUdeviceptr dptr = (CUdeviceptr)buffer;
-  DEVCHECK(cuMemGetHandleForAddressRange(
-      handleOut, dptr, size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, flags));
+  CUresult err = cuMemGetHandleForAddressRange(
+      handleOut, dptr, size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, flags);
+  if (err != CUDA_SUCCESS) {
+    // Clear the sticky CUDA error so downstream kernel launches aren't affected
+    (void)cudaGetLastError();
+    return flagcxUnhandledDeviceError;
+  }
   return flagcxSuccess;
 }
 
@@ -575,8 +580,6 @@ flagcxResult_t cudaAdaptorSymPhysAlloc(void *ptr, size_t size,
     return flagcxSystemError;
 
   // Retain the physical allocation handle from the VMM-backed pointer
-  INFO(FLAGCX_INIT, "[symPhysAlloc] retaining handle for ptr=%p size=%zu", ptr,
-       size);
   CUresult retainRes = cuMemRetainAllocationHandle(cuHandle, ptr);
   if (retainRes != CUDA_SUCCESS) {
     WARN("[symPhysAlloc] cuMemRetainAllocationHandle FAILED: %d ptr=%p",
@@ -584,13 +587,10 @@ flagcxResult_t cudaAdaptorSymPhysAlloc(void *ptr, size_t size,
     free(cuHandle);
     return flagcxUnhandledDeviceError;
   }
-  INFO(FLAGCX_INIT, "[symPhysAlloc] retain OK, handle=0x%llx",
-       (unsigned long long)*cuHandle);
 
   // Discover actual physical allocation size (already granularity-aligned)
   size_t actualAllocSize = 0;
   DEVCHECK(cuMemGetAddressRange(NULL, &actualAllocSize, (CUdeviceptr)ptr));
-  INFO(FLAGCX_INIT, "[symPhysAlloc] actualAllocSize=%zu", actualAllocSize);
   *allocSize = actualAllocSize;
 
   // Export as POSIX fd for IPC sharing
@@ -598,7 +598,6 @@ flagcxResult_t cudaAdaptorSymPhysAlloc(void *ptr, size_t size,
     free(cuHandle);
     return flagcxInvalidArgument;
   }
-  INFO(FLAGCX_INIT, "[symPhysAlloc] exporting shareable handle...");
   CUresult exportRes = cuMemExportToShareableHandle(
       shareableHandle, *cuHandle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0);
   if (exportRes != CUDA_SUCCESS) {
@@ -607,7 +606,8 @@ flagcxResult_t cudaAdaptorSymPhysAlloc(void *ptr, size_t size,
     free(cuHandle);
     return flagcxUnhandledDeviceError;
   }
-  INFO(FLAGCX_INIT, "[symPhysAlloc] export OK, fd=%d", *(int *)shareableHandle);
+  INFO(FLAGCX_INIT, "[symPhysAlloc] ptr=%p allocSize=%zu fd=%d", ptr,
+       actualAllocSize, *(int *)shareableHandle);
   *handleSize = sizeof(int); // POSIX fd is an int
   *physHandle = cuHandle;
   return flagcxSuccess;

--- a/flagcx/adaptor/device/cuda_adaptor.cc
+++ b/flagcx/adaptor/device/cuda_adaptor.cc
@@ -5,7 +5,12 @@
 #include "adaptor.h"
 #include "alloc.h"
 #include "param.h"
+#include <mutex>
 #include <unistd.h>
+#include <unordered_map>
+
+static std::mutex gVmmHandleMapMtx;
+static std::unordered_map<void *, CUmemGenericAllocationHandle> gVmmHandleMap;
 
 std::map<flagcxMemcpyType_t, cudaMemcpyKind> memcpy_type_map = {
     {flagcxMemcpyHostToDevice, cudaMemcpyHostToDevice},
@@ -191,8 +196,12 @@ flagcxResult_t cudaAdaptorGdrMemAlloc(void **ptr, size_t size,
   }
   INFO(FLAGCX_INIT, "[gdrMemAlloc] VMM alloc OK: ptr=%p size=%zu", *ptr,
        handleSize);
-  /* Release the create-time handle reference; the mapping holds its own. */
-  cuMemRelease(handle);
+  /* Retain the handle so cuMemGetHandleForAddressRange can export DMA-BUF fds.
+     Released in cudaAdaptorGdrMemFree. */
+  {
+    std::lock_guard<std::mutex> lk(gVmmHandleMapMtx);
+    gVmmHandleMap[*ptr] = handle;
+  }
 #else
   DEVCHECK(cudaMalloc(ptr, size));
   cudaPointerAttributes attrs;
@@ -218,6 +227,16 @@ flagcxResult_t cudaAdaptorGdrMemFree(void *ptr, void *memHandle) {
   DEVCHECK(cuMemGetAddressRange(NULL, &size, (CUdeviceptr)ptr));
   DEVCHECK(cuMemUnmap((CUdeviceptr)ptr, size));
   DEVCHECK(cuMemAddressFree((CUdeviceptr)ptr, size));
+
+  // Release the VMM handle we retained at alloc time
+  {
+    std::lock_guard<std::mutex> lk(gVmmHandleMapMtx);
+    auto it = gVmmHandleMap.find(ptr);
+    if (it != gVmmHandleMap.end()) {
+      cuMemRelease(it->second);
+      gVmmHandleMap.erase(it);
+    }
+  }
 #else
   DEVCHECK(cudaFree(ptr));
 #endif

--- a/flagcx/adaptor/device/cuda_adaptor.cc
+++ b/flagcx/adaptor/device/cuda_adaptor.cc
@@ -145,22 +145,31 @@ flagcxResult_t cudaAdaptorGdrMemAlloc(void **ptr, size_t size,
   DEVCHECK(cuDeviceGetAttribute(
       &flag, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED,
       currentDev));
+  INFO(FLAGCX_INIT,
+       "[gdrMemAlloc] dev=%d GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED=%d "
+       "size=%zu",
+       cudaDev, flag, size);
   if (flag)
     memprop.allocFlags.gpuDirectRDMACapable = 1;
   DEVCHECK(cuMemGetAllocationGranularity(&memGran, &memprop,
                                          CU_MEM_ALLOC_GRANULARITY_RECOMMENDED));
   ALIGN_SIZE(handleSize, memGran);
+  INFO(FLAGCX_INIT,
+       "[gdrMemAlloc] memGran=%zu handleSize=%zu gpuDirectRDMACapable=%d",
+       memGran, handleSize, (int)memprop.allocFlags.gpuDirectRDMACapable);
   /* Allocate the physical memory on the device */
   DEVCHECK(cuMemCreate(&handle, handleSize, &memprop, 0));
   /* Reserve a virtual address range */
   cuRes = cuMemAddressReserve((CUdeviceptr *)ptr, handleSize, memGran, 0, 0);
   if (cuRes != CUDA_SUCCESS) {
+    WARN("[gdrMemAlloc] cuMemAddressReserve FAILED: %d", (int)cuRes);
     cuMemRelease(handle);
     return flagcxUnhandledDeviceError;
   }
   /* Map the virtual address range to the physical allocation */
   cuRes = cuMemMap((CUdeviceptr)*ptr, handleSize, 0, handle, 0);
   if (cuRes != CUDA_SUCCESS) {
+    WARN("[gdrMemAlloc] cuMemMap FAILED: %d", (int)cuRes);
     cuMemAddressFree((CUdeviceptr)*ptr, handleSize);
     cuMemRelease(handle);
     *ptr = NULL;
@@ -173,12 +182,15 @@ flagcxResult_t cudaAdaptorGdrMemAlloc(void **ptr, size_t size,
   accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
   cuRes = cuMemSetAccess((CUdeviceptr)*ptr, handleSize, &accessDesc, 1);
   if (cuRes != CUDA_SUCCESS) {
+    WARN("[gdrMemAlloc] cuMemSetAccess FAILED: %d", (int)cuRes);
     cuMemUnmap((CUdeviceptr)*ptr, handleSize);
     cuMemAddressFree((CUdeviceptr)*ptr, handleSize);
     cuMemRelease(handle);
     *ptr = NULL;
     return flagcxUnhandledDeviceError;
   }
+  INFO(FLAGCX_INIT, "[gdrMemAlloc] VMM alloc OK: ptr=%p size=%zu", *ptr,
+       handleSize);
   /* Release the create-time handle reference; the mapping holds its own. */
   cuMemRelease(handle);
 #else
@@ -544,11 +556,22 @@ flagcxResult_t cudaAdaptorSymPhysAlloc(void *ptr, size_t size,
     return flagcxSystemError;
 
   // Retain the physical allocation handle from the VMM-backed pointer
-  DEVCHECK(cuMemRetainAllocationHandle(cuHandle, ptr));
+  INFO(FLAGCX_INIT, "[symPhysAlloc] retaining handle for ptr=%p size=%zu", ptr,
+       size);
+  CUresult retainRes = cuMemRetainAllocationHandle(cuHandle, ptr);
+  if (retainRes != CUDA_SUCCESS) {
+    WARN("[symPhysAlloc] cuMemRetainAllocationHandle FAILED: %d ptr=%p",
+         (int)retainRes, ptr);
+    free(cuHandle);
+    return flagcxUnhandledDeviceError;
+  }
+  INFO(FLAGCX_INIT, "[symPhysAlloc] retain OK, handle=0x%llx",
+       (unsigned long long)*cuHandle);
 
   // Discover actual physical allocation size (already granularity-aligned)
   size_t actualAllocSize = 0;
   DEVCHECK(cuMemGetAddressRange(NULL, &actualAllocSize, (CUdeviceptr)ptr));
+  INFO(FLAGCX_INIT, "[symPhysAlloc] actualAllocSize=%zu", actualAllocSize);
   *allocSize = actualAllocSize;
 
   // Export as POSIX fd for IPC sharing
@@ -556,8 +579,16 @@ flagcxResult_t cudaAdaptorSymPhysAlloc(void *ptr, size_t size,
     free(cuHandle);
     return flagcxInvalidArgument;
   }
-  DEVCHECK(cuMemExportToShareableHandle(
-      shareableHandle, *cuHandle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0));
+  INFO(FLAGCX_INIT, "[symPhysAlloc] exporting shareable handle...");
+  CUresult exportRes = cuMemExportToShareableHandle(
+      shareableHandle, *cuHandle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0);
+  if (exportRes != CUDA_SUCCESS) {
+    WARN("[symPhysAlloc] cuMemExportToShareableHandle FAILED: %d",
+         (int)exportRes);
+    free(cuHandle);
+    return flagcxUnhandledDeviceError;
+  }
+  INFO(FLAGCX_INIT, "[symPhysAlloc] export OK, fd=%d", *(int *)shareableHandle);
   *handleSize = sizeof(int); // POSIX fd is an int
   *physHandle = cuHandle;
   return flagcxSuccess;

--- a/flagcx/adaptor/flagcx_device.cc
+++ b/flagcx/adaptor/flagcx_device.cc
@@ -1478,6 +1478,15 @@ void releaseIpcTableSlot(flagcxComm_t comm, int slot) {
   // Move resources to deferred linked list for cleanup at comm destroy
   struct flagcxDeferredIpcEntry *d =
       (struct flagcxDeferredIpcEntry *)malloc(sizeof(*d));
+  if (d == nullptr) {
+    // OOM: leave slot occupied so flagcxCommCleanupIpcTable handles it at
+    // destroy. The slot won't be reusable, but resources are still safe.
+    WARN(
+        "releaseIpcTableSlot: OOM, keeping slot %d occupied until comm destroy",
+        slot);
+    e->inUse = false;
+    return;
+  }
   d->hostPeerPtrs = e->hostPeerPtrs;
   d->devPeerPtrs = e->devPeerPtrs;
   d->nPeers = e->nPeers;

--- a/flagcx/adaptor/flagcx_device.cc
+++ b/flagcx/adaptor/flagcx_device.cc
@@ -1008,7 +1008,7 @@ extern "C" flagcxResult_t flagcxDevCommDestroy(flagcxComm_t comm,
   if (comm != nullptr && comm->heteroComm != nullptr &&
       comm->heteroComm->devCommHandle == devComm) {
     if (devComm->signalBuffer) {
-      flagcxOneSideSignalDeregister(comm->heteroComm);
+      flagcxOneSideSignalDeregister(comm);
     }
     comm->heteroComm->devCommHandle = nullptr;
   }
@@ -1244,11 +1244,10 @@ extern "C" flagcxResult_t flagcxDevMemDestroy(flagcxComm_t comm,
     return flagcxSuccess;
   }
 
-  // Mark IPC table entry as no longer in use (actual cleanup deferred to
-  // flagcxCommDestroy.
-  if (comm != nullptr && devMem->ipcIndex >= 0 &&
-      devMem->ipcIndex < FLAGCX_MAX_IPC_ENTRIES) {
-    comm->ipcTable[devMem->ipcIndex].inUse = false;
+  // Release IPC table slot (resources moved to deferred queue for cleanup at
+  // comm destroy).
+  if (devMem->ipcIndex >= 0) {
+    releaseIpcTableSlot(comm, devMem->ipcIndex);
   }
 
   // Free window allocation if present
@@ -1461,6 +1460,56 @@ flagcxResult_t flagcxCommCleanupIpcTable(flagcxComm_t comm) {
     e->inUse = false;
   }
 
+  return flagcxSuccess;
+}
+
+// ==========================================================================
+// Deferred IPC table slot release.
+// ==========================================================================
+void releaseIpcTableSlot(flagcxComm_t comm, int slot) {
+  if (comm == nullptr || slot < 0 || slot >= FLAGCX_MAX_IPC_ENTRIES)
+    return;
+  struct flagcxIpcTableEntry *e = &comm->ipcTable[slot];
+  if (e->hostPeerPtrs == nullptr && e->devPeerPtrs == nullptr) {
+    e->inUse = false;
+    return;
+  }
+
+  // Move resources to deferred linked list for cleanup at comm destroy
+  struct flagcxDeferredIpcEntry *d =
+      (struct flagcxDeferredIpcEntry *)malloc(sizeof(*d));
+  d->hostPeerPtrs = e->hostPeerPtrs;
+  d->devPeerPtrs = e->devPeerPtrs;
+  d->nPeers = e->nPeers;
+  d->basePtr = e->basePtr;
+  d->next = nullptr;
+  flagcxIntruQueueEnqueue(&comm->deferredIpcQueue, d);
+
+  // Clear slot — now reusable by buildIpcPeerPointers
+  e->hostPeerPtrs = nullptr;
+  e->devPeerPtrs = nullptr;
+  e->nPeers = 0;
+  e->basePtr = nullptr;
+  e->inUse = false;
+}
+
+flagcxResult_t flagcxCommDrainDeferredIpc(flagcxComm_t comm) {
+  if (comm == nullptr)
+    return flagcxSuccess;
+  while (!flagcxIntruQueueEmpty(&comm->deferredIpcQueue)) {
+    struct flagcxDeferredIpcEntry *d =
+        flagcxIntruQueueDequeue(&comm->deferredIpcQueue);
+    if (d->hostPeerPtrs) {
+      for (int j = 0; j < d->nPeers; j++) {
+        if (d->hostPeerPtrs[j] && d->hostPeerPtrs[j] != d->basePtr)
+          deviceAdaptor->ipcMemHandleClose(d->hostPeerPtrs[j]);
+      }
+      free(d->hostPeerPtrs);
+    }
+    if (d->devPeerPtrs)
+      deviceAdaptor->deviceFree(d->devPeerPtrs, flagcxMemDevice, NULL);
+    free(d);
+  }
   return flagcxSuccess;
 }
 

--- a/flagcx/adaptor/include/device_api/default_comm_traits.h
+++ b/flagcx/adaptor/include/device_api/default_comm_traits.h
@@ -494,8 +494,10 @@ struct CommTraits<Default<PlatformTag>> {
     // ---- MR offset helper ----
     FLAGCX_DEVICE_INLINE_DECORATOR
     static size_t toDataOffset(const Window &win, size_t off) {
-      void *ptr = win.getLocalPointer(off);
-      return (uintptr_t)ptr - win.mrBase;
+      // Use rawPtr (the original buffer VA used for MR registration) rather
+      // than getLocalPointer() which may return a VMM flat-mapped VA that
+      // differs from the MR-registered VA.
+      return (uintptr_t)win.getRawPtr() + off - win.mrBase;
     }
 
     // ---- Action decomposition helpers ----

--- a/flagcx/adaptor/net/ibrc_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_adaptor.cc
@@ -1623,10 +1623,6 @@ flagcxResult_t flagcxIbRegMrDmaBufInternal(flagcxIbNetCommDevBase *base,
             "regAddr=0x%lx size=%lld rkey=0x%x lkey=0x%x fd=%d",
             (unsigned long)addr, (long long)pages * pageSize, mr->rkey,
             mr->lkey, fd);
-      INFO(FLAGCX_REG,
-           "[ibRegMr] NEW MR: addr=0x%lx size=%lld rkey=0x%x lkey=0x%x fd=%d",
-           (unsigned long)addr, (long long)pages * pageSize, mr->rkey, mr->lkey,
-           fd);
       if (slot != cache->population)
         memmove(cache->slots + slot + 1, cache->slots + slot,
                 (cache->population - slot) * sizeof(struct flagcxIbMr));
@@ -2441,14 +2437,6 @@ flagcxResult_t flagcxIbIput(void *sendComm, uint64_t srcOff, uint64_t dstOff,
   void *dstPtr = (void *)(dstInfo->baseVas[dstRank] + dstOff);
   int lkey = srcInfo->lkeys[srcRank];
   int rkey = dstInfo->rkeys[dstRank];
-  WARN("flagcxIbIput: srcRank=%d dstRank=%d srcOff=%lu dstOff=%lu "
-       "size=%zu srcPtr=%p dstPtr=%p lkey=0x%x rkey=0x%x "
-       "srcBase=0x%lx dstBase=0x%lx regionSize=%zu/%zu",
-       srcRank, dstRank, (unsigned long)srcOff, (unsigned long)dstOff, size,
-       srcPtr, dstPtr, (unsigned)lkey, (unsigned)rkey,
-       (unsigned long)srcInfo->baseVas[srcRank],
-       (unsigned long)dstInfo->baseVas[dstRank], srcInfo->regionSize,
-       dstInfo->regionSize);
   struct flagcxIbRequest *req;
   FLAGCXCHECK(flagcxIbGetRequest(&comm->base, &req));
   req->type = FLAGCX_NET_IB_REQ_IPUT;
@@ -2693,7 +2681,6 @@ flagcxResult_t flagcxIbIputSignal(void *sendComm, uint64_t srcOff,
     void *dstPtr = (void *)(dstInfo->baseVas[dstRank] + dstOff);
     uint32_t lkey = srcInfo->lkeys[srcRank];
     uint32_t rkey = dstInfo->rkeys[dstRank];
-
     wr[0].opcode = IBV_WR_RDMA_WRITE;
     wr[0].send_flags = 0; // No CQE — only signal gets CQE
     wr[0].wr_id = req - comm->base.reqs;

--- a/flagcx/adaptor/net/ibrc_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_adaptor.cc
@@ -1623,6 +1623,10 @@ flagcxResult_t flagcxIbRegMrDmaBufInternal(flagcxIbNetCommDevBase *base,
             "regAddr=0x%lx size=%lld rkey=0x%x lkey=0x%x fd=%d",
             (unsigned long)addr, (long long)pages * pageSize, mr->rkey,
             mr->lkey, fd);
+      INFO(FLAGCX_REG,
+           "[ibRegMr] NEW MR: addr=0x%lx size=%lld rkey=0x%x lkey=0x%x fd=%d",
+           (unsigned long)addr, (long long)pages * pageSize, mr->rkey, mr->lkey,
+           fd);
       if (slot != cache->population)
         memmove(cache->slots + slot + 1, cache->slots + slot,
                 (cache->population - slot) * sizeof(struct flagcxIbMr));
@@ -2437,6 +2441,14 @@ flagcxResult_t flagcxIbIput(void *sendComm, uint64_t srcOff, uint64_t dstOff,
   void *dstPtr = (void *)(dstInfo->baseVas[dstRank] + dstOff);
   int lkey = srcInfo->lkeys[srcRank];
   int rkey = dstInfo->rkeys[dstRank];
+  WARN("flagcxIbIput: srcRank=%d dstRank=%d srcOff=%lu dstOff=%lu "
+       "size=%zu srcPtr=%p dstPtr=%p lkey=0x%x rkey=0x%x "
+       "srcBase=0x%lx dstBase=0x%lx regionSize=%zu/%zu",
+       srcRank, dstRank, (unsigned long)srcOff, (unsigned long)dstOff, size,
+       srcPtr, dstPtr, (unsigned)lkey, (unsigned)rkey,
+       (unsigned long)srcInfo->baseVas[srcRank],
+       (unsigned long)dstInfo->baseVas[dstRank], srcInfo->regionSize,
+       dstInfo->regionSize);
   struct flagcxIbRequest *req;
   FLAGCXCHECK(flagcxIbGetRequest(&comm->base, &req));
   req->type = FLAGCX_NET_IB_REQ_IPUT;

--- a/flagcx/core/flagcx_hetero.cc
+++ b/flagcx/core/flagcx_hetero.cc
@@ -789,6 +789,9 @@ flagcxResult_t flagcxHeteroFlushRma(flagcxHeteroComm_t comm, int peer,
       return flagcxRemoteError;
     usleep(100);
   }
+  // Check rmaError after wait: doneSeqs may have been advanced despite failure
+  if (__atomic_load_n(&proxy->rmaError, __ATOMIC_ACQUIRE))
+    return flagcxRemoteError;
   return flagcxSuccess;
 }
 

--- a/flagcx/core/flagcx_hetero.cc
+++ b/flagcx/core/flagcx_hetero.cc
@@ -789,8 +789,8 @@ flagcxResult_t flagcxHeteroFlushRma(flagcxHeteroComm_t comm, int peer,
       return flagcxRemoteError;
     usleep(100);
   }
-  // Check rmaError after wait: kernel proxy direct-post path advances doneSeqs
-  // unconditionally (even on failure) to prevent flush hangs.
+  // Final rmaError check: kernel proxy or network failures set rmaError;
+  // catch errors that occurred after doneSeqs reached the target.
   if (__atomic_load_n(&proxy->rmaError, __ATOMIC_ACQUIRE))
     return flagcxRemoteError;
   return flagcxSuccess;
@@ -831,8 +831,8 @@ flagcxResult_t flagcxHeteroFlushAllRma(flagcxHeteroComm_t comm) {
       usleep(100);
     }
   }
-  // Check rmaError after wait: kernel proxy direct-post path advances doneSeqs
-  // unconditionally (even on failure) to prevent flush hangs.
+  // Final rmaError check: kernel proxy or network failures set rmaError;
+  // catch errors that occurred after doneSeqs reached the target.
   if (__atomic_load_n(&proxy->rmaError, __ATOMIC_ACQUIRE))
     return flagcxRemoteError;
   return flagcxSuccess;

--- a/flagcx/core/flagcx_hetero.cc
+++ b/flagcx/core/flagcx_hetero.cc
@@ -789,7 +789,8 @@ flagcxResult_t flagcxHeteroFlushRma(flagcxHeteroComm_t comm, int peer,
       return flagcxRemoteError;
     usleep(100);
   }
-  // Check rmaError after wait: doneSeqs may have been advanced despite failure
+  // Check rmaError after wait: kernel proxy direct-post path advances doneSeqs
+  // unconditionally (even on failure) to prevent flush hangs.
   if (__atomic_load_n(&proxy->rmaError, __ATOMIC_ACQUIRE))
     return flagcxRemoteError;
   return flagcxSuccess;
@@ -830,6 +831,10 @@ flagcxResult_t flagcxHeteroFlushAllRma(flagcxHeteroComm_t comm) {
       usleep(100);
     }
   }
+  // Check rmaError after wait: kernel proxy direct-post path advances doneSeqs
+  // unconditionally (even on failure) to prevent flush hangs.
+  if (__atomic_load_n(&proxy->rmaError, __ATOMIC_ACQUIRE))
+    return flagcxRemoteError;
   return flagcxSuccess;
 }
 

--- a/flagcx/core/include/global_comm.h
+++ b/flagcx/core/include/global_comm.h
@@ -35,6 +35,16 @@ struct flagcxDeferredFree {
   int memType; // flagcxMemDevice, flagcxMemHost, etc.
 };
 
+// Deferred IPC entry — moved from ipcTable when a slot is released at runtime.
+// Actual ipcMemHandleClose + deviceFree happens at comm destroy.
+struct flagcxDeferredIpcEntry {
+  void **hostPeerPtrs;
+  void **devPeerPtrs;
+  int nPeers;
+  void *basePtr;
+  struct flagcxDeferredIpcEntry *next;
+};
+
 // Deferred DevComm buffer handle — buffers that cannot be freed immediately
 // in flagcxDevCommDestroy because peers may still hold IPC mappings to them.
 // Drained at flagcxCommDestroy time.
@@ -109,6 +119,11 @@ struct flagcxComm {
 
   // IPC peer pointer table — deferred cleanup
   struct flagcxIpcTableEntry ipcTable[FLAGCX_MAX_IPC_ENTRIES];
+
+  // Deferred IPC entry queue — IPC resources moved here when slots are released
+  // at runtime; actual ipcMemHandleClose + deviceFree deferred to comm destroy.
+  flagcxIntruQueue<struct flagcxDeferredIpcEntry, &flagcxDeferredIpcEntry::next>
+      deferredIpcQueue;
 
   // Deferred DevComm buffer queue — buffers stashed here during
   // flagcxDevCommDestroy, drained at flagcxCommDestroy.

--- a/flagcx/core/include/onesided.h
+++ b/flagcx/core/include/onesided.h
@@ -41,6 +41,9 @@ struct flagcxOneSideHandleInfo {
   // NULL if VMM not available or window not registered with
   // FLAGCX_WIN_COLL_SYMMETRIC.
   struct flagcxSymWindow *symWin;
+
+  // IPC table slot index for signal buffer D2D bypass (-1 if none).
+  int signalIpcSlot;
 };
 
 // Internal implementation used by sym_heap and flagcxCommRegister

--- a/flagcx/core/include/onesided.h
+++ b/flagcx/core/include/onesided.h
@@ -23,9 +23,19 @@ struct flagcxOneSideHandleInfo {
   void *localMrHandle; // local rank's MR handle for deregMr
   void *localRecvComm; // recvComm used for MR registration (PD match)
   // Full-mesh IB connections (including self loopback, aligned with NCCL GIN)
-  void **fullSendComms; // [nRanks] per-peer sendComm (NULL if not owner)
-  void **fullRecvComms; // [nRanks] per-peer recvComm (NULL if not owner)
+  void **fullSendComms; // [nRanks] per-peer sendComm — alias for
+                        // contextSendComms[0]
+  void **fullRecvComms; // [nRanks] per-peer recvComm — alias for
+                        // contextRecvComms[0]
   int nRanks;           // number of ranks (for cleanup iteration)
+
+  // Per-context QP arrays for thread isolation (NCCL GIN pattern).
+  // Context 0 = RMA proxy; contexts 1..N = kernel proxy threads.
+  // Each context has its own full-mesh of RC QPs so no QP is shared
+  // across threads. All contexts share the same MR handles/rkeys (same PD).
+  void ***contextSendComms; // [nContexts][nRanks]
+  void ***contextRecvComms; // [nContexts][nRanks]
+  int nContexts;            // 1 + nKernelProxies
 
   // Symmetric memory window for intra-node D2D bypass (CE path).
   // NULL if VMM not available or window not registered with

--- a/flagcx/core/include/proxy.h
+++ b/flagcx/core/include/proxy.h
@@ -30,7 +30,7 @@ enum flagcxProxyOpState {
 struct flagcxProxyKernelState {
   pthread_t threads[FLAGCX_DEVICE_CTA_COUNT];
   flagcxFifo_t fifos[FLAGCX_DEVICE_CTA_COUNT];
-  int contextCount = 1;
+  int contextCount = 0;
   flagcxStream_t stream;
   int stop = 0;
   // Synchronization for initialization

--- a/flagcx/core/include/proxy.h
+++ b/flagcx/core/include/proxy.h
@@ -37,6 +37,11 @@ struct flagcxProxyKernelState {
   pthread_mutex_t initMutex;
   pthread_cond_t initCond;
   int ready = 0;
+  // Shared per-peer spinlocks for PUT_VALUE staging slot protection.
+  // All kernel proxy threads lock pvLocks[peer] before writing the staging
+  // buffer and posting iput, preventing cross-thread corruption.
+  pthread_spinlock_t *pvLocks = nullptr;
+  int pvLocksCount = 0;
 };
 
 struct flagcxProxyArgs;

--- a/flagcx/core/include/proxy.h
+++ b/flagcx/core/include/proxy.h
@@ -37,6 +37,7 @@ struct flagcxProxyKernelState {
   pthread_mutex_t initMutex;
   pthread_cond_t initCond;
   int ready = 0;
+  int initFailed = 0;
   // Shared per-peer spinlocks for PUT_VALUE staging slot protection.
   // All kernel proxy threads lock pvLocks[peer] before writing the staging
   // buffer and posting iput, preventing cross-thread corruption.

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -1426,6 +1426,7 @@ static void flagcxKernelProxyPoll(struct flagcxKernelProxyState *state,
                                   struct flagcxHeteroComm *comm) {
   struct flagcxRmaProxyState *proxy = comm->rmaProxy;
   struct flagcxNetAdaptor *net = comm->netAdaptor;
+  bool anyCompleted = false;
   for (int p = 0; p < state->nRanks; p++) {
     struct flagcxKernelProxyPeerState *ps = &state->peers[p];
     while (ps->head != ps->tail) {
@@ -1438,31 +1439,36 @@ static void flagcxKernelProxyPoll(struct flagcxKernelProxyState *state,
         if (res != flagcxSuccess) {
           WARN("flagcxKernelProxyPoll: test failed peer=%d res=%d", p,
                (int)res);
-          __atomic_store_n(&proxy->rmaError, 1, __ATOMIC_RELEASE);
+          __atomic_store_n((int *)&proxy->rmaError, 1, __ATOMIC_RELEASE);
           done = 1;
           failed = true;
         }
       } else {
-        // Post failed earlier; retire without advancing counters.
+        // Post failed earlier; retire as failed.
         done = 1;
         failed = true;
       }
       if (!done)
         break;
       ps->head++;
+      // Always advance doneSeqs (even on failure) to prevent flush hangs.
+      __atomic_store_n((uint64_t *)&proxy->doneSeqs[p], inf->opSeq,
+                       __ATOMIC_RELEASE);
+      if (proxy->doneSeqsCpu != NULL)
+        __atomic_store_n((uint64_t *)&proxy->doneSeqsCpu[p], inf->opSeq,
+                         __ATOMIC_RELEASE);
       if (!failed) {
-        __atomic_store_n(&proxy->doneSeqs[p], inf->opSeq, __ATOMIC_RELEASE);
-        if (proxy->doneSeqsCpu != NULL)
-          __atomic_store_n(&proxy->doneSeqsCpu[p], inf->opSeq,
-                           __ATOMIC_RELEASE);
         __atomic_fetch_add(&proxy->completionCount, 1ULL, __ATOMIC_RELEASE);
-        if (!proxy->useStreamOps) {
-          pthread_mutex_lock(&proxy->doneMutex);
-          pthread_cond_broadcast(&proxy->doneCond);
-          pthread_mutex_unlock(&proxy->doneMutex);
-        }
+        anyCompleted = true;
       }
     }
+  }
+  // Batch the broadcast: signal waiters once per poll sweep, not per
+  // completion.
+  if (anyCompleted && !proxy->useStreamOps) {
+    pthread_mutex_lock(&proxy->doneMutex);
+    pthread_cond_broadcast(&proxy->doneCond);
+    pthread_mutex_unlock(&proxy->doneMutex);
   }
 }
 
@@ -1481,11 +1487,34 @@ flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
     return flagcxInternalError;
   }
 
+  // Validate MR indices (mirrors flagcxHeteroPut/PutValue validation)
+  if (comm->oneSideHandleCount < 1 || comm->oneSideHandles[0] == NULL) {
+    WARN("flagcxKernelProxyPost: no oneSideHandles available");
+    return flagcxInternalError;
+  }
+  if (dstMrIdx >= 0 && dstMrIdx >= comm->oneSideHandleCount) {
+    WARN("flagcxKernelProxyPost: dstMrIdx %d out of range (count=%d)", dstMrIdx,
+         comm->oneSideHandleCount);
+    return flagcxInvalidArgument;
+  }
+  if (srcMrIdx >= 0 && srcMrIdx >= comm->oneSideHandleCount) {
+    WARN("flagcxKernelProxyPost: srcMrIdx %d out of range (count=%d)", srcMrIdx,
+         comm->oneSideHandleCount);
+    return flagcxInvalidArgument;
+  }
+
   // Back-pressure: if ring is full, poll until a slot frees.
+  int spins = 0;
   while ((ps->tail - ps->head) >= FLAGCX_KPROXY_MAX_INFLIGHT) {
     flagcxKernelProxyPoll(state, comm);
-    if ((ps->tail - ps->head) >= FLAGCX_KPROXY_MAX_INFLIGHT)
+    if ((ps->tail - ps->head) >= FLAGCX_KPROXY_MAX_INFLIGHT) {
+      if (++spins > 10000000) {
+        WARN("flagcxKernelProxyPost: back-pressure timeout peer=%d", peer);
+        __atomic_store_n((int *)&proxy->rmaError, 1, __ATOMIC_RELEASE);
+        return flagcxInternalError;
+      }
       sched_yield();
+    }
   }
 
   void *sendComm = comm->oneSideHandles[0]->fullSendComms[peer];
@@ -1497,7 +1526,7 @@ flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
 
   // Assign opSeq (shared atomic counter with RMA Proxy for ordering)
   uint64_t opSeq =
-      __atomic_add_fetch(&proxy->opSeqs[peer], 1, __ATOMIC_RELAXED);
+      __atomic_add_fetch((uint64_t *)&proxy->opSeqs[peer], 1, __ATOMIC_RELAXED);
 
   void *request = NULL;
   flagcxResult_t res = flagcxSuccess;
@@ -1513,13 +1542,8 @@ flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
       break;
     case FLAGCX_RMA_PUT_SIGNAL: {
       void **sigHandles = (void **)comm->signalHandle;
-      if (size > 0 && srcMrIdx >= 0) {
-        srcHandles = (void **)comm->oneSideHandles[srcMrIdx];
-        dstHandles = (void **)comm->oneSideHandles[dstMrIdx];
-      } else {
-        srcHandles = NULL;
-        dstHandles = NULL;
-      }
+      // srcHandles/dstHandles already set above for size>0 && srcMrIdx>=0,
+      // or NULL otherwise — no need to reassign.
       res = net->iputSignal(sendComm, srcOff, dstOff, size, comm->rank, peer,
                             srcHandles, dstHandles, signalOff, sigHandles,
                             signalValue, &request);
@@ -1550,7 +1574,7 @@ flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
   if (res != flagcxSuccess) {
     WARN("flagcxKernelProxyPost: post failed peer=%d type=%d res=%d", peer,
          type, (int)res);
-    __atomic_store_n(&proxy->rmaError, 1, __ATOMIC_RELEASE);
+    __atomic_store_n((int *)&proxy->rmaError, 1, __ATOMIC_RELEASE);
     request = NULL; // will be retired as failed
   }
 
@@ -1565,6 +1589,8 @@ flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
 // Drain all in-flight requests (called at thread shutdown).
 static void flagcxKernelProxyDrain(struct flagcxKernelProxyState *state,
                                    struct flagcxHeteroComm *comm) {
+  if (state->peers == NULL)
+    return;
   struct flagcxNetAdaptor *net = comm->netAdaptor;
   struct flagcxRmaProxyState *proxy = comm->rmaProxy;
   for (int p = 0; p < state->nRanks; p++) {
@@ -1572,23 +1598,28 @@ static void flagcxKernelProxyDrain(struct flagcxKernelProxyState *state,
     while (ps->head != ps->tail) {
       uint32_t idx = ps->head & FLAGCX_KPROXY_RING_MASK;
       struct flagcxKernelProxyInflight *inf = &ps->ring[idx];
+      bool succeeded = false;
       if (inf->request != NULL) {
         int done = 0;
+        bool testFailed = false;
         while (!done) {
           flagcxResult_t res = net->test(inf->request, &done, NULL);
           if (res != flagcxSuccess) {
+            testFailed = true;
             done = 1;
             break;
           }
         }
+        succeeded = !testFailed;
       }
-      if (inf->request != NULL) {
-        __atomic_store_n(&proxy->doneSeqs[p], inf->opSeq, __ATOMIC_RELEASE);
-        if (proxy->doneSeqsCpu != NULL)
-          __atomic_store_n(&proxy->doneSeqsCpu[p], inf->opSeq,
-                           __ATOMIC_RELEASE);
+      // Always advance doneSeqs to prevent flush hangs on failed ops.
+      __atomic_store_n((uint64_t *)&proxy->doneSeqs[p], inf->opSeq,
+                       __ATOMIC_RELEASE);
+      if (proxy->doneSeqsCpu != NULL)
+        __atomic_store_n((uint64_t *)&proxy->doneSeqsCpu[p], inf->opSeq,
+                         __ATOMIC_RELEASE);
+      if (succeeded)
         __atomic_fetch_add(&proxy->completionCount, 1ULL, __ATOMIC_RELEASE);
-      }
       ps->head++;
     }
   }

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -1160,6 +1160,10 @@ flagcxResult_t flagcxProxyInit(struct flagcxHeteroComm *comm) {
     comm->proxyState->progressState.stop = 1;
     pthread_join(comm->proxyState->thread, NULL);
     pthread_join(comm->proxyState->progressState.thread, NULL);
+    free(comm->proxyState->peerAddresses);
+    comm->proxyState->peerAddresses = NULL;
+    pthread_mutex_destroy(&comm->proxyState->kernelState.initMutex);
+    pthread_cond_destroy(&comm->proxyState->kernelState.initCond);
     return flagcxSystemError;
   }
   comm->proxyState->kernelState.pvLocksCount = nRanks;
@@ -1439,7 +1443,6 @@ out:
 
 struct flagcxKernelProxyInflight {
   void *request;
-  uint64_t opSeq;
 };
 
 struct flagcxKernelProxyPeerState {
@@ -1463,7 +1466,6 @@ static void flagcxKernelProxyPoll(struct flagcxKernelProxyState *state,
   struct flagcxNetAdaptor *net = comm->netAdaptor;
   if (proxy == NULL || net == NULL)
     return;
-  bool anyRetired = false;
   for (int p = 0; p < state->nRanks; p++) {
     struct flagcxKernelProxyPeerState *ps = &state->peers[p];
     while (ps->head != ps->tail) {
@@ -1489,47 +1491,21 @@ static void flagcxKernelProxyPoll(struct flagcxKernelProxyState *state,
         break;
       ps->head++;
       state->totalInflight--;
-      anyRetired = true;
-      // CAS max-tracking: multiple kernel proxy threads may complete ops for
-      // the same peer out of order. Only advance doneSeqs forward.
-      uint64_t prev =
-          __atomic_load_n((uint64_t *)&proxy->doneSeqs[p], __ATOMIC_RELAXED);
-      while (inf->opSeq > prev) {
-        if (__atomic_compare_exchange_n((uint64_t *)&proxy->doneSeqs[p], &prev,
-                                        inf->opSeq, true, __ATOMIC_RELEASE,
-                                        __ATOMIC_RELAXED))
-          break;
-      }
-      if (proxy->doneSeqsCpu != NULL) {
-        prev = __atomic_load_n((uint64_t *)&proxy->doneSeqsCpu[p],
-                               __ATOMIC_RELAXED);
-        while (inf->opSeq > prev) {
-          if (__atomic_compare_exchange_n((uint64_t *)&proxy->doneSeqsCpu[p],
-                                          &prev, inf->opSeq, true,
-                                          __ATOMIC_RELEASE, __ATOMIC_RELAXED))
-            break;
-        }
-      }
+      // Kernel proxy threads no longer update proxy->doneSeqs/opSeqs.
+      // Completion is communicated to GPU via signal/counter mechanism.
       if (!failed) {
         __atomic_fetch_add(&proxy->completionCount, 1ULL, __ATOMIC_RELEASE);
       }
     }
   }
-  // Batch the broadcast: signal waiters once per poll sweep on any retirement.
-  if (anyRetired && !proxy->useStreamOps) {
-    pthread_mutex_lock(&proxy->doneMutex);
-    pthread_cond_broadcast(&proxy->doneCond);
-    pthread_mutex_unlock(&proxy->doneMutex);
-  }
 }
 
 // Post an IB operation directly from the kernel proxy thread.
-static flagcxResult_t
-flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
-                      struct flagcxHeteroComm *comm, int peer, int type,
-                      uint64_t srcOff, uint64_t dstOff, size_t size,
-                      int srcMrIdx, int dstMrIdx, uint64_t signalOff,
-                      uint64_t signalValue, uint64_t putValue) {
+static flagcxResult_t flagcxKernelProxyPost(
+    struct flagcxKernelProxyState *state, struct flagcxHeteroComm *comm,
+    int peer, int type, int contextId, uint64_t srcOff, uint64_t dstOff,
+    size_t size, int srcMrIdx, int dstMrIdx, uint64_t signalOff,
+    uint64_t signalValue, uint64_t putValue) {
   struct flagcxKernelProxyPeerState *ps = &state->peers[peer];
   struct flagcxRmaProxyState *proxy = comm->rmaProxy;
   struct flagcxNetAdaptor *net = comm->netAdaptor;
@@ -1575,9 +1551,20 @@ flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
     }
   }
 
-  void *sendComm = comm->oneSideHandles[0]->fullSendComms[peer];
+  // Use this context's own QP (context 0 = RMA proxy, contexts 1..N = kernel
+  // proxy).
+  int ctx = contextId + 1;
+  struct flagcxOneSideHandleInfo *h0 = comm->oneSideHandles[0];
+  if (h0->contextSendComms == NULL || ctx >= h0->nContexts) {
+    WARN("flagcxKernelProxyPost: contextSendComms not available ctx=%d "
+         "nContexts=%d",
+         ctx, h0->nContexts);
+    return flagcxInternalError;
+  }
+  void *sendComm = h0->contextSendComms[ctx][peer];
   if (sendComm == NULL) {
-    WARN("flagcxKernelProxyPost: sendComm is NULL for peer=%d", peer);
+    WARN("flagcxKernelProxyPost: sendComm is NULL for ctx=%d peer=%d", ctx,
+         peer);
     return flagcxInternalError;
   }
   void **srcHandles = NULL, **dstHandles = NULL;
@@ -1592,13 +1579,9 @@ flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
     return flagcxInvalidArgument;
   }
 
-  // Assign opSeq (shared atomic counter with RMA Proxy for ordering).
-  // Multiple kernel proxy threads may post to the same peer concurrently,
-  // and the RMA Proxy thread may also post (via stream path). The atomic
-  // increment ensures unique opSeqs; completion order may differ from
-  // assignment order, so Poll uses CAS max-tracking on doneSeqs.
-  uint64_t opSeq =
-      __atomic_add_fetch((uint64_t *)&proxy->opSeqs[peer], 1, __ATOMIC_RELAXED);
+  // Kernel proxy threads use their own per-context QPs and do not participate
+  // in the RMA proxy's opSeqs/doneSeqs tracking. Completion is signaled to the
+  // GPU via the signal/counter mechanism (WaitSignal).
 
   void *request = NULL;
   flagcxResult_t res = flagcxSuccess;
@@ -1688,6 +1671,11 @@ flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
       // sge, not inline copy). Without this, another thread could overwrite
       // the staging slot while the previous RDMA WRITE is still in-flight.
       pthread_spinlock_t *pvLocks = comm->proxyState->kernelState.pvLocks;
+      if (pvLocks == NULL) {
+        WARN("flagcxKernelProxyPost: pvLocks not initialized");
+        res = flagcxInternalError;
+        break;
+      }
       pthread_spin_lock(&pvLocks[peer]);
       *staging = putValue;
       void **stagingHandles = (void **)stagingH;
@@ -1707,33 +1695,9 @@ flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
         }
       }
       pthread_spin_unlock(&pvLocks[peer]);
-      // PUT_VALUE completes inline — update doneSeqs directly, skip ring.
+      // PUT_VALUE completes inline — no ring entry needed.
       if (res == flagcxSuccess) {
-        // CAS max-tracking (same pattern as Poll/Drain).
-        uint64_t prev = __atomic_load_n((uint64_t *)&proxy->doneSeqs[peer],
-                                        __ATOMIC_RELAXED);
-        while (opSeq > prev) {
-          if (__atomic_compare_exchange_n((uint64_t *)&proxy->doneSeqs[peer],
-                                          &prev, opSeq, true, __ATOMIC_RELEASE,
-                                          __ATOMIC_RELAXED))
-            break;
-        }
-        if (proxy->doneSeqsCpu != NULL) {
-          prev = __atomic_load_n((uint64_t *)&proxy->doneSeqsCpu[peer],
-                                 __ATOMIC_RELAXED);
-          while (opSeq > prev) {
-            if (__atomic_compare_exchange_n(
-                    (uint64_t *)&proxy->doneSeqsCpu[peer], &prev, opSeq, true,
-                    __ATOMIC_RELEASE, __ATOMIC_RELAXED))
-              break;
-          }
-        }
         __atomic_fetch_add(&proxy->completionCount, 1ULL, __ATOMIC_RELEASE);
-        if (!proxy->useStreamOps) {
-          pthread_mutex_lock(&proxy->doneMutex);
-          pthread_cond_broadcast(&proxy->doneCond);
-          pthread_mutex_unlock(&proxy->doneMutex);
-        }
       } else {
         WARN("flagcxKernelProxyPost: PUT_VALUE failed peer=%d res=%d", peer,
              (int)res);
@@ -1755,7 +1719,6 @@ flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
 
   uint32_t idx = ps->tail & FLAGCX_KPROXY_RING_MASK;
   ps->ring[idx].request = request;
-  ps->ring[idx].opSeq = opSeq;
   ps->tail++;
   state->totalInflight++;
 
@@ -1795,38 +1758,31 @@ static void flagcxKernelProxyDrain(struct flagcxKernelProxyState *state,
         }
         succeeded = !testFailed;
       }
-      // CAS max-tracking: another thread may have already advanced doneSeqs
-      // past our opSeq if it had a higher opSeq that completed earlier.
-      // Use the same pattern as flagcxKernelProxyPoll to avoid regression.
-      uint64_t prev =
-          __atomic_load_n((uint64_t *)&proxy->doneSeqs[p], __ATOMIC_RELAXED);
-      while (inf->opSeq > prev) {
-        if (__atomic_compare_exchange_n((uint64_t *)&proxy->doneSeqs[p], &prev,
-                                        inf->opSeq, true, __ATOMIC_RELEASE,
-                                        __ATOMIC_RELAXED))
-          break;
-      }
-      if (proxy->doneSeqsCpu != NULL) {
-        prev = __atomic_load_n((uint64_t *)&proxy->doneSeqsCpu[p],
-                               __ATOMIC_RELAXED);
-        while (inf->opSeq > prev) {
-          if (__atomic_compare_exchange_n((uint64_t *)&proxy->doneSeqsCpu[p],
-                                          &prev, inf->opSeq, true,
-                                          __ATOMIC_RELEASE, __ATOMIC_RELAXED))
-            break;
-        }
-      }
       if (succeeded)
         __atomic_fetch_add(&proxy->completionCount, 1ULL, __ATOMIC_RELEASE);
       ps->head++;
     }
   }
-  // Final broadcast to unblock any waiters
-  if (proxy && !proxy->useStreamOps) {
-    pthread_mutex_lock(&proxy->doneMutex);
-    pthread_cond_broadcast(&proxy->doneCond);
-    pthread_mutex_unlock(&proxy->doneMutex);
-  }
+}
+
+// Validate that a one-sided peer is reachable via the given context's QP.
+static flagcxResult_t
+flagcxKernelProxyValidatePeer(struct flagcxHeteroComm *comm, int peerRank,
+                              int ctx) {
+  struct flagcxOneSideHandleInfo *meshH =
+      (comm->oneSideHandleCount > 0) ? comm->oneSideHandles[0] : NULL;
+  if (meshH == NULL)
+    return flagcxNotSupported;
+  if (peerRank < 0 || peerRank >= comm->nRanks)
+    return flagcxInvalidArgument;
+
+  // Check per-context full-mesh connection exists for this peer
+  if (meshH->contextSendComms == NULL || ctx >= meshH->nContexts ||
+      meshH->contextSendComms[ctx] == NULL ||
+      meshH->contextSendComms[ctx][peerRank] == NULL)
+    return flagcxNotSupported;
+
+  return flagcxSuccess;
 }
 
 void *flagcxProxyKernelService(void *args) {
@@ -1842,21 +1798,7 @@ void *flagcxProxyKernelService(void *args) {
   delete arg;
   flagcxResult_t res = flagcxSuccess;
 
-  auto validateOneSidedPeer = [](struct flagcxHeteroComm *comm,
-                                 int peerRank) -> flagcxResult_t {
-    struct flagcxOneSideHandleInfo *meshH =
-        (comm->oneSideHandleCount > 0) ? comm->oneSideHandles[0] : NULL;
-    if (meshH == NULL)
-      return flagcxNotSupported;
-    if (peerRank < 0 || peerRank >= comm->nRanks)
-      return flagcxInvalidArgument;
-
-    // Check full-mesh connection exists for this peer (including self-loopback)
-    if (meshH->fullSendComms == NULL || meshH->fullSendComms[peerRank] == NULL)
-      return flagcxNotSupported;
-
-    return flagcxSuccess;
-  };
+  int ctx = contextId + 1; // kernel proxy context index
 
   // Set device context
   FLAGCXCHECKGOTO(deviceAdaptor->setDevice(comm->cudaDev), res, out);
@@ -1884,23 +1826,30 @@ void *flagcxProxyKernelService(void *args) {
   kproxyState =
       (struct flagcxKernelProxyState *)calloc(1, sizeof(*kproxyState));
   if (kproxyState == NULL) {
+    WARN("flagcxProxyKernelService: failed to allocate kproxyState");
     res = flagcxSystemError;
-    goto out;
+    goto init_done;
   }
   kproxyState->nRanks = comm->nRanks;
   kproxyState->totalInflight = 0;
   kproxyState->peers = (struct flagcxKernelProxyPeerState *)calloc(
       comm->nRanks, sizeof(struct flagcxKernelProxyPeerState));
   if (kproxyState->peers == NULL) {
+    WARN("flagcxProxyKernelService: failed to allocate peers array");
     res = flagcxSystemError;
-    goto out;
+    goto init_done;
   }
 
-  // Signal that initialization is complete
+init_done:
+  // Signal initialization complete (even on failure, so init thread doesn't
+  // deadlock)
   pthread_mutex_lock(&comm->proxyState->kernelState.initMutex);
   comm->proxyState->kernelState.ready++;
   pthread_cond_broadcast(&comm->proxyState->kernelState.initCond);
   pthread_mutex_unlock(&comm->proxyState->kernelState.initMutex);
+
+  if (res != flagcxSuccess)
+    goto out;
 
   while (true) {
     if (comm->proxyState->kernelState.stop == 1)
@@ -1969,7 +1918,7 @@ void *flagcxProxyKernelService(void *args) {
               "rank=%d flagcxDevicePrimPut called by proxyKernelService.",
               comm->rank);
         int peerRank = (int)ptr->getPeerRank();
-        res = validateOneSidedPeer(comm, peerRank);
+        res = flagcxKernelProxyValidatePeer(comm, peerRank, ctx);
         if (res != flagcxSuccess)
           break;
         int srcMrIdx = (int)ptr->getSrcMrIdx();
@@ -1978,8 +1927,8 @@ void *flagcxProxyKernelService(void *args) {
         size_t dstOffset = (size_t)ptr->getDstOffset();
         size_t size = (size_t)ptr->getSize();
         res = flagcxKernelProxyPost(kproxyState, comm, peerRank, FLAGCX_RMA_PUT,
-                                    srcOffset, dstOffset, size, srcMrIdx,
-                                    dstMrIdx, 0, 0, 0);
+                                    contextId, srcOffset, dstOffset, size,
+                                    srcMrIdx, dstMrIdx, 0, 0, 0);
         break;
       }
       case flagcxDevicePrimSignal: {
@@ -1994,7 +1943,7 @@ void *flagcxProxyKernelService(void *args) {
         if (bufType == 0) {
           // Signal buffer: RDMA FETCH_AND_ADD to peer's signalBuffer
           int peerRank = (int)ptr->getPeerRank();
-          res = validateOneSidedPeer(comm, peerRank);
+          res = flagcxKernelProxyValidatePeer(comm, peerRank, ctx);
           if (res != flagcxSuccess)
             break;
           if (comm->signalHandle == NULL) {
@@ -2005,8 +1954,8 @@ void *flagcxProxyKernelService(void *args) {
             break;
           }
           res = flagcxKernelProxyPost(kproxyState, comm, peerRank,
-                                      FLAGCX_RMA_PUT_SIGNAL, 0, 0, 0, -1, -1,
-                                      signalOff, signalValue, 0);
+                                      FLAGCX_RMA_PUT_SIGNAL, contextId, 0, 0, 0,
+                                      -1, -1, signalOff, signalValue, 0);
         } else {
           // Counter buffer: local CPU atomic increment (no network operation)
           flagcxDevComm_t dc = comm->devCommHandle;
@@ -2054,7 +2003,7 @@ void *flagcxProxyKernelService(void *args) {
               "rank=%d flagcxDevicePrimPutSignal called by proxyKernelService.",
               comm->rank);
         int peerRank = (int)ptr->getPeerRank();
-        res = validateOneSidedPeer(comm, peerRank);
+        res = flagcxKernelProxyValidatePeer(comm, peerRank, ctx);
         if (res != flagcxSuccess)
           break;
         int srcMrIdx = (int)ptr->getSrcMrIdx();
@@ -2071,22 +2020,23 @@ void *flagcxProxyKernelService(void *args) {
           res = flagcxInternalError;
           break;
         }
-        res = flagcxKernelProxyPost(
-            kproxyState, comm, peerRank, FLAGCX_RMA_PUT_SIGNAL, srcOffset,
-            dstOffset, size, srcMrIdx, dstMrIdx, signalOff, signalValue, 0);
+        res = flagcxKernelProxyPost(kproxyState, comm, peerRank,
+                                    FLAGCX_RMA_PUT_SIGNAL, contextId, srcOffset,
+                                    dstOffset, size, srcMrIdx, dstMrIdx,
+                                    signalOff, signalValue, 0);
         break;
       }
       case flagcxDevicePrimPutValue: {
         int peerRank = (int)ptr->getPeerRank();
-        res = validateOneSidedPeer(comm, peerRank);
+        res = flagcxKernelProxyValidatePeer(comm, peerRank, ctx);
         if (res != flagcxSuccess)
           break;
         int dstMrIdx = (int)ptr->getDstMrIdx();
         size_t dstOffset = (size_t)ptr->getDstOffset();
         uint64_t value = ptr->getValue();
         res = flagcxKernelProxyPost(kproxyState, comm, peerRank,
-                                    FLAGCX_RMA_PUT_VALUE, 0, dstOffset, 0, -1,
-                                    dstMrIdx, 0, 0, value);
+                                    FLAGCX_RMA_PUT_VALUE, contextId, 0,
+                                    dstOffset, 0, -1, dstMrIdx, 0, 0, value);
         break;
       }
       case flagcxDevicePrimGet: {
@@ -2094,7 +2044,7 @@ void *flagcxProxyKernelService(void *args) {
               "rank=%d flagcxDevicePrimGet called by proxyKernelService.",
               comm->rank);
         int peerRank = (int)ptr->getPeerRank();
-        res = validateOneSidedPeer(comm, peerRank);
+        res = flagcxKernelProxyValidatePeer(comm, peerRank, ctx);
         if (res != flagcxSuccess)
           break;
         int srcMrIdx = (int)ptr->getSrcMrIdx();
@@ -2103,8 +2053,8 @@ void *flagcxProxyKernelService(void *args) {
         size_t dstOffset = (size_t)ptr->getDstOffset();
         size_t size = (size_t)ptr->getSize();
         res = flagcxKernelProxyPost(kproxyState, comm, peerRank, FLAGCX_RMA_GET,
-                                    srcOffset, dstOffset, size, srcMrIdx,
-                                    dstMrIdx, 0, 0, 0);
+                                    contextId, srcOffset, dstOffset, size,
+                                    srcMrIdx, dstMrIdx, 0, 0, 0);
         break;
       }
       case flagcxDevicePrimWait:

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -1193,7 +1193,14 @@ flagcxResult_t flagcxProxyInit(struct flagcxHeteroComm *comm) {
     pthread_cond_wait(&comm->proxyState->kernelState.initCond,
                       &comm->proxyState->kernelState.initMutex);
   }
+  int initFailed = comm->proxyState->kernelState.initFailed;
   pthread_mutex_unlock(&comm->proxyState->kernelState.initMutex);
+
+  if (initFailed > 0) {
+    WARN("flagcxProxyInit: %d kernel proxy thread(s) failed initialization",
+         initFailed);
+    return flagcxSystemError;
+  }
 
   if (nStarted == 0) {
     WARN("flagcxProxyInit: no kernel proxy threads started");
@@ -1845,6 +1852,8 @@ init_done:
   // deadlock)
   pthread_mutex_lock(&comm->proxyState->kernelState.initMutex);
   comm->proxyState->kernelState.ready++;
+  if (res != flagcxSuccess)
+    comm->proxyState->kernelState.initFailed++;
   pthread_cond_broadcast(&comm->proxyState->kernelState.initCond);
   pthread_mutex_unlock(&comm->proxyState->kernelState.initMutex);
 

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -1397,12 +1397,216 @@ out:
   return NULL;
 }
 
+// ============================================================================
+// Kernel Proxy Direct NetAdaptor Posting
+// Bypasses RMA Proxy: posts IB ops directly from kernel proxy thread.
+// ============================================================================
+
+#define FLAGCX_KPROXY_MAX_INFLIGHT 256
+#define FLAGCX_KPROXY_RING_MASK (FLAGCX_KPROXY_MAX_INFLIGHT - 1)
+
+struct flagcxKernelProxyInflight {
+  void *request;
+  uint64_t opSeq;
+};
+
+struct flagcxKernelProxyPeerState {
+  struct flagcxKernelProxyInflight ring[FLAGCX_KPROXY_MAX_INFLIGHT];
+  uint32_t head; // oldest outstanding
+  uint32_t tail; // next slot to write
+};
+
+struct flagcxKernelProxyState {
+  struct flagcxKernelProxyPeerState *peers; // [nRanks]
+  int nRanks;
+};
+
+// Poll completions for all peers. Non-blocking sweep.
+static void flagcxKernelProxyPoll(struct flagcxKernelProxyState *state,
+                                  struct flagcxHeteroComm *comm) {
+  struct flagcxRmaProxyState *proxy = comm->rmaProxy;
+  struct flagcxNetAdaptor *net = comm->netAdaptor;
+  for (int p = 0; p < state->nRanks; p++) {
+    struct flagcxKernelProxyPeerState *ps = &state->peers[p];
+    while (ps->head != ps->tail) {
+      uint32_t idx = ps->head & FLAGCX_KPROXY_RING_MASK;
+      struct flagcxKernelProxyInflight *inf = &ps->ring[idx];
+      int done = 0;
+      bool failed = false;
+      if (inf->request != NULL) {
+        flagcxResult_t res = net->test(inf->request, &done, NULL);
+        if (res != flagcxSuccess) {
+          WARN("flagcxKernelProxyPoll: test failed peer=%d res=%d", p,
+               (int)res);
+          __atomic_store_n(&proxy->rmaError, 1, __ATOMIC_RELEASE);
+          done = 1;
+          failed = true;
+        }
+      } else {
+        // Post failed earlier; retire without advancing counters.
+        done = 1;
+        failed = true;
+      }
+      if (!done)
+        break;
+      ps->head++;
+      if (!failed) {
+        __atomic_store_n(&proxy->doneSeqs[p], inf->opSeq, __ATOMIC_RELEASE);
+        if (proxy->doneSeqsCpu != NULL)
+          __atomic_store_n(&proxy->doneSeqsCpu[p], inf->opSeq,
+                           __ATOMIC_RELEASE);
+        __atomic_fetch_add(&proxy->completionCount, 1ULL, __ATOMIC_RELEASE);
+        if (!proxy->useStreamOps) {
+          pthread_mutex_lock(&proxy->doneMutex);
+          pthread_cond_broadcast(&proxy->doneCond);
+          pthread_mutex_unlock(&proxy->doneMutex);
+        }
+      }
+    }
+  }
+}
+
+// Post an IB operation directly from the kernel proxy thread.
+static flagcxResult_t
+flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
+                      struct flagcxHeteroComm *comm, int peer, int type,
+                      uint64_t srcOff, uint64_t dstOff, size_t size,
+                      int srcMrIdx, int dstMrIdx, uint64_t signalOff,
+                      uint64_t signalValue, uint64_t putValue) {
+  struct flagcxKernelProxyPeerState *ps = &state->peers[peer];
+  struct flagcxRmaProxyState *proxy = comm->rmaProxy;
+  struct flagcxNetAdaptor *net = comm->netAdaptor;
+  if (proxy == NULL || net == NULL) {
+    WARN("flagcxKernelProxyPost: rmaProxy or netAdaptor not initialized");
+    return flagcxInternalError;
+  }
+
+  // Back-pressure: if ring is full, poll until a slot frees.
+  while ((ps->tail - ps->head) >= FLAGCX_KPROXY_MAX_INFLIGHT) {
+    flagcxKernelProxyPoll(state, comm);
+    if ((ps->tail - ps->head) >= FLAGCX_KPROXY_MAX_INFLIGHT)
+      sched_yield();
+  }
+
+  void *sendComm = comm->oneSideHandles[0]->fullSendComms[peer];
+  void **srcHandles = NULL, **dstHandles = NULL;
+  if (size > 0 && srcMrIdx >= 0) {
+    srcHandles = (void **)comm->oneSideHandles[srcMrIdx];
+    dstHandles = (void **)comm->oneSideHandles[dstMrIdx];
+  }
+
+  // Assign opSeq (shared atomic counter with RMA Proxy for ordering)
+  uint64_t opSeq =
+      __atomic_add_fetch(&proxy->opSeqs[peer], 1, __ATOMIC_RELAXED);
+
+  void *request = NULL;
+  flagcxResult_t res = flagcxSuccess;
+
+  switch (type) {
+    case FLAGCX_RMA_PUT:
+      res = net->iput(sendComm, srcOff, dstOff, size, comm->rank, peer,
+                      srcHandles, dstHandles, &request);
+      break;
+    case FLAGCX_RMA_GET:
+      res = net->iget(sendComm, srcOff, dstOff, size, peer, comm->rank,
+                      srcHandles, dstHandles, &request);
+      break;
+    case FLAGCX_RMA_PUT_SIGNAL: {
+      void **sigHandles = (void **)comm->signalHandle;
+      if (size > 0 && srcMrIdx >= 0) {
+        srcHandles = (void **)comm->oneSideHandles[srcMrIdx];
+        dstHandles = (void **)comm->oneSideHandles[dstMrIdx];
+      } else {
+        srcHandles = NULL;
+        dstHandles = NULL;
+      }
+      res = net->iputSignal(sendComm, srcOff, dstOff, size, comm->rank, peer,
+                            srcHandles, dstHandles, signalOff, sigHandles,
+                            signalValue, &request);
+      break;
+    }
+    case FLAGCX_RMA_PUT_VALUE: {
+      struct flagcxOneSideHandleInfo *stagingH = comm->stagingHandle;
+      if (stagingH == NULL || stagingH->baseVas == NULL) {
+        WARN("flagcxKernelProxyPost: staging handles not initialized");
+        res = flagcxInternalError;
+        break;
+      }
+      size_t slot = (size_t)peer * sizeof(uint64_t);
+      volatile uint64_t *staging =
+          (volatile uint64_t *)(stagingH->baseVas[comm->rank] + slot);
+      *staging = putValue;
+      void **stagingHandles = (void **)stagingH;
+      void **dstH = (void **)comm->oneSideHandles[dstMrIdx];
+      res = net->iput(sendComm, slot, dstOff, sizeof(uint64_t), comm->rank,
+                      peer, stagingHandles, dstH, &request);
+      break;
+    }
+    default:
+      WARN("flagcxKernelProxyPost: unknown type %d", type);
+      return flagcxInternalError;
+  }
+
+  if (res != flagcxSuccess) {
+    WARN("flagcxKernelProxyPost: post failed peer=%d type=%d res=%d", peer,
+         type, (int)res);
+    __atomic_store_n(&proxy->rmaError, 1, __ATOMIC_RELEASE);
+    request = NULL; // will be retired as failed
+  }
+
+  uint32_t idx = ps->tail & FLAGCX_KPROXY_RING_MASK;
+  ps->ring[idx].request = request;
+  ps->ring[idx].opSeq = opSeq;
+  ps->tail++;
+
+  return res;
+}
+
+// Drain all in-flight requests (called at thread shutdown).
+static void flagcxKernelProxyDrain(struct flagcxKernelProxyState *state,
+                                   struct flagcxHeteroComm *comm) {
+  struct flagcxNetAdaptor *net = comm->netAdaptor;
+  struct flagcxRmaProxyState *proxy = comm->rmaProxy;
+  for (int p = 0; p < state->nRanks; p++) {
+    struct flagcxKernelProxyPeerState *ps = &state->peers[p];
+    while (ps->head != ps->tail) {
+      uint32_t idx = ps->head & FLAGCX_KPROXY_RING_MASK;
+      struct flagcxKernelProxyInflight *inf = &ps->ring[idx];
+      if (inf->request != NULL) {
+        int done = 0;
+        while (!done) {
+          flagcxResult_t res = net->test(inf->request, &done, NULL);
+          if (res != flagcxSuccess) {
+            done = 1;
+            break;
+          }
+        }
+      }
+      if (inf->request != NULL) {
+        __atomic_store_n(&proxy->doneSeqs[p], inf->opSeq, __ATOMIC_RELEASE);
+        if (proxy->doneSeqsCpu != NULL)
+          __atomic_store_n(&proxy->doneSeqsCpu[p], inf->opSeq,
+                           __ATOMIC_RELEASE);
+        __atomic_fetch_add(&proxy->completionCount, 1ULL, __ATOMIC_RELEASE);
+      }
+      ps->head++;
+    }
+  }
+  // Final broadcast to unblock any waiters
+  if (proxy && !proxy->useStreamOps) {
+    pthread_mutex_lock(&proxy->doneMutex);
+    pthread_cond_broadcast(&proxy->doneCond);
+    pthread_mutex_unlock(&proxy->doneMutex);
+  }
+}
+
 void *flagcxProxyKernelService(void *args) {
   int groupCount = 0;
   int termCount = 0;
   flagcxDeviceTrigger_t ptr = NULL;
   flagcxFifo_t fifo = NULL;
   flagcxStream_t stream = NULL;
+  struct flagcxKernelProxyState *kproxyState = NULL;
   flagcxProxyKernelServiceArg *arg = (flagcxProxyKernelServiceArg *)args;
   struct flagcxHeteroComm *comm = arg->comm;
   int contextId = arg->contextId;
@@ -1447,6 +1651,21 @@ void *flagcxProxyKernelService(void *args) {
   // Allocate trigger structure
   FLAGCXCHECKGOTO(flagcxCalloc(&ptr, sizeof(flagcxDeviceTrigger)), res, out);
 
+  // Initialize direct posting state (bypasses RMA Proxy for one-sided ops)
+  kproxyState =
+      (struct flagcxKernelProxyState *)calloc(1, sizeof(*kproxyState));
+  if (kproxyState == NULL) {
+    res = flagcxSystemError;
+    goto out;
+  }
+  kproxyState->nRanks = comm->nRanks;
+  kproxyState->peers = (struct flagcxKernelProxyPeerState *)calloc(
+      comm->nRanks, sizeof(struct flagcxKernelProxyPeerState));
+  if (kproxyState->peers == NULL) {
+    res = flagcxSystemError;
+    goto out;
+  }
+
   // Signal that initialization is complete
   pthread_mutex_lock(&comm->proxyState->kernelState.initMutex);
   comm->proxyState->kernelState.ready++;
@@ -1456,6 +1675,8 @@ void *flagcxProxyKernelService(void *args) {
   while (true) {
     if (comm->proxyState->kernelState.stop == 1)
       break;
+    // Poll completions for direct-posted IB ops
+    flagcxKernelProxyPoll(kproxyState, comm);
     dequeue(fifo->buffer, ptr);
     if ((ptr->getPrim() == flagcxDevicePrimSend ||
          ptr->getPrim() == flagcxDevicePrimRecv) &&
@@ -1526,8 +1747,9 @@ void *flagcxProxyKernelService(void *args) {
         size_t srcOffset = (size_t)ptr->getSrcOffset();
         size_t dstOffset = (size_t)ptr->getDstOffset();
         size_t size = (size_t)ptr->getSize();
-        res = flagcxHeteroPut(comm, peerRank, srcOffset, dstOffset, size,
-                              srcMrIdx, dstMrIdx);
+        res = flagcxKernelProxyPost(kproxyState, comm, peerRank, FLAGCX_RMA_PUT,
+                                    srcOffset, dstOffset, size, srcMrIdx,
+                                    dstMrIdx, 0, 0, 0);
         break;
       }
       case flagcxDevicePrimSignal: {
@@ -1552,8 +1774,9 @@ void *flagcxProxyKernelService(void *args) {
             res = flagcxInternalError;
             break;
           }
-          res = flagcxHeteroPutSignal(comm, peerRank, 0, 0, 0, signalOff, 0, 0,
-                                      signalValue);
+          res = flagcxKernelProxyPost(kproxyState, comm, peerRank,
+                                      FLAGCX_RMA_PUT_SIGNAL, 0, 0, 0, -1, -1,
+                                      signalOff, signalValue, 0);
         } else {
           // Counter buffer: local CPU atomic increment (no network operation)
           flagcxDevComm_t dc = comm->devCommHandle;
@@ -1618,16 +1841,22 @@ void *flagcxProxyKernelService(void *args) {
           res = flagcxInternalError;
           break;
         }
-        res = flagcxHeteroPutSignal(comm, peerRank, srcOffset, dstOffset, size,
-                                    signalOff, srcMrIdx, dstMrIdx, signalValue);
+        res = flagcxKernelProxyPost(
+            kproxyState, comm, peerRank, FLAGCX_RMA_PUT_SIGNAL, srcOffset,
+            dstOffset, size, srcMrIdx, dstMrIdx, signalOff, signalValue, 0);
         break;
       }
       case flagcxDevicePrimPutValue: {
         int peerRank = (int)ptr->getPeerRank();
+        res = validateOneSidedPeer(comm, peerRank);
+        if (res != flagcxSuccess)
+          break;
         int dstMrIdx = (int)ptr->getDstMrIdx();
         size_t dstOffset = (size_t)ptr->getDstOffset();
         uint64_t value = ptr->getValue();
-        res = flagcxHeteroPutValue(comm, peerRank, value, dstOffset, dstMrIdx);
+        res = flagcxKernelProxyPost(kproxyState, comm, peerRank,
+                                    FLAGCX_RMA_PUT_VALUE, 0, dstOffset, 0, -1,
+                                    dstMrIdx, 0, 0, value);
         break;
       }
       case flagcxDevicePrimGet: {
@@ -1643,8 +1872,9 @@ void *flagcxProxyKernelService(void *args) {
         size_t srcOffset = (size_t)ptr->getSrcOffset();
         size_t dstOffset = (size_t)ptr->getDstOffset();
         size_t size = (size_t)ptr->getSize();
-        res = flagcxHeteroGet(comm, peerRank, srcOffset, dstOffset, size,
-                              srcMrIdx, dstMrIdx);
+        res = flagcxKernelProxyPost(kproxyState, comm, peerRank, FLAGCX_RMA_GET,
+                                    srcOffset, dstOffset, size, srcMrIdx,
+                                    dstMrIdx, 0, 0, 0);
         break;
       }
       case flagcxDevicePrimWait:
@@ -1692,6 +1922,13 @@ void *flagcxProxyKernelService(void *args) {
       break;
   }
 out:
+  // Drain all in-flight direct IB requests before teardown
+  if (kproxyState != NULL) {
+    flagcxKernelProxyDrain(kproxyState, comm);
+    free(kproxyState->peers);
+    free(kproxyState);
+    kproxyState = NULL;
+  }
   // destroy stream (only if created)
   if (stream != nullptr) {
     deviceAdaptor->streamSynchronize(stream);

--- a/flagcx/core/proxy.cc
+++ b/flagcx/core/proxy.cc
@@ -24,6 +24,7 @@
 #include <string>
 #include <sys/syscall.h>
 #include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 using namespace std;
 
@@ -448,6 +449,8 @@ flagcxProxyGetPostedOps(struct flagcxProxyState *proxyState, int *added) {
 
 FLAGCX_PARAM(ProgressAppendOpFreq, "PROGRESS_APPENDOP_FREQ", 8);
 FLAGCX_PARAM(KernelProxyParallelism, "KERNEL_PROXY_PARALLELISM", 4);
+FLAGCX_PARAM(KernelProxyBackpressureTimeout,
+             "KERNEL_PROXY_BACKPRESSURE_TIMEOUT", 30);
 
 inline void *flagcxProxyProgress(void *proxyState_) {
   struct flagcxProxyState *proxyState = (flagcxProxyState *)proxyState_;
@@ -1145,6 +1148,26 @@ flagcxResult_t flagcxProxyInit(struct flagcxHeteroComm *comm) {
     nKernelProxies = FLAGCX_DEVICE_CTA_COUNT;
   comm->proxyState->kernelState.contextCount = nKernelProxies;
 
+  // Initialize shared per-peer spinlocks for PUT_VALUE staging protection.
+  // Must be done before threads start since threads reference them.
+  int nRanks = comm->nRanks;
+  comm->proxyState->kernelState.pvLocks =
+      (pthread_spinlock_t *)calloc(nRanks, sizeof(pthread_spinlock_t));
+  if (comm->proxyState->kernelState.pvLocks == NULL) {
+    WARN("flagcxProxyInit: failed to allocate pvLocks for %d ranks", nRanks);
+    // Clean up already-started service/progress threads before returning.
+    comm->proxyState->stop = 1;
+    comm->proxyState->progressState.stop = 1;
+    pthread_join(comm->proxyState->thread, NULL);
+    pthread_join(comm->proxyState->progressState.thread, NULL);
+    return flagcxSystemError;
+  }
+  comm->proxyState->kernelState.pvLocksCount = nRanks;
+  for (int i = 0; i < nRanks; i++) {
+    pthread_spin_init(&comm->proxyState->kernelState.pvLocks[i],
+                      PTHREAD_PROCESS_PRIVATE);
+  }
+
   int nStarted = 0;
   for (int i = 0; i < nKernelProxies; i++) {
     flagcxProxyKernelServiceArg *arg = new flagcxProxyKernelServiceArg{comm, i};
@@ -1372,6 +1395,13 @@ out:
   }
   pthread_mutex_destroy(&comm->proxyState->kernelState.initMutex);
   pthread_cond_destroy(&comm->proxyState->kernelState.initCond);
+  if (comm->proxyState->kernelState.pvLocks != NULL) {
+    for (int i = 0; i < comm->proxyState->kernelState.pvLocksCount; i++) {
+      pthread_spin_destroy(&comm->proxyState->kernelState.pvLocks[i]);
+    }
+    free((void *)comm->proxyState->kernelState.pvLocks);
+    comm->proxyState->kernelState.pvLocks = NULL;
+  }
 #endif
 
   // Close sockets and drain any remaining async ops
@@ -1402,6 +1432,8 @@ out:
 // Bypasses RMA Proxy: posts IB ops directly from kernel proxy thread.
 // ============================================================================
 
+// Note: each kernel proxy thread allocates nRanks × (256 × 16B + 8B) ≈
+// 4KB/peer. With contextCount threads, total is contextCount × nRanks × 4KB.
 #define FLAGCX_KPROXY_MAX_INFLIGHT 256
 #define FLAGCX_KPROXY_RING_MASK (FLAGCX_KPROXY_MAX_INFLIGHT - 1)
 
@@ -1419,14 +1451,19 @@ struct flagcxKernelProxyPeerState {
 struct flagcxKernelProxyState {
   struct flagcxKernelProxyPeerState *peers; // [nRanks]
   int nRanks;
+  uint32_t totalInflight; // number of ops in-flight across all peers
 };
 
 // Poll completions for all peers. Non-blocking sweep.
 static void flagcxKernelProxyPoll(struct flagcxKernelProxyState *state,
                                   struct flagcxHeteroComm *comm) {
+  if (state->totalInflight == 0)
+    return;
   struct flagcxRmaProxyState *proxy = comm->rmaProxy;
   struct flagcxNetAdaptor *net = comm->netAdaptor;
-  bool anyCompleted = false;
+  if (proxy == NULL || net == NULL)
+    return;
+  bool anyRetired = false;
   for (int p = 0; p < state->nRanks; p++) {
     struct flagcxKernelProxyPeerState *ps = &state->peers[p];
     while (ps->head != ps->tail) {
@@ -1451,21 +1488,35 @@ static void flagcxKernelProxyPoll(struct flagcxKernelProxyState *state,
       if (!done)
         break;
       ps->head++;
-      // Always advance doneSeqs (even on failure) to prevent flush hangs.
-      __atomic_store_n((uint64_t *)&proxy->doneSeqs[p], inf->opSeq,
-                       __ATOMIC_RELEASE);
-      if (proxy->doneSeqsCpu != NULL)
-        __atomic_store_n((uint64_t *)&proxy->doneSeqsCpu[p], inf->opSeq,
-                         __ATOMIC_RELEASE);
+      state->totalInflight--;
+      anyRetired = true;
+      // CAS max-tracking: multiple kernel proxy threads may complete ops for
+      // the same peer out of order. Only advance doneSeqs forward.
+      uint64_t prev =
+          __atomic_load_n((uint64_t *)&proxy->doneSeqs[p], __ATOMIC_RELAXED);
+      while (inf->opSeq > prev) {
+        if (__atomic_compare_exchange_n((uint64_t *)&proxy->doneSeqs[p], &prev,
+                                        inf->opSeq, true, __ATOMIC_RELEASE,
+                                        __ATOMIC_RELAXED))
+          break;
+      }
+      if (proxy->doneSeqsCpu != NULL) {
+        prev = __atomic_load_n((uint64_t *)&proxy->doneSeqsCpu[p],
+                               __ATOMIC_RELAXED);
+        while (inf->opSeq > prev) {
+          if (__atomic_compare_exchange_n((uint64_t *)&proxy->doneSeqsCpu[p],
+                                          &prev, inf->opSeq, true,
+                                          __ATOMIC_RELEASE, __ATOMIC_RELAXED))
+            break;
+        }
+      }
       if (!failed) {
         __atomic_fetch_add(&proxy->completionCount, 1ULL, __ATOMIC_RELEASE);
-        anyCompleted = true;
       }
     }
   }
-  // Batch the broadcast: signal waiters once per poll sweep, not per
-  // completion.
-  if (anyCompleted && !proxy->useStreamOps) {
+  // Batch the broadcast: signal waiters once per poll sweep on any retirement.
+  if (anyRetired && !proxy->useStreamOps) {
     pthread_mutex_lock(&proxy->doneMutex);
     pthread_cond_broadcast(&proxy->doneCond);
     pthread_mutex_unlock(&proxy->doneMutex);
@@ -1504,12 +1555,19 @@ flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
   }
 
   // Back-pressure: if ring is full, poll until a slot frees.
-  int spins = 0;
+  int64_t timeoutSec = flagcxParamKernelProxyBackpressureTimeout();
+  struct timespec deadline;
+  clock_gettime(CLOCK_MONOTONIC, &deadline);
+  deadline.tv_sec += timeoutSec;
   while ((ps->tail - ps->head) >= FLAGCX_KPROXY_MAX_INFLIGHT) {
     flagcxKernelProxyPoll(state, comm);
     if ((ps->tail - ps->head) >= FLAGCX_KPROXY_MAX_INFLIGHT) {
-      if (++spins > 10000000) {
-        WARN("flagcxKernelProxyPost: back-pressure timeout peer=%d", peer);
+      struct timespec now;
+      clock_gettime(CLOCK_MONOTONIC, &now);
+      if (now.tv_sec > deadline.tv_sec ||
+          (now.tv_sec == deadline.tv_sec && now.tv_nsec >= deadline.tv_nsec)) {
+        WARN("flagcxKernelProxyPost: back-pressure timeout (%lds) peer=%d",
+             (long)timeoutSec, peer);
         __atomic_store_n((int *)&proxy->rmaError, 1, __ATOMIC_RELEASE);
         return flagcxInternalError;
       }
@@ -1518,13 +1576,27 @@ flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
   }
 
   void *sendComm = comm->oneSideHandles[0]->fullSendComms[peer];
+  if (sendComm == NULL) {
+    WARN("flagcxKernelProxyPost: sendComm is NULL for peer=%d", peer);
+    return flagcxInternalError;
+  }
   void **srcHandles = NULL, **dstHandles = NULL;
-  if (size > 0 && srcMrIdx >= 0) {
+  if (size > 0 && srcMrIdx >= 0 && dstMrIdx >= 0) {
     srcHandles = (void **)comm->oneSideHandles[srcMrIdx];
     dstHandles = (void **)comm->oneSideHandles[dstMrIdx];
   }
+  // Reject data-bearing ops with invalid MR indices (handles would be NULL).
+  if (size > 0 && (srcHandles == NULL || dstHandles == NULL)) {
+    WARN("flagcxKernelProxyPost: data op size=%zu with NULL handles peer=%d",
+         size, peer);
+    return flagcxInvalidArgument;
+  }
 
-  // Assign opSeq (shared atomic counter with RMA Proxy for ordering)
+  // Assign opSeq (shared atomic counter with RMA Proxy for ordering).
+  // Multiple kernel proxy threads may post to the same peer concurrently,
+  // and the RMA Proxy thread may also post (via stream path). The atomic
+  // increment ensures unique opSeqs; completion order may differ from
+  // assignment order, so Poll uses CAS max-tracking on doneSeqs.
   uint64_t opSeq =
       __atomic_add_fetch((uint64_t *)&proxy->opSeqs[peer], 1, __ATOMIC_RELAXED);
 
@@ -1533,14 +1605,33 @@ flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
 
   switch (type) {
     case FLAGCX_RMA_PUT:
+      if (net->iput == NULL) {
+        WARN("flagcxKernelProxyPost: netAdaptor->iput not implemented");
+        res = flagcxNotSupported;
+        break;
+      }
       res = net->iput(sendComm, srcOff, dstOff, size, comm->rank, peer,
                       srcHandles, dstHandles, &request);
       break;
     case FLAGCX_RMA_GET:
+      if (net->iget == NULL) {
+        WARN("flagcxKernelProxyPost: netAdaptor->iget not implemented");
+        res = flagcxNotSupported;
+        break;
+      }
       res = net->iget(sendComm, srcOff, dstOff, size, peer, comm->rank,
                       srcHandles, dstHandles, &request);
       break;
     case FLAGCX_RMA_PUT_SIGNAL: {
+      // iputSignal issues data + signal as two RDMA ops on the same QP.
+      // IB RC QP guarantees in-order completion, so a single ring entry
+      // (tracking only the signal request) is sufficient — the data op is
+      // guaranteed to complete before the signal op returns done from test().
+      if (net->iputSignal == NULL) {
+        WARN("flagcxKernelProxyPost: netAdaptor->iputSignal not implemented");
+        res = flagcxNotSupported;
+        break;
+      }
       void **sigHandles = (void **)comm->signalHandle;
       // srcHandles/dstHandles already set above for size>0 && srcMrIdx>=0,
       // or NULL otherwise — no need to reassign.
@@ -1550,21 +1641,105 @@ flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
       break;
     }
     case FLAGCX_RMA_PUT_VALUE: {
+      // Serialize PUT_VALUE per-peer: drain all prior ops to ensure the staging
+      // slot is idle. The NIC reads staging asynchronously, so concurrent
+      // PUT_VALUE to the same peer would corrupt the buffer.
+      struct timespec pvDeadline;
+      clock_gettime(CLOCK_MONOTONIC, &pvDeadline);
+      pvDeadline.tv_sec += timeoutSec;
+      while (ps->head != ps->tail) {
+        flagcxKernelProxyPoll(state, comm);
+        if (ps->head != ps->tail) {
+          struct timespec now;
+          clock_gettime(CLOCK_MONOTONIC, &now);
+          if (now.tv_sec > pvDeadline.tv_sec ||
+              (now.tv_sec == pvDeadline.tv_sec &&
+               now.tv_nsec >= pvDeadline.tv_nsec)) {
+            WARN(
+                "flagcxKernelProxyPost: PUT_VALUE drain timeout (%lds) peer=%d",
+                (long)timeoutSec, peer);
+            __atomic_store_n((int *)&proxy->rmaError, 1, __ATOMIC_RELEASE);
+            return flagcxInternalError;
+          }
+          sched_yield();
+        }
+      }
       struct flagcxOneSideHandleInfo *stagingH = comm->stagingHandle;
       if (stagingH == NULL || stagingH->baseVas == NULL) {
         WARN("flagcxKernelProxyPost: staging handles not initialized");
         res = flagcxInternalError;
         break;
       }
+      if (dstMrIdx < 0 || dstMrIdx >= comm->oneSideHandleCount) {
+        WARN("flagcxKernelProxyPost: PUT_VALUE dstMrIdx %d invalid", dstMrIdx);
+        res = flagcxInvalidArgument;
+        break;
+      }
+      if (net->iput == NULL) {
+        WARN("flagcxKernelProxyPost: netAdaptor->iput not implemented");
+        res = flagcxNotSupported;
+        break;
+      }
       size_t slot = (size_t)peer * sizeof(uint64_t);
       volatile uint64_t *staging =
           (volatile uint64_t *)(stagingH->baseVas[comm->rank] + slot);
+      // Lock covers write + iput + poll-to-completion so the staging slot
+      // remains stable for the entire RDMA lifetime (NIC reads source via
+      // sge, not inline copy). Without this, another thread could overwrite
+      // the staging slot while the previous RDMA WRITE is still in-flight.
+      pthread_spinlock_t *pvLocks = comm->proxyState->kernelState.pvLocks;
+      pthread_spin_lock(&pvLocks[peer]);
       *staging = putValue;
       void **stagingHandles = (void **)stagingH;
       void **dstH = (void **)comm->oneSideHandles[dstMrIdx];
       res = net->iput(sendComm, slot, dstOff, sizeof(uint64_t), comm->rank,
                       peer, stagingHandles, dstH, &request);
-      break;
+      if (res == flagcxSuccess && request != NULL) {
+        // Spin-poll until NIC finishes reading the staging slot.
+        // PUT_VALUE is 8 bytes — completion is typically < 5μs.
+        int done = 0;
+        while (!done) {
+          res = net->test(request, &done, NULL);
+          if (res != flagcxSuccess) {
+            __atomic_store_n((int *)&proxy->rmaError, 1, __ATOMIC_RELEASE);
+            break;
+          }
+        }
+      }
+      pthread_spin_unlock(&pvLocks[peer]);
+      // PUT_VALUE completes inline — update doneSeqs directly, skip ring.
+      if (res == flagcxSuccess) {
+        // CAS max-tracking (same pattern as Poll/Drain).
+        uint64_t prev = __atomic_load_n((uint64_t *)&proxy->doneSeqs[peer],
+                                        __ATOMIC_RELAXED);
+        while (opSeq > prev) {
+          if (__atomic_compare_exchange_n((uint64_t *)&proxy->doneSeqs[peer],
+                                          &prev, opSeq, true, __ATOMIC_RELEASE,
+                                          __ATOMIC_RELAXED))
+            break;
+        }
+        if (proxy->doneSeqsCpu != NULL) {
+          prev = __atomic_load_n((uint64_t *)&proxy->doneSeqsCpu[peer],
+                                 __ATOMIC_RELAXED);
+          while (opSeq > prev) {
+            if (__atomic_compare_exchange_n(
+                    (uint64_t *)&proxy->doneSeqsCpu[peer], &prev, opSeq, true,
+                    __ATOMIC_RELEASE, __ATOMIC_RELAXED))
+              break;
+          }
+        }
+        __atomic_fetch_add(&proxy->completionCount, 1ULL, __ATOMIC_RELEASE);
+        if (!proxy->useStreamOps) {
+          pthread_mutex_lock(&proxy->doneMutex);
+          pthread_cond_broadcast(&proxy->doneCond);
+          pthread_mutex_unlock(&proxy->doneMutex);
+        }
+      } else {
+        WARN("flagcxKernelProxyPost: PUT_VALUE failed peer=%d res=%d", peer,
+             (int)res);
+        __atomic_store_n((int *)&proxy->rmaError, 1, __ATOMIC_RELEASE);
+      }
+      return res;
     }
     default:
       WARN("flagcxKernelProxyPost: unknown type %d", type);
@@ -1582,6 +1757,7 @@ flagcxKernelProxyPost(struct flagcxKernelProxyState *state,
   ps->ring[idx].request = request;
   ps->ring[idx].opSeq = opSeq;
   ps->tail++;
+  state->totalInflight++;
 
   return res;
 }
@@ -1593,6 +1769,8 @@ static void flagcxKernelProxyDrain(struct flagcxKernelProxyState *state,
     return;
   struct flagcxNetAdaptor *net = comm->netAdaptor;
   struct flagcxRmaProxyState *proxy = comm->rmaProxy;
+  if (net == NULL || proxy == NULL)
+    return;
   for (int p = 0; p < state->nRanks; p++) {
     struct flagcxKernelProxyPeerState *ps = &state->peers[p];
     while (ps->head != ps->tail) {
@@ -1605,19 +1783,39 @@ static void flagcxKernelProxyDrain(struct flagcxKernelProxyState *state,
         while (!done) {
           flagcxResult_t res = net->test(inf->request, &done, NULL);
           if (res != flagcxSuccess) {
+            WARN("flagcxKernelProxyDrain: test failed peer=%d res=%d", p,
+                 (int)res);
+            __atomic_store_n((int *)&proxy->rmaError, 1, __ATOMIC_RELEASE);
             testFailed = true;
             done = 1;
             break;
           }
+          if (!done)
+            sched_yield();
         }
         succeeded = !testFailed;
       }
-      // Always advance doneSeqs to prevent flush hangs on failed ops.
-      __atomic_store_n((uint64_t *)&proxy->doneSeqs[p], inf->opSeq,
-                       __ATOMIC_RELEASE);
-      if (proxy->doneSeqsCpu != NULL)
-        __atomic_store_n((uint64_t *)&proxy->doneSeqsCpu[p], inf->opSeq,
-                         __ATOMIC_RELEASE);
+      // CAS max-tracking: another thread may have already advanced doneSeqs
+      // past our opSeq if it had a higher opSeq that completed earlier.
+      // Use the same pattern as flagcxKernelProxyPoll to avoid regression.
+      uint64_t prev =
+          __atomic_load_n((uint64_t *)&proxy->doneSeqs[p], __ATOMIC_RELAXED);
+      while (inf->opSeq > prev) {
+        if (__atomic_compare_exchange_n((uint64_t *)&proxy->doneSeqs[p], &prev,
+                                        inf->opSeq, true, __ATOMIC_RELEASE,
+                                        __ATOMIC_RELAXED))
+          break;
+      }
+      if (proxy->doneSeqsCpu != NULL) {
+        prev = __atomic_load_n((uint64_t *)&proxy->doneSeqsCpu[p],
+                               __ATOMIC_RELAXED);
+        while (inf->opSeq > prev) {
+          if (__atomic_compare_exchange_n((uint64_t *)&proxy->doneSeqsCpu[p],
+                                          &prev, inf->opSeq, true,
+                                          __ATOMIC_RELEASE, __ATOMIC_RELAXED))
+            break;
+        }
+      }
       if (succeeded)
         __atomic_fetch_add(&proxy->completionCount, 1ULL, __ATOMIC_RELEASE);
       ps->head++;
@@ -1690,6 +1888,7 @@ void *flagcxProxyKernelService(void *args) {
     goto out;
   }
   kproxyState->nRanks = comm->nRanks;
+  kproxyState->totalInflight = 0;
   kproxyState->peers = (struct flagcxKernelProxyPeerState *)calloc(
       comm->nRanks, sizeof(struct flagcxKernelProxyPeerState));
   if (kproxyState->peers == NULL) {

--- a/flagcx/core/sym_heap.cc
+++ b/flagcx/core/sym_heap.cc
@@ -69,6 +69,10 @@ flagcxResult_t flagcxSymWindowRegister(flagcxHeteroComm_t comm, void *buff,
 
       flagcxResult_t allocRes = deviceAdaptor->symPhysAlloc(
           buff, size, &physHandle, &shareableFd, &handleSize, &allocSize);
+      INFO(FLAGCX_INIT,
+           "[symWindowRegister] symPhysAlloc: res=%d physHandle=%p "
+           "shareableFd=%d allocSize=%zu buff=%p size=%zu",
+           (int)allocRes, physHandle, shareableFd, allocSize, buff, size);
       int localAllocOk =
           (allocRes == flagcxSuccess && physHandle != nullptr && allocSize > 0)
               ? 1
@@ -157,6 +161,10 @@ flagcxResult_t flagcxSymWindowRegister(flagcxHeteroComm_t comm, void *buff,
                 ? deviceAdaptor->symFlatMap(peerHandles, localRanks, localRank,
                                             physHandle, allocSize, &flatBase)
                 : flagcxNotSupported;
+        INFO(FLAGCX_INIT,
+             "[symWindowRegister] symFlatMap: mapRes=%d flatBase=%p "
+             "localRanks=%d allocSize=%zu",
+             (int)mapRes, flatBase, localRanks, allocSize);
         if (mapRes == flagcxSuccess && flatBase != nullptr) {
           d->flatBase = flatBase;
           d->physHandle = physHandle;
@@ -316,7 +324,12 @@ flagcxResult_t flagcxSymWindowRegister(flagcxHeteroComm_t comm, void *buff,
 
   // ---- Inter-node MR registration ----
   {
+    INFO(FLAGCX_INIT,
+         "[symWindowRegister] vmmOk=%d, registering MR for buff=%p size=%zu",
+         (int)d->isVMM, buff, size);
     flagcxResult_t regRes = flagcxOneSideRegisterInternal(comm, buff, size);
+    INFO(FLAGCX_INIT, "[symWindowRegister] OneSideRegisterInternal result=%d",
+         (int)regRes);
     if (regRes == flagcxSuccess) {
       for (int i = 0; i < comm->oneSideHandleCount; i++) {
         struct flagcxOneSideHandleInfo *info = comm->oneSideHandles[i];

--- a/flagcx/core/sym_heap.cc
+++ b/flagcx/core/sym_heap.cc
@@ -328,8 +328,6 @@ flagcxResult_t flagcxSymWindowRegister(flagcxHeteroComm_t comm, void *buff,
          "[symWindowRegister] vmmOk=%d, registering MR for buff=%p size=%zu",
          (int)d->isVMM, buff, size);
     flagcxResult_t regRes = flagcxOneSideRegisterInternal(comm, buff, size);
-    INFO(FLAGCX_INIT, "[symWindowRegister] OneSideRegisterInternal result=%d",
-         (int)regRes);
     if (regRes == flagcxSuccess) {
       for (int i = 0; i < comm->oneSideHandleCount; i++) {
         struct flagcxOneSideHandleInfo *info = comm->oneSideHandles[i];

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -860,10 +860,10 @@ fail_mr:
   return res;
 }
 
-flagcxResult_t
-flagcxOneSideSignalDeregister(struct flagcxHeteroComm *heteroComm) {
-  if (heteroComm == NULL)
+flagcxResult_t flagcxOneSideSignalDeregister(flagcxComm_t comm) {
+  if (comm == NULL || comm->heteroComm == NULL)
     return flagcxInternalError;
+  struct flagcxHeteroComm *heteroComm = comm->heteroComm;
   struct flagcxOneSideHandleInfo *info = heteroComm->signalHandle;
   if (info == NULL)
     return flagcxSuccess;
@@ -881,10 +881,9 @@ flagcxOneSideSignalDeregister(struct flagcxHeteroComm *heteroComm) {
     }
   }
 
-  // Release IPC table slot if one was allocated for D2D bypass.
-  if (heteroComm->ipcTable != NULL && info->signalIpcSlot >= 0 &&
-      info->signalIpcSlot < heteroComm->ipcTableSize) {
-    heteroComm->ipcTable[info->signalIpcSlot].inUse = false;
+  // Release IPC table slot (resources deferred to comm destroy).
+  if (info->signalIpcSlot >= 0) {
+    releaseIpcTableSlot(comm, info->signalIpcSlot);
   }
 
   free(info->baseVas);
@@ -2279,7 +2278,7 @@ flagcxResult_t flagcxCommDestroy(flagcxComm_t comm) {
     FLAGCXCHECK(flagcxCommRelayDestroy(comm));
     // Destroy hetero comm (stops/joins proxy threads, frees proxyState)
     flagcxOneSideStagingDeregister(comm);
-    flagcxOneSideSignalDeregister(comm->heteroComm);
+    flagcxOneSideSignalDeregister(comm);
     flagcxOneSideDeregister(comm->heteroComm);
 
     // Destroy hetero comm
@@ -2293,6 +2292,9 @@ flagcxResult_t flagcxCommDestroy(flagcxComm_t comm) {
 
   // Clean up IPC peer pointer table — deferred to here.
   FLAGCXCHECK(flagcxCommCleanupIpcTable(comm));
+
+  // Drain deferred IPC entries (slots released at runtime).
+  FLAGCXCHECK(flagcxCommDrainDeferredIpc(comm));
 
   // Drain deferred DevComm buffer queue.
   FLAGCXCHECK(flagcxCommDrainDeferredBuffers(comm));

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -495,8 +495,13 @@ flagcxResult_t flagcxOneSideRegisterInternal(flagcxHeteroComm_t heteroComm,
   // Register MR for this buffer
   {
     int type = FLAGCX_PTR_CUDA;
+    INFO(FLAGCX_REG,
+         "[OneSideRegister] calling regMr: buff=%p size=%zu type=%d", buff,
+         size, type);
     res = heteroComm->netAdaptor->regMr(regComm, buff, size, type,
                                         FLAGCX_NET_MR_FLAG_NONE, &mrHandle);
+    INFO(FLAGCX_REG, "[OneSideRegister] regMr result: res=%d mrHandle=%p",
+         (int)res, mrHandle);
   }
   if (res != flagcxSuccess || mrHandle == NULL) {
     INFO(FLAGCX_REG, "flagcxOneSideRegister: regMr failed, res=%d", res);

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -252,29 +252,29 @@ flagcxResult_t flagcxMemFree(void *ptr) {
 // Build full-mesh IB connections (including self-loopback) for one-sided ops.
 // Called once on the first flagcxOneSideRegister invocation; stored in
 // handle[0]. Pattern aligned with NCCL GIN gin.cc:146-158.
+// Build one full-mesh of IB connections for a single context.
+// On success, stores sendComms[peer] and recvComms[peer] arrays into
+// *outSend/*outRecv.
 static flagcxResult_t
-flagcxOneSideBuildFullMesh(struct flagcxHeteroComm *heteroComm,
-                           struct flagcxOneSideHandleInfo *info) {
-  int nranks = heteroComm->nRanks;
-  int rank = heteroComm->rank;
+flagcxOneSideBuildOneContext(struct flagcxHeteroComm *heteroComm, int nranks,
+                             int rank, int contextIdx, void ***outSend,
+                             void ***outRecv) {
   flagcxResult_t res = flagcxSuccess;
-
   void *listenComm = NULL;
   flagcxNetHandle_t *allHandles = NULL;
+  void **sendComms = NULL;
+  void **recvComms = NULL;
 
-  FLAGCXCHECKGOTO(flagcxCalloc(&info->fullSendComms, nranks), res, fail);
-  FLAGCXCHECKGOTO(flagcxCalloc(&info->fullRecvComms, nranks), res, fail);
-  info->nRanks = nranks;
+  FLAGCXCHECKGOTO(flagcxCalloc(&sendComms, nranks), res, fail);
+  FLAGCXCHECKGOTO(flagcxCalloc(&recvComms, nranks), res, fail);
 
   {
-    // 1. Create listen comm and allgather listen handles
     flagcxNetHandle_t myListenHandle = {};
     FLAGCXCHECKGOTO(heteroComm->netAdaptor->listen(heteroComm->netDev,
                                                    (void *)myListenHandle,
                                                    &listenComm),
                     res, fail);
 
-    // Allgather listen handles from all ranks
     FLAGCXCHECKGOTO(flagcxCalloc(&allHandles, nranks), res, fail_listen);
     memcpy(&allHandles[rank], &myListenHandle, sizeof(flagcxNetHandle_t));
     FLAGCXCHECKGOTO(bootstrapCollAllGather(heteroComm->bootstrap,
@@ -282,72 +282,137 @@ flagcxOneSideBuildFullMesh(struct flagcxHeteroComm *heteroComm,
                                            sizeof(flagcxNetHandle_t)),
                     res, fail_handles);
 
-    // 2. Deadlock-free full-mesh connection (NCCL GIN pattern)
+    // Deadlock-free full-mesh connection (NCCL GIN pattern)
     for (int i = 0; i < nranks; i++) {
-      int connectPeer = (rank + i) % nranks; // i=0 → self
+      int connectPeer = (rank + i) % nranks;
       int acceptPeer = (rank - i + nranks) % nranks;
 
-      // Connect to connectPeer + accept from acceptPeer in lockstep
-      void *sendComm = NULL, *recvComm = NULL;
-      while (sendComm == NULL || recvComm == NULL) {
-        if (sendComm == NULL) {
+      void *sc = NULL, *rc = NULL;
+      while (sc == NULL || rc == NULL) {
+        if (sc == NULL) {
           res = heteroComm->netAdaptor->connect(
-              heteroComm->netDev, (void *)&allHandles[connectPeer], &sendComm);
+              heteroComm->netDev, (void *)&allHandles[connectPeer], &sc);
           if (res != flagcxSuccess && res != flagcxInProgress) {
-            INFO(FLAGCX_REG,
-                 "flagcxOneSideBuildFullMesh: connect to peer %d failed, "
-                 "res=%d",
-                 connectPeer, res);
+            INFO(
+                FLAGCX_REG,
+                "flagcxOneSideBuildFullMesh: ctx %d connect to peer %d failed, "
+                "res=%d",
+                contextIdx, connectPeer, res);
             goto fail_handles;
           }
         }
-        if (recvComm == NULL) {
-          res = heteroComm->netAdaptor->accept(listenComm, &recvComm);
+        if (rc == NULL) {
+          res = heteroComm->netAdaptor->accept(listenComm, &rc);
           if (res != flagcxSuccess && res != flagcxInProgress) {
             INFO(FLAGCX_REG,
-                 "flagcxOneSideBuildFullMesh: accept from peer %d failed, "
+                 "flagcxOneSideBuildFullMesh: ctx %d accept from peer %d "
+                 "failed, "
                  "res=%d",
-                 acceptPeer, res);
+                 contextIdx, acceptPeer, res);
             goto fail_handles;
           }
         }
-        if (sendComm == NULL || recvComm == NULL)
+        if (sc == NULL || rc == NULL)
           sched_yield();
       }
-      info->fullSendComms[connectPeer] = sendComm;
-      info->fullRecvComms[acceptPeer] = recvComm;
-      INFO(FLAGCX_REG,
-           "flagcxOneSideBuildFullMesh: rank %d connected peer %d (i=%d)", rank,
-           connectPeer, i);
+      sendComms[connectPeer] = sc;
+      recvComms[acceptPeer] = rc;
     }
 
     free(allHandles);
     heteroComm->netAdaptor->closeListen(listenComm);
   }
 
-  INFO(FLAGCX_REG,
-       "flagcxOneSideBuildFullMesh: rank %d, %d full-mesh connections "
-       "(including self-loopback)",
-       rank, nranks);
+  INFO(FLAGCX_REG, "flagcxOneSideBuildFullMesh: rank %d ctx %d, %d connections",
+       rank, contextIdx, nranks);
+  *outSend = sendComms;
+  *outRecv = recvComms;
   return flagcxSuccess;
 
 fail_handles:
-  // cleanup partial connections on error
   for (int i = 0; i < nranks; i++) {
-    if (info->fullSendComms[i])
-      heteroComm->netAdaptor->closeSend(info->fullSendComms[i]);
-    if (info->fullRecvComms[i])
-      heteroComm->netAdaptor->closeRecv(info->fullRecvComms[i]);
+    if (sendComms[i])
+      heteroComm->netAdaptor->closeSend(sendComms[i]);
+    if (recvComms[i])
+      heteroComm->netAdaptor->closeRecv(recvComms[i]);
   }
   free(allHandles);
 fail_listen:
   heteroComm->netAdaptor->closeListen(listenComm);
 fail:
-  free(info->fullSendComms);
-  free(info->fullRecvComms);
+  free(sendComms);
+  free(recvComms);
+  *outSend = NULL;
+  *outRecv = NULL;
+  return res;
+}
+
+static flagcxResult_t
+flagcxOneSideBuildFullMesh(struct flagcxHeteroComm *heteroComm,
+                           struct flagcxOneSideHandleInfo *info) {
+  int nranks = heteroComm->nRanks;
+  int rank = heteroComm->rank;
+  flagcxResult_t res = flagcxSuccess;
+
+  // Determine number of contexts: 1 (RMA proxy) + N (kernel proxy threads).
+  // contextCount defaults to 0; only set by flagcxProxyInit when
+  // COMPILE_KERNEL_HOST. Ensure proxy is initialized so contextCount is
+  // reliable.
+  int nContexts = 1;
+  if (heteroComm->proxyState != NULL &&
+      heteroComm->proxyState->initialized == 0) {
+    FLAGCXCHECKGOTO(flagcxProxyInit(heteroComm), res, fail);
+  }
+  if (heteroComm->proxyState != NULL)
+    nContexts = 1 + heteroComm->proxyState->kernelState.contextCount;
+  info->nContexts = nContexts;
+  info->nRanks = nranks;
+
+  FLAGCXCHECKGOTO(flagcxCalloc(&info->contextSendComms, nContexts), res, fail);
+  FLAGCXCHECKGOTO(flagcxCalloc(&info->contextRecvComms, nContexts), res, fail);
+
+  // Build one full-mesh per context (collective: all ranks participate per
+  // round)
+  for (int ctx = 0; ctx < nContexts; ctx++) {
+    FLAGCXCHECKGOTO(flagcxOneSideBuildOneContext(heteroComm, nranks, rank, ctx,
+                                                 &info->contextSendComms[ctx],
+                                                 &info->contextRecvComms[ctx]),
+                    res, fail_partial);
+  }
+
+  // Legacy aliases: context 0 = RMA proxy
+  info->fullSendComms = info->contextSendComms[0];
+  info->fullRecvComms = info->contextRecvComms[0];
+
+  INFO(FLAGCX_REG,
+       "flagcxOneSideBuildFullMesh: rank %d, %d contexts × %d peers "
+       "(including self-loopback)",
+       rank, nContexts, nranks);
+  return flagcxSuccess;
+
+fail_partial:
+  // Cleanup contexts that were successfully created
+  for (int ctx = 0; ctx < nContexts; ctx++) {
+    if (info->contextSendComms[ctx] != NULL) {
+      for (int i = 0; i < nranks; i++) {
+        if (info->contextSendComms[ctx][i])
+          heteroComm->netAdaptor->closeSend(info->contextSendComms[ctx][i]);
+        if (info->contextRecvComms[ctx][i])
+          heteroComm->netAdaptor->closeRecv(info->contextRecvComms[ctx][i]);
+      }
+      free(info->contextSendComms[ctx]);
+      free(info->contextRecvComms[ctx]);
+    }
+  }
+  free(info->contextSendComms);
+  free(info->contextRecvComms);
+fail:
+  info->contextSendComms = NULL;
+  info->contextRecvComms = NULL;
   info->fullSendComms = NULL;
   info->fullRecvComms = NULL;
   info->nRanks = 0;
+  info->nContexts = 0;
   return res;
 }
 
@@ -503,15 +568,21 @@ fail_mr:
     heteroComm->netAdaptor->deregMr(regComm, mrHandle);
 fail_mesh:
   if (isFirstHandle) {
-    // Clean up full-mesh connections on first-handle failure
-    for (int i = 0; i < heteroComm->nRanks; i++) {
-      if (info->fullSendComms && info->fullSendComms[i])
-        heteroComm->netAdaptor->closeSend(info->fullSendComms[i]);
-      if (info->fullRecvComms && info->fullRecvComms[i])
-        heteroComm->netAdaptor->closeRecv(info->fullRecvComms[i]);
+    // Clean up per-context full-mesh connections on first-handle failure
+    for (int ctx = 0; ctx < info->nContexts; ctx++) {
+      if (info->contextSendComms && info->contextSendComms[ctx]) {
+        for (int i = 0; i < heteroComm->nRanks; i++) {
+          if (info->contextSendComms[ctx][i])
+            heteroComm->netAdaptor->closeSend(info->contextSendComms[ctx][i]);
+          if (info->contextRecvComms[ctx][i])
+            heteroComm->netAdaptor->closeRecv(info->contextRecvComms[ctx][i]);
+        }
+        free(info->contextSendComms[ctx]);
+        free(info->contextRecvComms[ctx]);
+      }
     }
-    free(info->fullSendComms);
-    free(info->fullRecvComms);
+    free(info->contextSendComms);
+    free(info->contextRecvComms);
   }
 fail_info:
   free(info);
@@ -550,16 +621,24 @@ flagcxResult_t flagcxOneSideDeregister(struct flagcxHeteroComm *heteroComm) {
         heteroComm->netAdaptor->deregMr(regComm, info->localMrHandle);
       }
 
-      // Close full-mesh connections (only in the first handle)
-      if (info->fullSendComms != NULL) {
-        for (int i = 0; i < info->nRanks; i++) {
-          if (info->fullSendComms[i])
-            heteroComm->netAdaptor->closeSend(info->fullSendComms[i]);
-          if (info->fullRecvComms[i])
-            heteroComm->netAdaptor->closeRecv(info->fullRecvComms[i]);
+      // Close per-context full-mesh connections (only in the first handle)
+      if (info->contextSendComms != NULL) {
+        for (int ctx = 0; ctx < info->nContexts; ctx++) {
+          if (info->contextSendComms[ctx] != NULL) {
+            for (int j = 0; j < info->nRanks; j++) {
+              if (info->contextSendComms[ctx][j])
+                heteroComm->netAdaptor->closeSend(
+                    info->contextSendComms[ctx][j]);
+              if (info->contextRecvComms[ctx][j])
+                heteroComm->netAdaptor->closeRecv(
+                    info->contextRecvComms[ctx][j]);
+            }
+            free(info->contextSendComms[ctx]);
+            free(info->contextRecvComms[ctx]);
+          }
         }
-        free(info->fullSendComms);
-        free(info->fullRecvComms);
+        free(info->contextSendComms);
+        free(info->contextRecvComms);
       }
     }
 

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 #include <unordered_map>
 
 flagcxRegPool globalRegPool;
@@ -495,11 +496,45 @@ flagcxResult_t flagcxOneSideRegisterInternal(flagcxHeteroComm_t heteroComm,
   // Register MR for this buffer
   {
     int type = FLAGCX_PTR_CUDA;
-    INFO(FLAGCX_REG,
-         "[OneSideRegister] calling regMr: buff=%p size=%zu type=%d", buff,
-         size, type);
-    res = heteroComm->netAdaptor->regMr(regComm, buff, size, type,
-                                        FLAGCX_NET_MR_FLAG_NONE, &mrHandle);
+    int dmaBufFd = -1;
+
+    // For VMM-allocated memory, use DMA-BUF registration (ibv_reg_dmabuf_mr)
+    // instead of nvidia-peermem (ibv_reg_mr). nvidia-peermem cannot correctly
+    // map VMM memory for RDMA, causing IBV_WC_REM_ACCESS_ERR at runtime.
+    if (flagcxParamVmmEnable() &&
+        deviceAdaptor->getHandleForAddressRange != NULL &&
+        heteroComm->netAdaptor->regMrDmaBuf != NULL) {
+      flagcxResult_t fdRes = deviceAdaptor->getHandleForAddressRange(
+          (void *)&dmaBufFd, buff, size, 0);
+      if (fdRes == flagcxSuccess && dmaBufFd >= 0) {
+        type = FLAGCX_PTR_DMABUF;
+        INFO(FLAGCX_REG,
+             "[OneSideRegister] using DMA-BUF: buff=%p size=%zu fd=%d", buff,
+             size, dmaBufFd);
+      } else {
+        WARN("[OneSideRegister] getHandleForAddressRange failed (res=%d), "
+             "falling back to nvidia-peermem",
+             (int)fdRes);
+        dmaBufFd = -1;
+      }
+    }
+
+    if (dmaBufFd >= 0) {
+      INFO(FLAGCX_REG,
+           "[OneSideRegister] calling regMrDmaBuf: buff=%p size=%zu type=%d "
+           "fd=%d",
+           buff, size, type, dmaBufFd);
+      res = heteroComm->netAdaptor->regMrDmaBuf(
+          regComm, buff, size, type, 0ULL, dmaBufFd, FLAGCX_NET_MR_FLAG_NONE,
+          &mrHandle);
+      close(dmaBufFd);
+    } else {
+      INFO(FLAGCX_REG,
+           "[OneSideRegister] calling regMr: buff=%p size=%zu type=%d", buff,
+           size, type);
+      res = heteroComm->netAdaptor->regMr(regComm, buff, size, type,
+                                          FLAGCX_NET_MR_FLAG_NONE, &mrHandle);
+    }
     INFO(FLAGCX_REG, "[OneSideRegister] regMr result: res=%d mrHandle=%p",
          (int)res, mrHandle);
   }
@@ -730,8 +765,36 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
   }
 
   {
-    res = heteroComm->netAdaptor->regMr(regComm, buff, size, ptrType,
-                                        FLAGCX_NET_MR_FLAG_FORCE_SO, &mrHandle);
+    int dmaBufFd = -1;
+
+    // For VMM-allocated signal buffers (FLAGCX_PTR_CUDA + VMM), use DMA-BUF
+    if (ptrType == FLAGCX_PTR_CUDA && flagcxParamVmmEnable() &&
+        deviceAdaptor->getHandleForAddressRange != NULL &&
+        heteroComm->netAdaptor->regMrDmaBuf != NULL) {
+      flagcxResult_t fdRes = deviceAdaptor->getHandleForAddressRange(
+          (void *)&dmaBufFd, buff, size, 0);
+      if (fdRes == flagcxSuccess && dmaBufFd >= 0) {
+        ptrType = FLAGCX_PTR_DMABUF;
+        INFO(FLAGCX_REG,
+             "[OneSideSignalRegister] using DMA-BUF: buff=%p size=%zu fd=%d",
+             buff, size, dmaBufFd);
+      } else {
+        WARN("[OneSideSignalRegister] getHandleForAddressRange failed (res=%d),"
+             " falling back to nvidia-peermem",
+             (int)fdRes);
+        dmaBufFd = -1;
+      }
+    }
+
+    if (dmaBufFd >= 0) {
+      res = heteroComm->netAdaptor->regMrDmaBuf(
+          regComm, buff, size, ptrType, 0ULL, dmaBufFd,
+          FLAGCX_NET_MR_FLAG_FORCE_SO, &mrHandle);
+      close(dmaBufFd);
+    } else {
+      res = heteroComm->netAdaptor->regMr(
+          regComm, buff, size, ptrType, FLAGCX_NET_MR_FLAG_FORCE_SO, &mrHandle);
+    }
   }
   if (res != flagcxSuccess || mrHandle == NULL) {
     INFO(FLAGCX_REG, "flagcxOneSideSignalRegister: regMr failed, res=%d", res);

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -512,7 +512,8 @@ flagcxResult_t flagcxOneSideRegisterInternal(flagcxHeteroComm_t heteroComm,
              "[OneSideRegister] using DMA-BUF: buff=%p size=%zu fd=%d", buff,
              size, dmaBufFd);
       } else {
-        WARN("[OneSideRegister] getHandleForAddressRange failed (res=%d), "
+        INFO(FLAGCX_REG,
+             "[OneSideRegister] getHandleForAddressRange failed (res=%d), "
              "falling back to nvidia-peermem",
              (int)fdRes);
         dmaBufFd = -1;
@@ -520,23 +521,14 @@ flagcxResult_t flagcxOneSideRegisterInternal(flagcxHeteroComm_t heteroComm,
     }
 
     if (dmaBufFd >= 0) {
-      INFO(FLAGCX_REG,
-           "[OneSideRegister] calling regMrDmaBuf: buff=%p size=%zu type=%d "
-           "fd=%d",
-           buff, size, type, dmaBufFd);
       res = heteroComm->netAdaptor->regMrDmaBuf(
           regComm, buff, size, type, 0ULL, dmaBufFd, FLAGCX_NET_MR_FLAG_NONE,
           &mrHandle);
       close(dmaBufFd);
     } else {
-      INFO(FLAGCX_REG,
-           "[OneSideRegister] calling regMr: buff=%p size=%zu type=%d", buff,
-           size, type);
       res = heteroComm->netAdaptor->regMr(regComm, buff, size, type,
                                           FLAGCX_NET_MR_FLAG_NONE, &mrHandle);
     }
-    INFO(FLAGCX_REG, "[OneSideRegister] regMr result: res=%d mrHandle=%p",
-         (int)res, mrHandle);
   }
   if (res != flagcxSuccess || mrHandle == NULL) {
     INFO(FLAGCX_REG, "flagcxOneSideRegister: regMr failed, res=%d", res);
@@ -779,7 +771,8 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
              "[OneSideSignalRegister] using DMA-BUF: buff=%p size=%zu fd=%d",
              buff, size, dmaBufFd);
       } else {
-        WARN("[OneSideSignalRegister] getHandleForAddressRange failed (res=%d),"
+        INFO(FLAGCX_REG,
+             "[OneSideSignalRegister] getHandleForAddressRange failed (res=%d),"
              " falling back to nvidia-peermem",
              (int)fdRes);
         dmaBufFd = -1;
@@ -1231,7 +1224,10 @@ flagcxResult_t flagcxCommRegister(const flagcxComm_t comm, void *buff,
   }
 
   // Step 2b: Create IPC handle for the buffer (hetero path only)
-  // Write-once: if localIpcHandleData is already populated, skip
+  // Write-once: if localIpcHandleData is already populated, skip.
+  // Note: cudaIpcGetMemHandle is incompatible with VMM buffers (cuMemCreate/
+  // cuMemMap). When it fails, we skip IPC handle creation and still proceed
+  // to Step 3 (one-sided MR registration) which handles VMM buffers correctly.
   {
     char zeros[sizeof(flagcxIpcHandleData)] = {};
     if (memcmp(&regItem->localIpcHandleData, zeros,
@@ -1239,22 +1235,32 @@ flagcxResult_t flagcxCommRegister(const flagcxComm_t comm, void *buff,
       flagcxIpcMemHandle_t handlePtr = nullptr;
       size_t ipcSize = 0;
       res = deviceAdaptor->ipcMemHandleCreate(&handlePtr, &ipcSize);
-      if (res != flagcxSuccess)
-        goto fail;
+      if (res != flagcxSuccess) {
+        res = flagcxSuccess;
+        goto skip_ipc;
+      }
       res = deviceAdaptor->ipcMemHandleGet(handlePtr, buff);
       if (res != flagcxSuccess) {
         deviceAdaptor->ipcMemHandleFree(handlePtr);
-        goto fail;
+        INFO(FLAGCX_REG,
+             "flagcxCommRegister: ipcMemHandleGet failed (%d) for buff %p "
+             "(likely VMM memory), skipping IPC handle",
+             (int)res, buff);
+        res = flagcxSuccess;
+        goto skip_ipc;
       }
       if (ipcSize > sizeof(flagcxIpcHandleData)) {
         deviceAdaptor->ipcMemHandleFree(handlePtr);
-        res = flagcxInternalError;
-        goto fail;
+        INFO(FLAGCX_REG,
+             "flagcxCommRegister: ipcSize %zu exceeds storage, skipping IPC",
+             ipcSize);
+        goto skip_ipc;
       }
       memcpy(&regItem->localIpcHandleData, handlePtr, ipcSize);
       deviceAdaptor->ipcMemHandleFree(handlePtr);
     }
   }
+skip_ipc:
 
   // Step 3: One-sided MR registration (hetero path only)
   {

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -813,7 +813,7 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
     info->lkeys[heteroComm->rank] = mr->lkey;
     info->localMrHandle = mrHandle;
     info->localRecvComm = selfRecvComm;
-
+    info->signalIpcSlot = -1;
     FLAGCXCHECKGOTO(bootstrapCollAllGather(heteroComm->bootstrap,
                                            (void *)info->baseVas,
                                            sizeof(uintptr_t)),
@@ -836,11 +836,12 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
   }
 
   // Register signal buffer in IPC table for intra-node D2D bypass.
-  // Guard on ptrType only (global env var, uniform across all ranks) to ensure
-  // all ranks enter the collective allGather inside buildIpcPeerPointers.
-  if (ptrType == FLAGCX_PTR_CUDA) {
+  // Skip when VMM is enabled: VMM buffers don't support cudaIpcGetMemHandle,
+  // and flagcxDevMemCreate uses flat VA peer access (Priority 1) instead.
+  if (!flagcxParamVmmEnable()) {
     int idx = buildIpcPeerPointers(comm, buff, size);
     if (idx >= 0) {
+      info->signalIpcSlot = idx;
       INFO(FLAGCX_REG, "Signal buffer IPC registered (slot %d) for D2D bypass",
            idx);
     }
@@ -878,6 +879,12 @@ flagcxOneSideSignalDeregister(struct flagcxHeteroComm *heteroComm) {
       }
       heteroComm->netAdaptor->deregMr(regComm, info->localMrHandle);
     }
+  }
+
+  // Release IPC table slot if one was allocated for D2D bypass.
+  if (heteroComm->ipcTable != NULL && info->signalIpcSlot >= 0 &&
+      info->signalIpcSlot < heteroComm->ipcTableSize) {
+    heteroComm->ipcTable[info->signalIpcSlot].inUse = false;
   }
 
   free(info->baseVas);

--- a/flagcx/flagcx.cc
+++ b/flagcx/flagcx.cc
@@ -838,7 +838,7 @@ flagcxResult_t flagcxOneSideSignalRegister(const flagcxComm_t comm, void *buff,
   // Register signal buffer in IPC table for intra-node D2D bypass.
   // Skip when VMM is enabled: VMM buffers don't support cudaIpcGetMemHandle,
   // and flagcxDevMemCreate uses flat VA peer access (Priority 1) instead.
-  if (!flagcxParamVmmEnable()) {
+  if (ptrType == FLAGCX_PTR_CUDA && !flagcxParamVmmEnable()) {
     int idx = buildIpcPeerPointers(comm, buff, size);
     if (idx >= 0) {
       info->signalIpcSlot = idx;

--- a/flagcx/include/flagcx_kernel_internal.h
+++ b/flagcx/include/flagcx_kernel_internal.h
@@ -194,6 +194,13 @@ flagcxResult_t flagcxDevMemFreeDevicePtr(flagcxDevMem_t devMem);
 // so that cudaFree does not deadlock on device synchronization.
 flagcxResult_t flagcxCommCleanupIpcTable(flagcxComm_t comm);
 
+// Release an IPC table slot at runtime — moves resources to a deferred queue
+// so the slot can be reused by buildIpcPeerPointers. Actual cleanup at destroy.
+void releaseIpcTableSlot(flagcxComm_t comm, int slot);
+
+// Drain deferred IPC entries queued by releaseIpcTableSlot.
+flagcxResult_t flagcxCommDrainDeferredIpc(flagcxComm_t comm);
+
 // Tear down inter-node signal relay stored on heteroComm.
 // Must be called before flagcxHeteroCommDestroy (which frees proxyState and
 // heteroComm). Internally drains FIFOs and performs a cross-rank barrier
@@ -215,8 +222,7 @@ flagcxResult_t flagcxOneSideDeregister(struct flagcxHeteroComm *heteroComm);
 // Release signal buffer resources (MR, network connections, handle arrays).
 // flagcxOneSideSignalRegister / flagcxOneSideStagingRegister /
 // flagcxOneSideStagingDeregister are declared in flagcx.h (extern "C").
-flagcxResult_t
-flagcxOneSideSignalDeregister(struct flagcxHeteroComm *heteroComm);
+flagcxResult_t flagcxOneSideSignalDeregister(flagcxComm_t comm);
 
 // One-sided barrier MR registration (host-pinned memory for inter-node
 // barrier). Collective: ALL ranks must call. Leaders pass recvComm+buff,

--- a/test/device_api/device_api.cu
+++ b/test/device_api/device_api.cu
@@ -271,14 +271,31 @@ flagcxResult_t flagcxInterOneSidedAlltoAll(flagcxDevMem_t sendMem,
     return flagcxInternalError;
   }
 
+  // Clear any prior sticky error
+  cudaError_t priorErr = cudaGetLastError();
+  if (priorErr != cudaSuccess) {
+    printf("[flagcxInterOneSidedAlltoAll] WARNING: prior CUDA error before "
+           "launch: %s (%d)\n",
+           cudaGetErrorString(priorErr), (int)priorErr);
+  }
+
   flagcxDevComm dc(*devComm);
   flagcxDevMem sm(*sendMem), rm(*recvMem);
+
+  printf("[flagcxInterOneSidedAlltoAll] launching kernel: CTAs=%d threads=%d "
+         "count=%zu stream=%p\n",
+         FLAGCX_DEVICE_CTA_COUNT, FLAGCX_DEVICE_THREADS_PER_CTA, count,
+         (void *)*(cudaStream_t *)stream);
 
   flagcxInterOneSidedAlltoAllKernel
       <<<FLAGCX_DEVICE_CTA_COUNT, FLAGCX_DEVICE_THREADS_PER_CTA, 0,
          *(cudaStream_t *)stream>>>(sm, rm, count, datatype, dc);
 
   cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf("[flagcxInterOneSidedAlltoAll] kernel launch FAILED: %s (%d)\n",
+           cudaGetErrorString(err), (int)err);
+  }
 
   return (err == cudaSuccess) ? flagcxSuccess : flagcxUnhandledDeviceError;
 }

--- a/test/device_api/device_api.cu
+++ b/test/device_api/device_api.cu
@@ -282,11 +282,6 @@ flagcxResult_t flagcxInterOneSidedAlltoAll(flagcxDevMem_t sendMem,
   flagcxDevComm dc(*devComm);
   flagcxDevMem sm(*sendMem), rm(*recvMem);
 
-  printf("[flagcxInterOneSidedAlltoAll] launching kernel: CTAs=%d threads=%d "
-         "count=%zu stream=%p\n",
-         FLAGCX_DEVICE_CTA_COUNT, FLAGCX_DEVICE_THREADS_PER_CTA, count,
-         (void *)*(cudaStream_t *)stream);
-
   flagcxInterOneSidedAlltoAllKernel
       <<<FLAGCX_DEVICE_CTA_COUNT, FLAGCX_DEVICE_THREADS_PER_CTA, 0,
          *(cudaStream_t *)stream>>>(sm, rm, count, datatype, dc);

--- a/test/device_api/device_api.cu
+++ b/test/device_api/device_api.cu
@@ -271,14 +271,6 @@ flagcxResult_t flagcxInterOneSidedAlltoAll(flagcxDevMem_t sendMem,
     return flagcxInternalError;
   }
 
-  // Clear any prior sticky error
-  cudaError_t priorErr = cudaGetLastError();
-  if (priorErr != cudaSuccess) {
-    printf("[flagcxInterOneSidedAlltoAll] WARNING: prior CUDA error before "
-           "launch: %s (%d)\n",
-           cudaGetErrorString(priorErr), (int)priorErr);
-  }
-
   flagcxDevComm dc(*devComm);
   flagcxDevMem sm(*sendMem), rm(*recvMem);
 

--- a/test/perf/host_api/test_get.cpp
+++ b/test/perf/host_api/test_get.cpp
@@ -350,7 +350,7 @@ int main(int argc, char *argv[]) {
   res = flagcxCommDeregister(comm, dataHandle);
   fatal(res, "flagcxCommDeregister failed", proc);
 
-  flagcxOneSideSignalDeregister(comm->heteroComm);
+  flagcxOneSideSignalDeregister(comm);
   flagcxMemFree(dataWindow);
   flagcxMemFree(signalWindow);
   free(hostStaging);

--- a/test/perf/host_api/test_one_side_register.cpp
+++ b/test/perf/host_api/test_one_side_register.cpp
@@ -259,7 +259,7 @@ int main(int argc, char *argv[]) {
       printf("\n[Phase 3] deregister comm1, then put via comm2\n");
 
     flagcxCommWindowDeregister(comm1, dataWin1);
-    flagcxOneSideSignalDeregister(comm1->heteroComm);
+    flagcxOneSideSignalDeregister(comm1);
     dataWin1 = nullptr;
     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -300,7 +300,7 @@ int main(int argc, char *argv[]) {
     devHandle->streamDestroy(waitStream);
 
     flagcxCommWindowDeregister(comm2, dataWin2);
-    flagcxOneSideSignalDeregister(comm2->heteroComm);
+    flagcxOneSideSignalDeregister(comm2);
     dataWin2 = nullptr;
   }
 

--- a/test/perf/host_api/test_put.cpp
+++ b/test/perf/host_api/test_put.cpp
@@ -295,7 +295,7 @@ int main(int argc, char *argv[]) {
   res = flagcxCommDeregister(comm, dataHandle);
   fatal(res, "flagcxCommDeregister failed", proc);
 
-  flagcxOneSideSignalDeregister(comm->heteroComm);
+  flagcxOneSideSignalDeregister(comm);
   flagcxMemFree(dataWindow);
   flagcxMemFree(signalWindow);
   free(hostStaging);

--- a/test/unittest/rma/coll_rma_get.cpp
+++ b/test/unittest/rma/coll_rma_get.cpp
@@ -74,8 +74,9 @@ TEST_F(RmaTest, GetSmall) {
     for (size_t i = 0; i < testSize; ++i) {
       if (received[i] != 0xCD) {
         mismatches++;
-        if (mismatches == 1)
+        if (mismatches == 1) {
           EXPECT_EQ(received[i], 0xCD) << "Mismatch at byte " << i;
+        }
       }
     }
     EXPECT_EQ(mismatches, 0);
@@ -130,8 +131,9 @@ TEST_F(RmaTest, GetLarge) {
       uint8_t expected = static_cast<uint8_t>((i * 7) & 0xFF);
       if (received[i] != expected) {
         mismatches++;
-        if (mismatches == 1)
+        if (mismatches == 1) {
           EXPECT_EQ(received[i], expected) << "Mismatch at byte " << i;
+        }
       }
     }
     EXPECT_EQ(mismatches, 0);
@@ -184,9 +186,10 @@ TEST_F(RmaTest, GetBidirectional) {
     uint8_t expected = static_cast<uint8_t>((peer + 1 + i) & 0xFF);
     if (received[i] != expected) {
       mismatches++;
-      if (mismatches == 1)
+      if (mismatches == 1) {
         EXPECT_EQ(received[i], expected)
             << "Mismatch at byte " << i << " reading from rank " << peer;
+      }
     }
   }
   EXPECT_EQ(mismatches, 0);

--- a/test/unittest/rma/coll_rma_put.cpp
+++ b/test/unittest/rma/coll_rma_put.cpp
@@ -77,8 +77,9 @@ TEST_F(RmaTest, PutSignalSmall) {
     for (size_t i = 0; i < testSize; ++i) {
       if (received[i] != 0xAB) {
         mismatches++;
-        if (mismatches == 1)
+        if (mismatches == 1) {
           EXPECT_EQ(received[i], 0xAB) << "Mismatch at byte " << i;
+        }
       }
     }
     EXPECT_EQ(mismatches, 0);
@@ -132,8 +133,9 @@ TEST_F(RmaTest, PutSignalLarge) {
       uint8_t expected = static_cast<uint8_t>(i & 0xFF);
       if (received[i] != expected) {
         mismatches++;
-        if (mismatches == 1)
+        if (mismatches == 1) {
           EXPECT_EQ(received[i], expected) << "Mismatch at byte " << i;
+        }
       }
     }
     EXPECT_EQ(mismatches, 0);

--- a/test/unittest/rma/rma_test.cpp
+++ b/test/unittest/rma/rma_test.cpp
@@ -76,7 +76,7 @@ void RmaTest::TearDownTestSuite() {
   }
 
   if (signalBuff && comm && comm->heteroComm) {
-    flagcxOneSideSignalDeregister(comm->heteroComm);
+    flagcxOneSideSignalDeregister(comm);
     flagcxMemFree(signalBuff);
     signalBuff = nullptr;
   }


### PR DESCRIPTION
### PR Category
CRL

### PR Types
Optimizations

### PR Description
This PR introduces a “direct posting” path for one-sided (RMA) operations from the kernel proxy thread, bypassing the existing RMA proxy enqueue/progress-thread mechanism in order to reduce overhead and improve performance for kernel-triggered puts/gets/signals.