### PR TITLE
test(kunlunxin): add generic IPC memory handle validation

### DIFF
--- a/flagcx/adaptor/device/kunlunxin_adaptor.cc
+++ b/flagcx/adaptor/device/kunlunxin_adaptor.cc
@@ -267,7 +267,16 @@ flagcxResult_t kunlunAdaptorEventQuery(flagcxEvent_t event) {
 
 flagcxResult_t kunlunAdaptorIpcMemHandleCreate(flagcxIpcMemHandle_t *handle,
                                                size_t *size) {
-  flagcxCalloc(handle, 1);
+  if (handle == NULL) {
+    return flagcxInvalidArgument;
+  }
+
+  *handle = NULL;
+  flagcxResult_t result = flagcxCalloc(handle, 1);
+  if (result != flagcxSuccess) {
+    return result;
+  }
+
   if (size != NULL) {
     *size = sizeof(cudaIpcMemHandle_t);
   }

--- a/test/make.inc
+++ b/test/make.inc
@@ -76,6 +76,14 @@ ifeq ($(USE_NVIDIA), 1)
   DEVICE_COMPILER  := $(DEVICE_HOME)/bin/nvcc
   ADAPTOR_DEFINE   := -DUSE_NVIDIA_ADAPTOR
   PLATFORM_IR_DIR  := $(PROJECT_ROOT)/bindings/ir/nvidia
+else ifeq ($(USE_KUNLUNXIN), 1)
+  DEVICE_HOME      ?= /usr/local/xpu
+  DEVICE_LIB       := $(DEVICE_HOME)/so
+  DEVICE_INCLUDE   := -I$(DEVICE_HOME)/include
+  DEVICE_LINK      := -L$(DEVICE_LIB) -lxpurt -lcudart
+  ADAPTOR_DEFINE   := -DUSE_KUNLUNXIN_ADAPTOR
+  CCL_HOME         ?= /usr/local/xccl
+  CCL_INCLUDE      := -I$(CCL_HOME)/include
 else ifeq ($(USE_DU), 1)
   DEVICE_HOME      ?= $(CUDA_PATH)
   DEVICE_LIB       := $(DEVICE_HOME)/lib64

--- a/test/unittest/adaptor/Makefile
+++ b/test/unittest/adaptor/Makefile
@@ -10,7 +10,7 @@ MPI_SRCS   := $(wildcard coll_*.cpp)
 MPI_OBJS   := $(MPI_SRCS:%.cpp=$(OBJDIR)/%.o)
 MPI_TARGET := $(BINDIR)/adaptor_mpi_tests
 MPIRUN     ?= mpirun
-MPI_NP     ?= 2
+MPI_NP     ?= 8
 
 .PHONY: all clean run-unit run-mpi run
 

--- a/test/unittest/adaptor/Makefile
+++ b/test/unittest/adaptor/Makefile
@@ -9,6 +9,8 @@ UNIT_TARGET := $(BINDIR)/adaptor_unit_tests
 MPI_SRCS   := $(wildcard coll_*.cpp)
 MPI_OBJS   := $(MPI_SRCS:%.cpp=$(OBJDIR)/%.o)
 MPI_TARGET := $(BINDIR)/adaptor_mpi_tests
+MPIRUN     ?= mpirun
+MPI_NP     ?= 2
 
 .PHONY: all clean run-unit run-mpi run
 
@@ -35,12 +37,12 @@ $(MPI_TARGET): $(MPI_OBJS)
 $(OBJDIR)/test_%.o: test_%.cpp
 	@mkdir -p $(OBJDIR)
 	@echo "Compiling $<"
-	@$(CXX) $< -o $@ -c $(CXXFLAGS) $(ADAPTOR_DEFINE) $(FLAGCX_INCLUDES) $(DEVICE_INCLUDE) $(CCL_INCLUDE) $(GTEST_INCLUDE) $(FIXTURE_INCLUDE)
+	@$(CXX) $< -o $@ -c $(CXXFLAGS) $(FLAGCX_INCLUDES) $(GTEST_INCLUDE) $(FIXTURE_INCLUDE)
 
 $(OBJDIR)/coll_%.o: coll_%.cpp
 	@mkdir -p $(OBJDIR)
 	@echo "Compiling $<"
-	@$(CXX) $< -o $@ -c $(CXXFLAGS) $(ADAPTOR_DEFINE) $(FLAGCX_INCLUDES) $(GTEST_INCLUDE) $(FIXTURE_INCLUDE) $(MPI_INCLUDE) $(DEVICE_INCLUDE) $(CCL_INCLUDE)
+	@$(CXX) $< -o $@ -c $(CXXFLAGS) $(FLAGCX_INCLUDES) $(GTEST_INCLUDE) $(FIXTURE_INCLUDE) $(MPI_INCLUDE)
 
 clean:
 	@rm -rf $(BUILDDIR)
@@ -49,6 +51,6 @@ run-unit: $(UNIT_TARGET)
 	@$(UNIT_TARGET)
 
 run-mpi: $(MPI_TARGET)
-	@mpirun --allow-run-as-root -np 8 $(MPI_TARGET)
+	@$(MPIRUN) --allow-run-as-root -np $(MPI_NP) $(MPI_TARGET)
 
 run: run-unit run-mpi

--- a/test/unittest/adaptor/Makefile
+++ b/test/unittest/adaptor/Makefile
@@ -35,12 +35,12 @@ $(MPI_TARGET): $(MPI_OBJS)
 $(OBJDIR)/test_%.o: test_%.cpp
 	@mkdir -p $(OBJDIR)
 	@echo "Compiling $<"
-	@$(CXX) $< -o $@ -c $(CXXFLAGS) $(FLAGCX_INCLUDES) $(GTEST_INCLUDE) $(FIXTURE_INCLUDE)
+	@$(CXX) $< -o $@ -c $(CXXFLAGS) $(ADAPTOR_DEFINE) $(FLAGCX_INCLUDES) $(DEVICE_INCLUDE) $(CCL_INCLUDE) $(GTEST_INCLUDE) $(FIXTURE_INCLUDE)
 
 $(OBJDIR)/coll_%.o: coll_%.cpp
 	@mkdir -p $(OBJDIR)
 	@echo "Compiling $<"
-	@$(CXX) $< -o $@ -c $(CXXFLAGS) $(FLAGCX_INCLUDES) $(GTEST_INCLUDE) $(FIXTURE_INCLUDE) $(MPI_INCLUDE)
+	@$(CXX) $< -o $@ -c $(CXXFLAGS) $(ADAPTOR_DEFINE) $(FLAGCX_INCLUDES) $(GTEST_INCLUDE) $(FIXTURE_INCLUDE) $(MPI_INCLUDE) $(DEVICE_INCLUDE) $(CCL_INCLUDE)
 
 clean:
 	@rm -rf $(BUILDDIR)

--- a/test/unittest/adaptor/coll_ipc_mem_handle.cpp
+++ b/test/unittest/adaptor/coll_ipc_mem_handle.cpp
@@ -1,6 +1,9 @@
 /*************************************************************************
  * Copyright (c) 2026. All Rights Reserved.
- * Cross-process IPC memory handle test (requires MPI and KunlunXin XPU).
+ * Cross-process IPC memory handle test.
+ *
+ * Run exactly two MPI ranks on the same host. Device IPC handles are
+ * host-local and cannot be transferred between different nodes.
  ************************************************************************/
 
 #include <gtest/gtest.h>
@@ -32,16 +35,25 @@ namespace {
     }                                                                          \
   } while (0)
 
+#define ASSERT_MPI_TRUE(condition)                                            \
+  do {                                                                        \
+    if (!(condition)) {                                                       \
+      ADD_FAILURE() << "MPI assertion failed: " << #condition;               \
+      MPI_Abort(MPI_COMM_WORLD, 1);                                           \
+      return;                                                                 \
+    }                                                                         \
+  } while (0)
+
 class IpcMemHandleMpiTest : public ::testing::Test {
 protected:
   void SetUp() override {
     flagcxDeviceHandleInit(&devHandle);
-    ASSERT_NE(devHandle, nullptr);
+    ASSERT_MPI_TRUE(devHandle != nullptr);
 
     int deviceCount = 0;
     ASSERT_FLAGCX_SUCCESS(devHandle->getDeviceCount(&deviceCount));
     if (deviceCount <= 0) {
-      ADD_FAILURE() << "No visible XPU device";
+      ADD_FAILURE() << "No visible device";
       MPI_Abort(MPI_COMM_WORLD, 1);
       return;
     }
@@ -70,11 +82,51 @@ TEST_F(IpcMemHandleMpiTest, CrossProcessLifecycle) {
   constexpr size_t bufferSize = 4096;
   constexpr int expectedValue = 0x12345678;
 
+  int localApisAvailable =
+      devHandle->ipcMemHandleCreate != nullptr &&
+      devHandle->ipcMemHandleGet != nullptr &&
+      devHandle->ipcMemHandleOpen != nullptr &&
+      devHandle->ipcMemHandleClose != nullptr &&
+      devHandle->ipcMemHandleFree != nullptr;
+  int allApisAvailable = 0;
+  ASSERT_MPI_SUCCESS(MPI_Allreduce(&localApisAvailable, &allApisAvailable, 1,
+                                   MPI_INT, MPI_MIN, MPI_COMM_WORLD));
+  if (!allApisAvailable) {
+    GTEST_SKIP() << "IPC memory handle APIs are not available";
+  }
+
+  // Every rank creates its receive/export storage before communication. This
+  // also provides a coordinated runtime capability check for stub backends.
+  flagcxIpcMemHandle_t handle = nullptr;
+  size_t localHandleSize = 0;
+  flagcxResult_t createResult =
+      devHandle->ipcMemHandleCreate(&handle, &localHandleSize);
+  if (createResult != flagcxSuccess &&
+    createResult != flagcxNotSupported) {
+    ADD_FAILURE() << "ipcMemHandleCreate returned "
+                  << static_cast<int>(createResult);
+    MPI_Abort(MPI_COMM_WORLD, static_cast<int>(createResult));
+    return;
+  }
+  int localSupported = createResult != flagcxNotSupported;
+  int allSupported = 0;
+  ASSERT_MPI_SUCCESS(MPI_Allreduce(&localSupported, &allSupported, 1, MPI_INT,
+                                   MPI_MIN, MPI_COMM_WORLD));
+  if (!allSupported) {
+    if (createResult == flagcxSuccess && handle != nullptr) {
+      ASSERT_FLAGCX_SUCCESS(devHandle->ipcMemHandleFree(handle));
+    }
+    GTEST_SKIP() << "IPC memory handles are not supported";
+  }
+  ASSERT_FLAGCX_SUCCESS(createResult);
+  ASSERT_MPI_TRUE(handle != nullptr);
+  ASSERT_MPI_TRUE(localHandleSize > 0);
+
   if (rank == 0) {
     void *devPtr = nullptr;
     ASSERT_FLAGCX_SUCCESS(devHandle->deviceMalloc(
         &devPtr, bufferSize, flagcxMemDevice, nullptr));
-    ASSERT_NE(devPtr, nullptr);
+    ASSERT_MPI_TRUE(devPtr != nullptr);
 
     int hostValue = expectedValue;
     ASSERT_FLAGCX_SUCCESS(devHandle->deviceMemcpy(
@@ -82,23 +134,18 @@ TEST_F(IpcMemHandleMpiTest, CrossProcessLifecycle) {
         nullptr));
     ASSERT_FLAGCX_SUCCESS(devHandle->streamSynchronize(nullptr));
 
-    flagcxIpcMemHandle_t handle = nullptr;
-    size_t handleSize = 0;
-    ASSERT_FLAGCX_SUCCESS(
-        devHandle->ipcMemHandleCreate(&handle, &handleSize));
-    ASSERT_NE(handle, nullptr);
-    ASSERT_GT(handleSize, static_cast<size_t>(0));
     ASSERT_FLAGCX_SUCCESS(devHandle->ipcMemHandleGet(handle, devPtr));
 
-    ASSERT_MPI_SUCCESS(MPI_Send(&handleSize, sizeof(handleSize), MPI_BYTE, 1,
-                                0, MPI_COMM_WORLD));
-    ASSERT_MPI_SUCCESS(MPI_Send(handle, static_cast<int>(handleSize), MPI_BYTE,
-                                1, 1, MPI_COMM_WORLD));
+    ASSERT_MPI_SUCCESS(MPI_Send(&localHandleSize, sizeof(localHandleSize),
+                                MPI_BYTE, 1, 0, MPI_COMM_WORLD));
+    ASSERT_MPI_SUCCESS(
+        MPI_Send(handle, static_cast<int>(localHandleSize), MPI_BYTE, 1, 1,
+                 MPI_COMM_WORLD));
 
     int acknowledgement = 0;
     ASSERT_MPI_SUCCESS(MPI_Recv(&acknowledgement, 1, MPI_INT, 1, 2,
                                 MPI_COMM_WORLD, MPI_STATUS_IGNORE));
-    ASSERT_EQ(acknowledgement, 1);
+    ASSERT_MPI_TRUE(acknowledgement == 1);
 
     ASSERT_FLAGCX_SUCCESS(devHandle->ipcMemHandleFree(handle));
     ASSERT_FLAGCX_SUCCESS(
@@ -109,11 +156,6 @@ TEST_F(IpcMemHandleMpiTest, CrossProcessLifecycle) {
                                 MPI_BYTE, 0, 0, MPI_COMM_WORLD,
                                 MPI_STATUS_IGNORE));
 
-    flagcxIpcMemHandle_t handle = nullptr;
-    size_t localHandleSize = 0;
-    ASSERT_FLAGCX_SUCCESS(
-        devHandle->ipcMemHandleCreate(&handle, &localHandleSize));
-    ASSERT_NE(handle, nullptr);
     if (localHandleSize != receivedHandleSize) {
       ADD_FAILURE() << "IPC handle size mismatch: local=" << localHandleSize
                     << ", remote=" << receivedHandleSize;
@@ -127,14 +169,14 @@ TEST_F(IpcMemHandleMpiTest, CrossProcessLifecycle) {
 
     void *mappedPtr = nullptr;
     ASSERT_FLAGCX_SUCCESS(devHandle->ipcMemHandleOpen(handle, &mappedPtr));
-    ASSERT_NE(mappedPtr, nullptr);
+    ASSERT_MPI_TRUE(mappedPtr != nullptr);
 
     int receivedValue = 0;
     ASSERT_FLAGCX_SUCCESS(devHandle->deviceMemcpy(
         &receivedValue, mappedPtr, sizeof(receivedValue),
         flagcxMemcpyDeviceToHost, nullptr));
     ASSERT_FLAGCX_SUCCESS(devHandle->streamSynchronize(nullptr));
-    EXPECT_EQ(receivedValue, expectedValue);
+    ASSERT_MPI_TRUE(receivedValue == expectedValue);
 
     ASSERT_FLAGCX_SUCCESS(devHandle->ipcMemHandleClose(mappedPtr));
     ASSERT_FLAGCX_SUCCESS(devHandle->ipcMemHandleFree(handle));

--- a/test/unittest/adaptor/coll_ipc_mem_handle.cpp
+++ b/test/unittest/adaptor/coll_ipc_mem_handle.cpp
@@ -76,7 +76,8 @@ TEST_F(IpcMemHandleMpiTest, CrossProcessLifecycle) {
   ASSERT_MPI_SUCCESS(MPI_Comm_size(MPI_COMM_WORLD, &worldSize));
 
   if (worldSize != 2) {
-    GTEST_SKIP() << "CrossProcessLifecycle requires exactly 2 MPI ranks";
+    GTEST_SKIP() << "CrossProcessLifecycle requires exactly 2 MPI ranks; "
+                 << "run with: make MPI_NP=2 run-mpi";
   }
 
   constexpr size_t bufferSize = 4096;

--- a/test/unittest/adaptor/coll_ipc_mem_handle.cpp
+++ b/test/unittest/adaptor/coll_ipc_mem_handle.cpp
@@ -1,0 +1,163 @@
+/*************************************************************************
+ * Copyright (c) 2026. All Rights Reserved.
+ * Cross-process IPC memory handle test (requires MPI and KunlunXin XPU).
+ ************************************************************************/
+
+#include <gtest/gtest.h>
+#include <mpi.h>
+
+#include "adaptor.h"
+#include "flagcx.h"
+
+
+namespace {
+
+#define ASSERT_FLAGCX_SUCCESS(expr)                                           \
+  do {                                                                        \
+    flagcxResult_t result = (expr);                                            \
+    if (result != flagcxSuccess) {                                             \
+      ADD_FAILURE() << #expr << " returned " << static_cast<int>(result);      \
+      MPI_Abort(MPI_COMM_WORLD, static_cast<int>(result));                     \
+      return;                                                                  \
+    }                                                                          \
+  } while (0)
+
+#define ASSERT_MPI_SUCCESS(expr)                                              \
+  do {                                                                        \
+    int result = (expr);                                                       \
+    if (result != MPI_SUCCESS) {                                               \
+      ADD_FAILURE() << #expr << " returned " << result;                        \
+      MPI_Abort(MPI_COMM_WORLD, result);                                       \
+      return;                                                                  \
+    }                                                                          \
+  } while (0)
+
+class IpcMemHandleMpiTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    flagcxDeviceHandleInit(&devHandle);
+    ASSERT_NE(devHandle, nullptr);
+
+    int deviceCount = 0;
+    ASSERT_FLAGCX_SUCCESS(devHandle->getDeviceCount(&deviceCount));
+    if (deviceCount <= 0) {
+      ADD_FAILURE() << "No visible XPU device";
+      MPI_Abort(MPI_COMM_WORLD, 1);
+      return;
+    }
+    ASSERT_FLAGCX_SUCCESS(devHandle->setDevice(0));
+  }
+
+  void TearDown() override {
+    if (devHandle != nullptr) {
+      flagcxDeviceHandleFree(devHandle);
+    }
+  }
+
+  flagcxDeviceHandle_t devHandle = nullptr;
+};
+
+TEST_F(IpcMemHandleMpiTest, CrossProcessLifecycle) {
+  int rank = -1;
+  int worldSize = 0;
+  ASSERT_MPI_SUCCESS(MPI_Comm_rank(MPI_COMM_WORLD, &rank));
+  ASSERT_MPI_SUCCESS(MPI_Comm_size(MPI_COMM_WORLD, &worldSize));
+
+  if (worldSize != 2) {
+    GTEST_SKIP() << "CrossProcessLifecycle requires exactly 2 MPI ranks";
+  }
+
+  constexpr size_t bufferSize = 4096;
+  constexpr int expectedValue = 0x12345678;
+
+  if (rank == 0) {
+    void *devPtr = nullptr;
+    ASSERT_FLAGCX_SUCCESS(devHandle->deviceMalloc(
+        &devPtr, bufferSize, flagcxMemDevice, nullptr));
+    ASSERT_NE(devPtr, nullptr);
+
+    int hostValue = expectedValue;
+    ASSERT_FLAGCX_SUCCESS(devHandle->deviceMemcpy(
+        devPtr, &hostValue, sizeof(hostValue), flagcxMemcpyHostToDevice,
+        nullptr));
+    ASSERT_FLAGCX_SUCCESS(devHandle->streamSynchronize(nullptr));
+
+    flagcxIpcMemHandle_t handle = nullptr;
+    size_t handleSize = 0;
+    ASSERT_FLAGCX_SUCCESS(
+        devHandle->ipcMemHandleCreate(&handle, &handleSize));
+    ASSERT_NE(handle, nullptr);
+    ASSERT_GT(handleSize, static_cast<size_t>(0));
+    ASSERT_FLAGCX_SUCCESS(devHandle->ipcMemHandleGet(handle, devPtr));
+
+    ASSERT_MPI_SUCCESS(MPI_Send(&handleSize, sizeof(handleSize), MPI_BYTE, 1,
+                                0, MPI_COMM_WORLD));
+    ASSERT_MPI_SUCCESS(MPI_Send(handle, static_cast<int>(handleSize), MPI_BYTE,
+                                1, 1, MPI_COMM_WORLD));
+
+    int acknowledgement = 0;
+    ASSERT_MPI_SUCCESS(MPI_Recv(&acknowledgement, 1, MPI_INT, 1, 2,
+                                MPI_COMM_WORLD, MPI_STATUS_IGNORE));
+    ASSERT_EQ(acknowledgement, 1);
+
+    ASSERT_FLAGCX_SUCCESS(devHandle->ipcMemHandleFree(handle));
+    ASSERT_FLAGCX_SUCCESS(
+        devHandle->deviceFree(devPtr, flagcxMemDevice, nullptr));
+  } else {
+    size_t receivedHandleSize = 0;
+    ASSERT_MPI_SUCCESS(MPI_Recv(&receivedHandleSize, sizeof(receivedHandleSize),
+                                MPI_BYTE, 0, 0, MPI_COMM_WORLD,
+                                MPI_STATUS_IGNORE));
+
+    flagcxIpcMemHandle_t handle = nullptr;
+    size_t localHandleSize = 0;
+    ASSERT_FLAGCX_SUCCESS(
+        devHandle->ipcMemHandleCreate(&handle, &localHandleSize));
+    ASSERT_NE(handle, nullptr);
+    if (localHandleSize != receivedHandleSize) {
+      ADD_FAILURE() << "IPC handle size mismatch: local=" << localHandleSize
+                    << ", remote=" << receivedHandleSize;
+      MPI_Abort(MPI_COMM_WORLD, 1);
+      return;
+    }
+
+    ASSERT_MPI_SUCCESS(MPI_Recv(handle, static_cast<int>(receivedHandleSize),
+                                MPI_BYTE, 0, 1, MPI_COMM_WORLD,
+                                MPI_STATUS_IGNORE));
+
+    void *mappedPtr = nullptr;
+    ASSERT_FLAGCX_SUCCESS(devHandle->ipcMemHandleOpen(handle, &mappedPtr));
+    ASSERT_NE(mappedPtr, nullptr);
+
+    int receivedValue = 0;
+    ASSERT_FLAGCX_SUCCESS(devHandle->deviceMemcpy(
+        &receivedValue, mappedPtr, sizeof(receivedValue),
+        flagcxMemcpyDeviceToHost, nullptr));
+    ASSERT_FLAGCX_SUCCESS(devHandle->streamSynchronize(nullptr));
+    EXPECT_EQ(receivedValue, expectedValue);
+
+    ASSERT_FLAGCX_SUCCESS(devHandle->ipcMemHandleClose(mappedPtr));
+    ASSERT_FLAGCX_SUCCESS(devHandle->ipcMemHandleFree(handle));
+
+    int acknowledgement = 1;
+    ASSERT_MPI_SUCCESS(
+        MPI_Send(&acknowledgement, 1, MPI_INT, 0, 2, MPI_COMM_WORLD));
+  }
+
+  ASSERT_MPI_SUCCESS(MPI_Barrier(MPI_COMM_WORLD));
+}
+
+} // namespace
+
+
+int main(int argc, char **argv) {
+  int mpiResult = MPI_Init(&argc, &argv);
+  if (mpiResult != MPI_SUCCESS) {
+    return mpiResult;
+  }
+
+  ::testing::InitGoogleTest(&argc, argv);
+  int testResult = RUN_ALL_TESTS();
+  MPI_Finalize();
+  return testResult;
+}

--- a/test/unittest/adaptor/test_device_adaptor.cpp
+++ b/test/unittest/adaptor/test_device_adaptor.cpp
@@ -3,6 +3,7 @@
  * Single device adaptor test - no multi-GPU or MPI required
  ************************************************************************/
 
+#include <cstdlib>
 #include <cstring>
 #include <gtest/gtest.h>
 #include <iostream>
@@ -10,6 +11,10 @@
 #include "adaptor.h"
 #include "flagcx.h"
 #include "topo.h"
+
+#ifdef USE_KUNLUNXIN_ADAPTOR
+#include "kunlunxin_adaptor.h"
+#endif
 
 class DeviceAdaptorTest : public ::testing::Test {
 protected:
@@ -441,6 +446,67 @@ TEST_F(DeviceAdaptorTest, StreamCopyAndFree) {
   // Clean up the original
   devHandle->streamDestroy(tempStream);
 }
+#ifdef USE_KUNLUNXIN_ADAPTOR
+// Test: ipcMemHandleCreate allocates a wrapper and reports its serialized size.
+// Get/Open/Close/Free are intentionally not called in this test.
+TEST_F(DeviceAdaptorTest, IpcMemHandleCreate) {
+  ASSERT_NE(devHandle->ipcMemHandleCreate, nullptr);
+
+  flagcxIpcMemHandle_t handle = nullptr;
+  size_t handleSize = 0;
+  EXPECT_EQ(devHandle->ipcMemHandleCreate(&handle, &handleSize),
+            flagcxSuccess);
+  EXPECT_NE(handle, nullptr);
+  EXPECT_GT(handleSize, static_cast<size_t>(0));
+
+  flagcxIpcMemHandle_t handleWithoutSize = nullptr;
+  EXPECT_EQ(devHandle->ipcMemHandleCreate(&handleWithoutSize, nullptr),
+            flagcxSuccess);
+  EXPECT_NE(handleWithoutSize, nullptr);
+
+  EXPECT_EQ(devHandle->ipcMemHandleCreate(nullptr, &handleSize),
+            flagcxInvalidArgument);
+
+  // Direct cleanup keeps this test independent of ipcMemHandleFree.
+  std::free(handle);
+  std::free(handleWithoutSize);
+}
+
+// Test: ipcMemHandleGet exports a handle from a live device allocation.
+// The wrapper is allocated directly so Create/Open/Close/Free are not involved.
+TEST_F(DeviceAdaptorTest, IpcMemHandleGet) {
+  ASSERT_NE(devHandle->ipcMemHandleGet, nullptr);
+
+  constexpr size_t bufferSize = 4096;
+  void *devPtr = nullptr;
+  ASSERT_EQ(devHandle->deviceMalloc(&devPtr, bufferSize, flagcxMemDevice,
+                                    stream),
+            flagcxSuccess);
+  ASSERT_NE(devPtr, nullptr);
+
+  flagcxIpcMemHandle_t handle = nullptr;
+  flagcxCalloc(&handle, 1);
+  ASSERT_NE(handle, nullptr);
+
+  EXPECT_EQ(devHandle->ipcMemHandleGet(handle, devPtr), flagcxSuccess);
+  EXPECT_EQ(devHandle->ipcMemHandleGet(nullptr, devPtr),
+            flagcxInvalidArgument);
+  EXPECT_EQ(devHandle->ipcMemHandleGet(handle, nullptr),
+            flagcxInvalidArgument);
+
+  std::free(handle);
+  EXPECT_EQ(devHandle->deviceFree(devPtr, flagcxMemDevice, stream),
+            flagcxSuccess);
+}
+
+// Test: ipcMemHandleClose rejects a null mapped pointer.
+// Successful Close is covered by the MPI lifecycle test.
+TEST_F(DeviceAdaptorTest, IpcMemHandleClose) {
+  ASSERT_NE(devHandle->ipcMemHandleClose, nullptr);
+  EXPECT_EQ(devHandle->ipcMemHandleClose(nullptr), flagcxInvalidArgument);
+}
+
+#endif
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/test/unittest/adaptor/test_device_adaptor.cpp
+++ b/test/unittest/adaptor/test_device_adaptor.cpp
@@ -3,7 +3,6 @@
  * Single device adaptor test - no multi-GPU or MPI required
  ************************************************************************/
 
-#include <cstdlib>
 #include <cstring>
 #include <gtest/gtest.h>
 #include <iostream>
@@ -11,10 +10,6 @@
 #include "adaptor.h"
 #include "flagcx.h"
 #include "topo.h"
-
-#ifdef USE_KUNLUNXIN_ADAPTOR
-#include "kunlunxin_adaptor.h"
-#endif
 
 class DeviceAdaptorTest : public ::testing::Test {
 protected:
@@ -446,36 +441,41 @@ TEST_F(DeviceAdaptorTest, StreamCopyAndFree) {
   // Clean up the original
   devHandle->streamDestroy(tempStream);
 }
-#ifdef USE_KUNLUNXIN_ADAPTOR
-// Test: ipcMemHandleCreate allocates a wrapper and reports its serialized size.
-// Get/Open/Close/Free are intentionally not called in this test.
+// Test ipcMemHandleCreate through the public opaque-handle contract.
+// ipcMemHandleFree is used only to release resources created by this test.
 TEST_F(DeviceAdaptorTest, IpcMemHandleCreate) {
-  ASSERT_NE(devHandle->ipcMemHandleCreate, nullptr);
+  if (devHandle->ipcMemHandleCreate == nullptr ||
+      devHandle->ipcMemHandleFree == nullptr) {
+    GTEST_SKIP() << "IPC memory handle APIs are not available";
+  }
 
   flagcxIpcMemHandle_t handle = nullptr;
   size_t handleSize = 0;
-  EXPECT_EQ(devHandle->ipcMemHandleCreate(&handle, &handleSize),
-            flagcxSuccess);
-  EXPECT_NE(handle, nullptr);
+  flagcxResult_t result =
+      devHandle->ipcMemHandleCreate(&handle, &handleSize);
+  if (result == flagcxNotSupported) {
+    GTEST_SKIP() << "IPC memory handles are not supported";
+  }
+  ASSERT_EQ(result, flagcxSuccess);
+  ASSERT_NE(handle, nullptr);
   EXPECT_GT(handleSize, static_cast<size_t>(0));
+  EXPECT_EQ(devHandle->ipcMemHandleFree(handle), flagcxSuccess);
 
   flagcxIpcMemHandle_t handleWithoutSize = nullptr;
-  EXPECT_EQ(devHandle->ipcMemHandleCreate(&handleWithoutSize, nullptr),
+  ASSERT_EQ(devHandle->ipcMemHandleCreate(&handleWithoutSize, nullptr),
             flagcxSuccess);
-  EXPECT_NE(handleWithoutSize, nullptr);
-
-  EXPECT_EQ(devHandle->ipcMemHandleCreate(nullptr, &handleSize),
-            flagcxInvalidArgument);
-
-  // Direct cleanup keeps this test independent of ipcMemHandleFree.
-  std::free(handle);
-  std::free(handleWithoutSize);
+  ASSERT_NE(handleWithoutSize, nullptr);
+  EXPECT_EQ(devHandle->ipcMemHandleFree(handleWithoutSize), flagcxSuccess);
 }
 
-// Test: ipcMemHandleGet exports a handle from a live device allocation.
-// The wrapper is allocated directly so Create/Open/Close/Free are not involved.
+// Test ipcMemHandleGet with a handle created through the public API.
+// Create/Free are fixture operations; Get remains the assertion target.
 TEST_F(DeviceAdaptorTest, IpcMemHandleGet) {
-  ASSERT_NE(devHandle->ipcMemHandleGet, nullptr);
+  if (devHandle->ipcMemHandleCreate == nullptr ||
+      devHandle->ipcMemHandleGet == nullptr ||
+      devHandle->ipcMemHandleFree == nullptr) {
+    GTEST_SKIP() << "IPC memory handle APIs are not available";
+  }
 
   constexpr size_t bufferSize = 4096;
   void *devPtr = nullptr;
@@ -485,8 +485,17 @@ TEST_F(DeviceAdaptorTest, IpcMemHandleGet) {
   ASSERT_NE(devPtr, nullptr);
 
   flagcxIpcMemHandle_t handle = nullptr;
-  flagcxCalloc(&handle, 1);
-  ASSERT_NE(handle, nullptr);
+  flagcxResult_t result = devHandle->ipcMemHandleCreate(&handle, nullptr);
+  if (result == flagcxNotSupported) {
+    EXPECT_EQ(devHandle->deviceFree(devPtr, flagcxMemDevice, stream),
+              flagcxSuccess);
+    GTEST_SKIP() << "IPC memory handles are not supported";
+  }
+  if (result != flagcxSuccess || handle == nullptr) {
+    EXPECT_EQ(devHandle->deviceFree(devPtr, flagcxMemDevice, stream),
+              flagcxSuccess);
+    FAIL() << "ipcMemHandleCreate returned " << static_cast<int>(result);
+  }
 
   EXPECT_EQ(devHandle->ipcMemHandleGet(handle, devPtr), flagcxSuccess);
   EXPECT_EQ(devHandle->ipcMemHandleGet(nullptr, devPtr),
@@ -494,7 +503,7 @@ TEST_F(DeviceAdaptorTest, IpcMemHandleGet) {
   EXPECT_EQ(devHandle->ipcMemHandleGet(handle, nullptr),
             flagcxInvalidArgument);
 
-  std::free(handle);
+  EXPECT_EQ(devHandle->ipcMemHandleFree(handle), flagcxSuccess);
   EXPECT_EQ(devHandle->deviceFree(devPtr, flagcxMemDevice, stream),
             flagcxSuccess);
 }
@@ -502,11 +511,16 @@ TEST_F(DeviceAdaptorTest, IpcMemHandleGet) {
 // Test: ipcMemHandleClose rejects a null mapped pointer.
 // Successful Close is covered by the MPI lifecycle test.
 TEST_F(DeviceAdaptorTest, IpcMemHandleClose) {
-  ASSERT_NE(devHandle->ipcMemHandleClose, nullptr);
-  EXPECT_EQ(devHandle->ipcMemHandleClose(nullptr), flagcxInvalidArgument);
-}
+  if (devHandle->ipcMemHandleClose == nullptr) {
+    GTEST_SKIP() << "ipcMemHandleClose is not available";
+  }
 
-#endif
+  flagcxResult_t result = devHandle->ipcMemHandleClose(nullptr);
+  if (result == flagcxNotSupported) {
+    GTEST_SKIP() << "IPC memory handles are not supported";
+  }
+  EXPECT_EQ(result, flagcxInvalidArgument);
+}
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
### PR Category

PAL (Portable Abstraction Layer)

### PR Types

Test Case

### PR Description

This PR adds generic IPC memory handle validation for the device adaptor,
based on FlagCX v0.13.0 (`0beba7aa`).

Changes:

- Add argument validation and allocation error propagation to the KunlunXin
  `ipcMemHandleCreate` implementation.
- Add backend-agnostic unit tests for `ipcMemHandleCreate`,
  `ipcMemHandleGet`, and `ipcMemHandleClose`.
- Manage opaque IPC handles only through the public adaptor APIs.
- Remove KunlunXin-specific conditional compilation and private-header
  dependencies from the adaptor tests.
- Add a two-rank, same-host MPI test covering:
  `Create -> Get -> transfer -> Open -> data validation -> Close -> Free`.
- Add KunlunXin and MPI build support for the adaptor tests.

Validation:

- 3 generic IPC adaptor unit tests passed.
- The two-rank same-host MPI IPC lifecycle test passed on both ranks.
- `git diff --check` passed.

Notes:

- Device IPC handles are host-local. The MPI lifecycle test must run with
  both ranks on the same host and does not support cross-node handle transfer.
- Runtime validation was completed on KunlunXin. Other device backends were
  not runtime-tested in this environment; unsupported IPC implementations
  are skipped at runtime.
- `DeviceAdaptorTest.StreamWaitEvent` still fails in the full adaptor suite
  in this environment and is not modified by this PR.