### PR TITLE
feat(kunlunxin): add GDR memory lifecycle support

### DIFF
--- a/flagcx/adaptor/device/kunlunxin_adaptor.cc
+++ b/flagcx/adaptor/device/kunlunxin_adaptor.cc
@@ -5,6 +5,8 @@
 #include "adaptor.h"
 #include "alloc.h"
 
+#include <xpu/runtime.h>
+
 std::map<flagcxMemcpyType_t, cudaMemcpyKind> memcpy_type_map = {
     {flagcxMemcpyHostToDevice, cudaMemcpyHostToDevice},
     {flagcxMemcpyDeviceToHost, cudaMemcpyDeviceToHost},
@@ -107,17 +109,75 @@ flagcxResult_t kunlunAdaptorHostGetDevicePointer(void **pDevice, void *pHost) {
   return flagcxSuccess;
 }
 
-flagcxResult_t kunlunAdaptorGdrMemAlloc(void **ptr, size_t size,
-                                        void *memHandle) {
-  if (ptr == NULL) {
+/*
+ * GdrMem lifecycle:
+ *   memHandleInit
+ *   gdrMemAlloc -> xpu_malloc + xccl_mmap
+ *   caller registers hostMappedPtr and completes communication
+ *   caller deregisters the MR
+ *   gdrMemFree -> xccl_munmap + xpu_free
+ *   memHandleDestroy
+ *
+ * memHandle is mandatory. It is passed by value, so gdrMemAlloc cannot safely
+ * create and return an implicit handle when the argument is null.
+ *
+ * Production upper-layer wiring is outside this implementation: the upper
+ * layer must own and propagate the same handle through allocation and cleanup.
+ */
+
+flagcxResult_t kunlunAdaptorMemHandleInit(int dev_id, void **memHandle) {
+  (void)dev_id;
+  if (memHandle == NULL) return flagcxInvalidArgument;
+  auto *h = new (std::nothrow) KunlunXinGdrMemHandle{};
+  if (h == NULL) return flagcxSystemError;
+  *memHandle = h;
+  return flagcxSuccess;
+}
+
+flagcxResult_t kunlunAdaptorMemHandleDestroy(int dev, void *memHandle) {
+  (void)dev;
+  if (memHandle == NULL) return flagcxSuccess;
+  auto *h = static_cast<KunlunXinGdrMemHandle *>(memHandle);
+  // Refuse to destroy a handle that still has a live mapping or unreleased device pointer.
+  if (h->mapped || h->devPtr != NULL) {
     return flagcxInvalidArgument;
   }
-  DEVCHECK(cudaMalloc(ptr, size));
-  cudaPointerAttributes attrs;
-  DEVCHECK(cudaPointerGetAttributes(&attrs, *ptr));
-  unsigned flags = 1;
-  DEVCHECK(cuPointerSetAttribute(&flags, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
-                                 (CUdeviceptr)attrs.devicePointer));
+  delete h;
+  return flagcxSuccess;
+}
+
+flagcxResult_t kunlunAdaptorGdrMemAlloc(void **ptr, size_t size,
+                                        void *memHandle) {
+  if (ptr == NULL || size == 0 || memHandle == NULL) {
+    return flagcxInvalidArgument;
+  }
+
+  auto *handle = static_cast<KunlunXinGdrMemHandle *>(memHandle);
+  // Reject if handle already holds a live mapping.
+  if (handle->mapped || handle->devPtr != NULL) {
+    return flagcxInvalidArgument;
+  }
+
+  // Step 1: allocate device memory.
+  void *devPtr = NULL;
+  int ret = xpu_malloc(&devPtr, size);
+  if (ret != 0 || devPtr == NULL) {
+    return flagcxUnhandledDeviceError;
+  }
+
+  // Step 2: map device VA to host VA (requires BKCL_USE_PEERMEM_XDR=1).
+  void *hostPtr = NULL;
+  ret = baidu::xpu::bkcl::xccl_mmap(&hostPtr, devPtr, size);
+  if (ret != 0 || hostPtr == NULL) {
+    xpu_free(devPtr);
+    return flagcxUnhandledDeviceError;
+  }
+
+  handle->devPtr        = devPtr;
+  handle->hostMappedPtr = hostPtr;
+  handle->size          = size;
+  handle->mapped        = true;
+  *ptr = devPtr;
   return flagcxSuccess;
 }
 
@@ -125,7 +185,30 @@ flagcxResult_t kunlunAdaptorGdrMemFree(void *ptr, void *memHandle) {
   if (ptr == NULL) {
     return flagcxSuccess;
   }
-  DEVCHECK(cudaFree(ptr));
+  if (memHandle == NULL) {
+    return flagcxInvalidArgument;
+  }
+
+  auto *handle = static_cast<KunlunXinGdrMemHandle *>(memHandle);
+
+  // Sanity check: ptr must match what we allocated.
+  if (handle->devPtr != ptr) {
+    return flagcxInvalidArgument;
+  }
+
+  // Step 1: unmap host mapping — must pass hostMappedPtr, not devPtr.
+  if (handle->mapped && handle->hostMappedPtr != NULL) {
+    int ret = baidu::xpu::bkcl::xccl_munmap(handle->hostMappedPtr,
+                                             handle->size);
+    if (ret != 0) return flagcxUnhandledDeviceError;
+  }
+
+  // Step 2: free device memory.
+  int ret = xpu_free(ptr);
+  if (ret != 0) return flagcxUnhandledDeviceError;
+
+  // Clear all handle fields.
+  *handle = {};
   return flagcxSuccess;
 }
 
@@ -427,8 +510,8 @@ struct flagcxDeviceAdaptor kunlunAdaptor {
       kunlunAdaptorGetDeviceCount, kunlunAdaptorGetVendor,
       kunlunAdaptorHostGetDevicePointer,
       // GDR functions
-      NULL, // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
-      NULL, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
+      kunlunAdaptorMemHandleInit,    // flagcxResult_t (*memHandleInit)(int dev_id, void **memHandle);
+      kunlunAdaptorMemHandleDestroy, // flagcxResult_t (*memHandleDestroy)(int dev, void *memHandle);
       kunlunAdaptorGdrMemAlloc, kunlunAdaptorGdrMemFree,
       NULL, // flagcxResult_t (*hostShareMemAlloc)(void **ptr, size_t size, void
             // *memHandle);

--- a/flagcx/adaptor/include/kunlunxin_adaptor.h
+++ b/flagcx/adaptor/include/kunlunxin_adaptor.h
@@ -31,6 +31,16 @@ struct flagcxIpcMemHandle {
   cudaIpcMemHandle_t base;
 };
 
+// GDR memory handle for alloc-internal mmap.
+// Allocated by memHandleInit, released by memHandleDestroy.
+// gdrMemAlloc fills all fields; gdrMemFree clears them after cleanup.
+struct KunlunXinGdrMemHandle {
+  void  *devPtr;         // device pointer from xpu_malloc
+  void  *hostMappedPtr;  // host VA from xccl_mmap, passed to ibv_reg_mr
+  size_t size;           // allocation size
+  bool   mapped;         // true between xccl_mmap and xccl_munmap
+};
+
 namespace baidu {
 namespace xpu {
 namespace bkcl {

--- a/test/make.inc
+++ b/test/make.inc
@@ -76,6 +76,16 @@ ifeq ($(USE_NVIDIA), 1)
   DEVICE_COMPILER  := $(DEVICE_HOME)/bin/nvcc
   ADAPTOR_DEFINE   := -DUSE_NVIDIA_ADAPTOR
   PLATFORM_IR_DIR  := $(PROJECT_ROOT)/bindings/ir/nvidia
+else ifeq ($(USE_KUNLUNXIN), 1)
+  DEVICE_HOME      ?= /usr/local/xpu
+  DEVICE_LIB       := $(DEVICE_HOME)/so
+  DEVICE_INCLUDE   := -I$(DEVICE_HOME)/include
+  DEVICE_LINK      := -L$(DEVICE_LIB) -Wl,-rpath,$(DEVICE_LIB) -lxpurt -lcudart
+  ADAPTOR_DEFINE   := -DUSE_KUNLUNXIN_ADAPTOR
+  CCL_HOME         ?= /usr/local/xccl
+  CCL_LIB          ?= $(CCL_HOME)/so
+  CCL_INCLUDE      := -I$(CCL_HOME)/include
+  CCL_LINK         := -L$(CCL_LIB) -Wl,-rpath,$(CCL_LIB) -lbkcl
 else ifeq ($(USE_DU), 1)
   DEVICE_HOME      ?= $(CUDA_PATH)
   DEVICE_LIB       := $(DEVICE_HOME)/lib64

--- a/test/unittest/adaptor/Makefile
+++ b/test/unittest/adaptor/Makefile
@@ -1,5 +1,8 @@
 include ../../make.inc
-
+ADAPTOR_EXTRA_LINK :=
+ifeq ($(USE_KUNLUNXIN), 1)
+ADAPTOR_EXTRA_LINK += -libverbs
+endif
 # [unit] tests: test_*.cpp — single GPU, no MPI required
 UNIT_SRCS   := $(wildcard test_*.cpp)
 UNIT_OBJS   := $(UNIT_SRCS:%.cpp=$(OBJDIR)/%.o)
@@ -25,22 +28,22 @@ all: $(ALL_TARGETS)
 $(UNIT_TARGET): $(UNIT_OBJS)
 	@mkdir -p $(BINDIR)
 	@echo "Linking   $@"
-	@$(CXX) $^ -o $@ $(FLAGCX_LINK) $(GTEST_LINK)
+	@$(CXX) $^ -o $@ $(FLAGCX_LINK) $(DEVICE_LINK) $(CCL_LINK) $(ADAPTOR_EXTRA_LINK) $(GTEST_LINK)
 
 $(MPI_TARGET): $(MPI_OBJS)
 	@mkdir -p $(BINDIR)
 	@echo "Linking   $@"
-	@$(CXX) $^ -o $@ $(FLAGCX_LINK) $(GTEST_LINK) $(MPI_LINK)
+	@$(CXX) $^ -o $@ $(FLAGCX_LINK) $(DEVICE_LINK) $(CCL_LINK) $(ADAPTOR_EXTRA_LINK) $(GTEST_LINK) $(MPI_LINK)
 
 $(OBJDIR)/test_%.o: test_%.cpp
 	@mkdir -p $(OBJDIR)
 	@echo "Compiling $<"
-	@$(CXX) $< -o $@ -c $(CXXFLAGS) $(FLAGCX_INCLUDES) $(GTEST_INCLUDE) $(FIXTURE_INCLUDE)
+	@$(CXX) $< -o $@ -c $(CXXFLAGS) $(ADAPTOR_DEFINE) $(FLAGCX_INCLUDES) $(DEVICE_INCLUDE) $(CCL_INCLUDE) $(GTEST_INCLUDE) $(FIXTURE_INCLUDE)
 
 $(OBJDIR)/coll_%.o: coll_%.cpp
 	@mkdir -p $(OBJDIR)
 	@echo "Compiling $<"
-	@$(CXX) $< -o $@ -c $(CXXFLAGS) $(FLAGCX_INCLUDES) $(GTEST_INCLUDE) $(FIXTURE_INCLUDE) $(MPI_INCLUDE)
+	@$(CXX) $< -o $@ -c $(CXXFLAGS) $(ADAPTOR_DEFINE) $(FLAGCX_INCLUDES) $(DEVICE_INCLUDE) $(CCL_INCLUDE) $(GTEST_INCLUDE) $(FIXTURE_INCLUDE) $(MPI_INCLUDE)
 
 clean:
 	@rm -rf $(BUILDDIR)

--- a/test/unittest/adaptor/test_device_adaptor.cpp
+++ b/test/unittest/adaptor/test_device_adaptor.cpp
@@ -11,6 +11,58 @@
 #include "flagcx.h"
 #include "topo.h"
 
+#ifdef USE_KUNLUNXIN_ADAPTOR
+#include <cuda_runtime.h>
+#include <infiniband/verbs.h>
+#include "kunlunxin_adaptor.h"
+#endif
+
+#ifdef USE_KUNLUNXIN_ADAPTOR
+namespace {
+// Scenario helper: register the mapped host VA with any available IB device,
+// then deregister it. This is intentionally used only by the lifecycle test.
+testing::AssertionResult verifyMrRegistration(void *ptr, size_t size) {
+  int count = 0;
+  ibv_device **devices = ibv_get_device_list(&count);
+  if (devices == nullptr || count == 0) {
+    if (devices != nullptr) ibv_free_device_list(devices);
+    return testing::AssertionFailure() << "no IB device is available";
+  }
+  for (int i = 0; i < count; ++i) {
+    ibv_context *context = ibv_open_device(devices[i]);
+    if (context == nullptr) continue;
+    ibv_pd *pd = ibv_alloc_pd(context);
+    if (pd != nullptr) {
+      const int access = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+                         IBV_ACCESS_REMOTE_READ;
+      ibv_mr *mr = ibv_reg_mr(pd, ptr, size, access);
+      if (mr != nullptr) {
+        const uint32_t lkey = mr->lkey;
+        const uint32_t rkey = mr->rkey;
+        const std::string deviceName = ibv_get_device_name(devices[i]);
+        const int deregResult = ibv_dereg_mr(mr);
+        ibv_dealloc_pd(pd);
+        ibv_close_device(context);
+        ibv_free_device_list(devices);
+        if (deregResult != 0) {
+          return testing::AssertionFailure()
+                 << "ibv_dereg_mr failed on " << deviceName
+                 << ", ret=" << deregResult;
+        }
+        std::cout << "[GDR lifecycle] ibv_reg_mr device="
+                  << deviceName << " lkey=" << lkey << " rkey=" << rkey
+                  << std::endl;
+        return testing::AssertionSuccess();
+      }
+      ibv_dealloc_pd(pd);
+    }
+    ibv_close_device(context);
+  }
+  ibv_free_device_list(devices);
+  return testing::AssertionFailure()
+         << "ibv_reg_mr failed on every available IB device";
+}
+}  // namespace
 class DeviceAdaptorTest : public ::testing::Test {
 protected:
   void SetUp() override {
@@ -441,6 +493,238 @@ TEST_F(DeviceAdaptorTest, StreamCopyAndFree) {
   // Clean up the original
   devHandle->streamDestroy(tempStream);
 }
+/*
+ * KunlunXin GDR test coverage
+ *
+ * Local validation:
+ * - GdrMemAlloc, GdrMemFree and MemHandleInitDestroy test one interface at a
+ *   time without using the paired interface as the test setup or oracle.
+ * - GdrMemoryLifecycle covers allocation, mapping, CPU/XPU data visibility,
+ *   MR registration/deregistration and cleanup.
+ *
+ * Required environment (export before XCCL/runtime initialization):
+ * - BKCL_USE_PEERMEM_XDR=1: enable the BKCL/XCCL peermem mapping used by
+ *   xccl_mmap. Without it, xccl_mmap returned no host-mapped address in the
+ *   validated environment.
+ * - CUDA_ENABLE_P2P_NO_UVA=1: enable the KunlunXin no-UVA peer-memory path.
+ *   This is a runtime prerequisite and does not replace xccl_mmap.
+ *
+ * Two-node acceptance:
+ * After the upper layer propagates the same non-null memHandle, reuse the
+ * existing RMA/SendRecv MPI suite on two physical nodes. Expect the RDMA path
+ * to be selected, the destination XPU payload to match, and gdrMemFree plus
+ * memHandleDestroy to complete. A same-node run may select IPC/SHM/P2P.
+ */
+
+// Unit test: only gdrMemAlloc is the target interface.
+// Cleanup deliberately uses xccl_munmap + xpu_free, not gdrMemFree.
+TEST_F(DeviceAdaptorTest, GdrMemAlloc) {
+  ASSERT_NE(deviceAdaptor->gdrMemAlloc, nullptr);
+
+  KunlunXinGdrMemHandle handle{};
+  void *rawHandle = &handle;
+  void *sentinel = reinterpret_cast<void *>(0x1);
+  void *out = sentinel;
+
+  EXPECT_EQ(deviceAdaptor->gdrMemAlloc(nullptr, TEST_SIZE, rawHandle),
+            flagcxInvalidArgument);
+  EXPECT_EQ(deviceAdaptor->gdrMemAlloc(&out, 0, rawHandle),
+            flagcxInvalidArgument);
+  EXPECT_EQ(out, sentinel);
+  EXPECT_EQ(deviceAdaptor->gdrMemAlloc(&out, TEST_SIZE, nullptr),
+            flagcxInvalidArgument);
+  EXPECT_EQ(out, sentinel);
+
+  out = nullptr;
+  ASSERT_EQ(deviceAdaptor->gdrMemAlloc(&out, TEST_SIZE, rawHandle),
+            flagcxSuccess)
+      << "BKCL_USE_PEERMEM_XDR=1 and CUDA_ENABLE_P2P_NO_UVA=1 are required";
+  ASSERT_NE(out, nullptr);
+
+  EXPECT_EQ(handle.devPtr, out);
+  EXPECT_NE(handle.hostMappedPtr, nullptr);
+  EXPECT_EQ(handle.size, TEST_SIZE);
+  EXPECT_TRUE(handle.mapped);
+
+  void *second = nullptr;
+  EXPECT_EQ(deviceAdaptor->gdrMemAlloc(&second, TEST_SIZE, rawHandle),
+            flagcxInvalidArgument);
+  EXPECT_EQ(second, nullptr);
+
+  // The returned device pointer must be usable by the device copy path.
+  uint64_t source = 0x1122334455667788ULL;
+  uint64_t destination = 0;
+  auto copyResult = devHandle->deviceMemcpy(
+      out, &source, sizeof(source), flagcxMemcpyHostToDevice, stream);
+  EXPECT_EQ(copyResult, flagcxSuccess);
+  if (copyResult == flagcxSuccess) {
+    EXPECT_EQ(devHandle->streamSynchronize(stream), flagcxSuccess);
+    copyResult = devHandle->deviceMemcpy(
+        &destination, out, sizeof(destination), flagcxMemcpyDeviceToHost,
+        stream);
+    EXPECT_EQ(copyResult, flagcxSuccess);
+    if (copyResult == flagcxSuccess) {
+      EXPECT_EQ(devHandle->streamSynchronize(stream), flagcxSuccess);
+      EXPECT_EQ(destination, source);
+    }
+  }
+
+  // Direct cleanup keeps this test independent from gdrMemFree.
+  if (handle.hostMappedPtr == nullptr) {
+    xpu_free(out);
+    handle = {};
+    FAIL() << "gdrMemAlloc returned success without a host mapping";
+  }
+  EXPECT_EQ(baidu::xpu::bkcl::xccl_munmap(handle.hostMappedPtr, handle.size),
+            0);
+  EXPECT_EQ(xpu_free(out), 0);
+  handle = {};
+}
+
+// Unit test: only gdrMemFree is the target interface.
+// Its input is constructed directly, without calling gdrMemAlloc.
+TEST_F(DeviceAdaptorTest, GdrMemFree) {
+  ASSERT_NE(deviceAdaptor->gdrMemFree, nullptr);
+  EXPECT_EQ(deviceAdaptor->gdrMemFree(nullptr, nullptr), flagcxSuccess);
+
+  void *devPtr = nullptr;
+  ASSERT_EQ(xpu_malloc(&devPtr, TEST_SIZE), 0);
+  ASSERT_NE(devPtr, nullptr);
+
+  void *hostPtr = nullptr;
+  const int mmapResult =
+      baidu::xpu::bkcl::xccl_mmap(&hostPtr, devPtr, TEST_SIZE);
+  if (mmapResult != 0 || hostPtr == nullptr) {
+    xpu_free(devPtr);
+    FAIL() << "xccl_mmap failed; check the peermem environment";
+  }
+
+  KunlunXinGdrMemHandle handle{devPtr, hostPtr, TEST_SIZE, true};
+  void *wrongPtr = reinterpret_cast<void *>(0xdeadbeef);
+  EXPECT_EQ(deviceAdaptor->gdrMemFree(wrongPtr, &handle),
+            flagcxInvalidArgument);
+  EXPECT_TRUE(handle.mapped);
+  EXPECT_EQ(handle.devPtr, devPtr);
+
+  ASSERT_EQ(deviceAdaptor->gdrMemFree(devPtr, &handle), flagcxSuccess);
+  EXPECT_EQ(handle.devPtr, nullptr);
+  EXPECT_EQ(handle.hostMappedPtr, nullptr);
+  EXPECT_EQ(handle.size, static_cast<size_t>(0));
+  EXPECT_FALSE(handle.mapped);
+}
+
+// Unit test for the handle constructor/destructor contract only.
+TEST_F(DeviceAdaptorTest, MemHandleInitDestroy) {
+  ASSERT_NE(deviceAdaptor->memHandleInit, nullptr);
+  ASSERT_NE(deviceAdaptor->memHandleDestroy, nullptr);
+
+  EXPECT_EQ(deviceAdaptor->memHandleInit(0, nullptr), flagcxInvalidArgument);
+  EXPECT_EQ(deviceAdaptor->memHandleDestroy(0, nullptr), flagcxSuccess);
+
+  void *rawHandle = nullptr;
+  ASSERT_EQ(deviceAdaptor->memHandleInit(0, &rawHandle), flagcxSuccess);
+  ASSERT_NE(rawHandle, nullptr);
+
+  auto *handle = static_cast<KunlunXinGdrMemHandle *>(rawHandle);
+  EXPECT_EQ(handle->devPtr, nullptr);
+  EXPECT_EQ(handle->hostMappedPtr, nullptr);
+  EXPECT_EQ(handle->size, static_cast<size_t>(0));
+  EXPECT_FALSE(handle->mapped);
+
+  handle->devPtr = reinterpret_cast<void *>(0x1);
+  EXPECT_EQ(deviceAdaptor->memHandleDestroy(0, rawHandle),
+            flagcxInvalidArgument);
+  handle->devPtr = nullptr;
+  EXPECT_EQ(deviceAdaptor->memHandleDestroy(0, rawHandle), flagcxSuccess);
+}
+
+// Scenario test: public adaptor interfaces plus the downstream RDMA
+// registration operation, covering the complete local GDR lifecycle.
+// This local scenario validates through MR registration. The follow-up
+// two-node acceptance test should verify an actual remote RDMA WRITE/READ and
+// payload visibility by reusing the repository RMA/SendRecv MPI suite.
+// Requires BKCL_USE_PEERMEM_XDR=1 and CUDA_ENABLE_P2P_NO_UVA=1 in the process
+// environment before XCCL/runtime initialization.
+TEST_F(DeviceAdaptorTest, GdrMemoryLifecycle) {
+  ASSERT_NE(deviceAdaptor->memHandleInit, nullptr);
+  ASSERT_NE(deviceAdaptor->memHandleDestroy, nullptr);
+  ASSERT_NE(deviceAdaptor->gdrMemAlloc, nullptr);
+  ASSERT_NE(deviceAdaptor->gdrMemFree, nullptr);
+
+  void *rawHandle = nullptr;
+  ASSERT_EQ(deviceAdaptor->memHandleInit(0, &rawHandle), flagcxSuccess);
+  ASSERT_NE(rawHandle, nullptr);
+
+  void *devPtr = nullptr;
+  const auto allocResult =
+      deviceAdaptor->gdrMemAlloc(&devPtr, TEST_SIZE, rawHandle);
+  if (allocResult != flagcxSuccess || devPtr == nullptr) {
+    deviceAdaptor->memHandleDestroy(0, rawHandle);
+    FAIL() << "gdrMemAlloc failed; check the peermem environment";
+  }
+
+  auto *handle = static_cast<KunlunXinGdrMemHandle *>(rawHandle);
+  auto cleanup = [&]() {
+    if (devPtr != nullptr) {
+      EXPECT_EQ(deviceAdaptor->gdrMemFree(devPtr, rawHandle), flagcxSuccess);
+      devPtr = nullptr;
+    }
+    if (rawHandle != nullptr) {
+      EXPECT_EQ(deviceAdaptor->memHandleDestroy(0, rawHandle), flagcxSuccess);
+      rawHandle = nullptr;
+    }
+  };
+
+  if (!handle->mapped || handle->hostMappedPtr == nullptr) {
+    cleanup();
+    FAIL() << "gdrMemAlloc did not create a host mapping";
+  }
+
+  // CPU mapped view -> device view.
+  auto *mappedValue = static_cast<uint64_t *>(handle->hostMappedPtr);
+  const uint64_t cpuValue = 0x1122334455667788ULL;
+  __atomic_store_n(mappedValue, cpuValue, __ATOMIC_RELEASE);
+
+  uint64_t deviceRead = 0;
+  auto result = devHandle->deviceMemcpy(
+      &deviceRead, devPtr, sizeof(deviceRead), flagcxMemcpyDeviceToHost,
+      stream);
+  if (result != flagcxSuccess ||
+      devHandle->streamSynchronize(stream) != flagcxSuccess) {
+    cleanup();
+    FAIL() << "device read after mapped CPU write failed";
+  }
+  EXPECT_EQ(deviceRead, cpuValue);
+
+  // Device view -> CPU mapped view.
+  uint64_t deviceValue = 0x8877665544332211ULL;
+  result = devHandle->deviceMemcpy(devPtr, &deviceValue, sizeof(deviceValue),
+                                   flagcxMemcpyHostToDevice, stream);
+  if (result != flagcxSuccess ||
+      devHandle->streamSynchronize(stream) != flagcxSuccess) {
+    cleanup();
+    FAIL() << "device write before mapped CPU read failed";
+  }
+  EXPECT_EQ(__atomic_load_n(mappedValue, __ATOMIC_ACQUIRE), deviceValue);
+
+  const auto mrResult =
+      verifyMrRegistration(handle->hostMappedPtr, handle->size);
+  if (!mrResult) {
+    cleanup();
+    FAIL() << mrResult.message();
+  }
+
+  ASSERT_EQ(deviceAdaptor->gdrMemFree(devPtr, rawHandle), flagcxSuccess);
+  devPtr = nullptr;
+  EXPECT_EQ(handle->devPtr, nullptr);
+  EXPECT_EQ(handle->hostMappedPtr, nullptr);
+  EXPECT_FALSE(handle->mapped);
+
+  EXPECT_EQ(deviceAdaptor->memHandleDestroy(0, rawHandle), flagcxSuccess);
+  rawHandle = nullptr;
+}
+#endif  // USE_KUNLUNXIN_ADAPTOR
+
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
### PR Category

PAL (Portable Abstraction Layer)

### PR Types

New Features / Test Case

### PR Description

Add KunlunXin GDR memory lifecycle support:

- Add `KunlunXinGdrMemHandle` and its initialization/destruction interfaces.
- Implement `gdrMemAlloc` using `xpu_malloc` and `xccl_mmap`.
- Implement `gdrMemFree` using `xccl_munmap` and `xpu_free`.
- Add argument validation, ownership checks, failure cleanup, and lifecycle tests.
- Add the required KunlunXin test build configuration.

Required environment variables:

- `BKCL_USE_PEERMEM_XDR=1`: enables the BKCL/XCCL peermem mapping path.
- `CUDA_ENABLE_P2P_NO_UVA=1`: enables the KunlunXin no-UVA peer-memory path.

Both variables must be set before XCCL/XPU runtime initialization.

### Validation

The adaptor tests for memory allocation, release, handle management, data
visibility, and local MR registration passed on a single-node KunlunXin
environment.

### Limitations

The current tests validate the local GDR lifecycle through
`ibv_reg_mr/ibv_dereg_mr`. Remote RDMA data transfer is not covered.

Production upper-layer call sites must propagate the same non-null `memHandle`
through allocation, registration, communication, and cleanup.

Maintainers with a two-node KunlunXin/RDMA environment are requested to run the
existing RMA or Send/Recv MPI tests and verify:

- IB/RDMA is selected instead of IPC, SHM, P2P, or socket fallback.
- The destination XPU receives the expected remote payload.
- Cleanup completes through `gdrMemFree` and `memHandleDestroy`.