### PR TITLE
net/ibrc: export DMA-BUF fd for VMM memory in P2P regMr

### DIFF
--- a/flagcx/adaptor/net/ibrc_p2p_adaptor.cc
+++ b/flagcx/adaptor/net/ibrc_p2p_adaptor.cc
@@ -14,6 +14,9 @@
 #include "ibvwrap.h"
 #include "socket.h"
 
+#include "adaptor.h"
+#include "param.h"
+
 #include <algorithm>
 #include <assert.h>
 #include <atomic>
@@ -215,8 +218,39 @@ static flagcxResult_t flagcxP2pRegMrDmaBuf(void *comm, void *data, size_t size,
 
 static flagcxResult_t flagcxP2pRegMr(void *comm, void *data, size_t size,
                                      int type, int mrFlags, void **mhandle) {
-  return flagcxP2pRegMrDmaBuf(comm, data, size, type, 0ULL, -1, mrFlags,
-                              mhandle);
+  // VMM-allocated device memory (e.g. PPU with FLAGCX_VMM_ENABLE=1) cannot be
+  // registered through peer-mem (ibv_reg_mr); export the range as a DMA-BUF fd
+  // and register via ibv_reg_dmabuf_mr instead. Fall back to fd=-1 (peer-mem)
+  // when no exporter is available, mirroring flagcxOneSideRegister.
+  int fd = -1;
+  if (flagcxParamVmmEnable() && deviceAdaptor != NULL &&
+      deviceAdaptor->getHandleForAddressRange != NULL) {
+    // cuMemGetHandleForAddressRange requires a page-aligned base and size, so
+    // align the exported range (base down, size up). data/size below stay raw:
+    // flagcxIbRegMrDmaBufInternal re-derives the same aligned base as the
+    // dma-buf's byte 0 and registers with offset 0, so the two line up. The
+    // rounded-up range never exceeds the (granularity-aligned) VMM allocation.
+    static __thread uintptr_t pageSize = 0;
+    if (pageSize == 0) {
+      pageSize = sysconf(_SC_PAGESIZE);
+    }
+    uintptr_t alignedAddr = (uintptr_t)data & -pageSize;
+    size_t alignedSize =
+        (((uintptr_t)data - alignedAddr) + size + pageSize - 1) & -pageSize;
+    int dmaBufFd = -1;
+    if (deviceAdaptor->getHandleForAddressRange(
+            (void *)&dmaBufFd, (void *)alignedAddr, alignedSize, 0) ==
+            flagcxSuccess &&
+        dmaBufFd >= 0) {
+      fd = dmaBufFd;
+    }
+  }
+  flagcxResult_t res =
+      flagcxP2pRegMrDmaBuf(comm, data, size, type, 0ULL, fd, mrFlags, mhandle);
+  if (fd >= 0) {
+    close(fd);
+  }
+  return res;
 }
 
 static flagcxResult_t flagcxP2pDeregMr(void *comm, void *mhandle) {


### PR DESCRIPTION
## Problem

Bringing up the PD-disaggregation service on PPU (810e) fails during memory registration with a remote-access error.

The P2P registration path is:

```
p2pconnector
  -> engine->adaptor->regMr
    -> flagcxP2pRegMr
      -> flagcxP2pRegMrDmaBuf(comm, data, size, type, 0ULL, -1, mrFlags, mhandle)
```

`flagcxP2pRegMr` always passed `fd = -1`, which forces registration through **peer-mem** (`ibv_reg_mr`). peer-mem cannot map memory allocated through the CUDA VMM APIs (`cuMemCreate` / `cuMemAddressReserve` / `cuMemMap` / `cuMemSetAccess`). The PPU adaptor allocates device buffers exactly this way when `FLAGCX_VMM_ENABLE=1` (the default), so the NIC never gets a valid mapping and registration fails.

Other adaptors are unaffected today because they either don't use VMM allocation or don't implement an exporter, so `fd = -1` (peer-mem) is still the correct path for them.

## Fix

In `flagcxP2pRegMr`, when a device exporter is available (`deviceAdaptor->getHandleForAddressRange`, implemented by the PPU adaptor via `cuMemGetHandleForAddressRange`) and VMM is enabled, export the buffer range as a **DMA-BUF fd** and register it via `ibv_reg_dmabuf_mr`, which does not go through peer-mem and can map VMM memory.

`cuMemGetHandleForAddressRange` requires a page-aligned base **and** size, so the exported range is aligned (base rounded down, size rounded up). The raw `data` / `size` are still passed to `flagcxP2pRegMrDmaBuf` with `offset = 0`; the IB internal (`flagcxIbRegMrDmaBufInternal`) re-derives the same aligned base as byte 0 of the DMA-BUF, so the iova/length line up. The rounded-up range never exceeds the granularity-aligned VMM allocation.

When no exporter is available or VMM is disabled, it falls back to `fd = -1` (peer-mem), so behavior for all other adaptors is byte-for-byte unchanged. The function signature and all call sites are unchanged.

## Scope

- One file changed: `flagcx/adaptor/net/ibrc_p2p_adaptor.cc` (+36 / -2).
- No interface change; the fix lives entirely inside the existing `flagcxP2pRegMr`.