### PR TITLE
[CRL] Avoid sticky device error state on host buffer registration

### DIFF
--- a/flagcx/adaptor/device/cann_adaptor.cc
+++ b/flagcx/adaptor/device/cann_adaptor.cc
@@ -368,6 +368,7 @@ struct flagcxDeviceAdaptor cannAdaptor {
       cannAdaptorSymFlatUnmap, cannAdaptorSymMulticastSupported,
       cannAdaptorSymMulticastCreate, cannAdaptorSymMulticastBind,
       cannAdaptorSymMulticastTeardown, cannAdaptorSymMulticastFree,
+      NULL, // flagcxResult_t (*getLastError)();
 };
 
 #endif // USE_ASCEND_ADAPTOR

--- a/flagcx/adaptor/device/cuda_adaptor.cc
+++ b/flagcx/adaptor/device/cuda_adaptor.cc
@@ -930,6 +930,11 @@ flagcxResult_t cudaAdaptorSymMulticastFree(void *) { return flagcxSuccess; }
 
 #endif // CUDART_VERSION >= 12010
 
+flagcxResult_t cudaAdaptorGetLastError() {
+  cudaError_t err = cudaGetLastError();
+  return err == cudaSuccess ? flagcxSuccess : flagcxSystemError;
+}
+
 struct flagcxDeviceAdaptor cudaAdaptor {
   "CUDA",
       // Basic functions
@@ -996,6 +1001,7 @@ struct flagcxDeviceAdaptor cudaAdaptor {
       cudaAdaptorSymFlatUnmap, cudaAdaptorSymMulticastSupported,
       cudaAdaptorSymMulticastCreate, cudaAdaptorSymMulticastBind,
       cudaAdaptorSymMulticastTeardown, cudaAdaptorSymMulticastFree,
+      cudaAdaptorGetLastError,
 };
 
 #endif // USE_NVIDIA_ADAPTOR

--- a/flagcx/adaptor/device/ducuda_adaptor.cc
+++ b/flagcx/adaptor/device/ducuda_adaptor.cc
@@ -608,6 +608,7 @@ struct flagcxDeviceAdaptor ducudaAdaptor {
       ducudaAdaptorSymMulticastSupported, ducudaAdaptorSymMulticastCreate,
       ducudaAdaptorSymMulticastBind, ducudaAdaptorSymMulticastTeardown,
       ducudaAdaptorSymMulticastFree,
+      NULL, // flagcxResult_t (*getLastError)();
 };
 
 #endif // USE_DU_ADAPTOR

--- a/flagcx/adaptor/device/hip_adaptor.cc
+++ b/flagcx/adaptor/device/hip_adaptor.cc
@@ -432,6 +432,7 @@ struct flagcxDeviceAdaptor hipAdaptor {
       hipAdaptorSymFlatUnmap, hipAdaptorSymMulticastSupported,
       hipAdaptorSymMulticastCreate, hipAdaptorSymMulticastBind,
       hipAdaptorSymMulticastTeardown, hipAdaptorSymMulticastFree,
+      NULL, // flagcxResult_t (*getLastError)();
 };
 
 #endif // USE_AMD_ADAPTOR

--- a/flagcx/adaptor/device/ixcuda_adaptor.cc
+++ b/flagcx/adaptor/device/ixcuda_adaptor.cc
@@ -443,5 +443,6 @@ struct flagcxDeviceAdaptor ixcudaAdaptor {
       ixcudaAdaptorSymMulticastSupported, ixcudaAdaptorSymMulticastCreate,
       ixcudaAdaptorSymMulticastBind, ixcudaAdaptorSymMulticastTeardown,
       ixcudaAdaptorSymMulticastFree,
+      NULL, // flagcxResult_t (*getLastError)();
 };
 #endif // USE_ILUVATAR_COREX_ADAPTOR

--- a/flagcx/adaptor/device/kunlunxin_adaptor.cc
+++ b/flagcx/adaptor/device/kunlunxin_adaptor.cc
@@ -522,5 +522,6 @@ struct flagcxDeviceAdaptor kunlunAdaptor {
       kunlunxinAdaptorSymMulticastSupported, kunlunxinAdaptorSymMulticastCreate,
       kunlunxinAdaptorSymMulticastBind, kunlunxinAdaptorSymMulticastTeardown,
       kunlunxinAdaptorSymMulticastFree,
+      NULL, // flagcxResult_t (*getLastError)();
 };
 #endif // USE_KUNLUNXIN_ADAPTOR

--- a/flagcx/adaptor/device/maca_adaptor.cc
+++ b/flagcx/adaptor/device/maca_adaptor.cc
@@ -450,6 +450,7 @@ struct flagcxDeviceAdaptor macaAdaptor {
       macaAdaptorSymFlatUnmap, macaAdaptorSymMulticastSupported,
       macaAdaptorSymMulticastCreate, macaAdaptorSymMulticastBind,
       macaAdaptorSymMulticastTeardown, macaAdaptorSymMulticastFree,
+      NULL, // flagcxResult_t (*getLastError)();
 };
 
 #endif // USE_METAX_ADAPTOR

--- a/flagcx/adaptor/device/mlu_adaptor.cc
+++ b/flagcx/adaptor/device/mlu_adaptor.cc
@@ -396,6 +396,7 @@ struct flagcxDeviceAdaptor mluAdaptor {
       mluAdaptorSymFlatUnmap, mluAdaptorSymMulticastSupported,
       mluAdaptorSymMulticastCreate, mluAdaptorSymMulticastBind,
       mluAdaptorSymMulticastTeardown, mluAdaptorSymMulticastFree,
+      NULL, // flagcxResult_t (*getLastError)();
 };
 
 #endif // USE_CAMBRICON_ADAPTOR

--- a/flagcx/adaptor/device/musa_adaptor.cc
+++ b/flagcx/adaptor/device/musa_adaptor.cc
@@ -425,6 +425,7 @@ struct flagcxDeviceAdaptor musaAdaptor {
       musaAdaptorSymFlatUnmap, musaAdaptorSymMulticastSupported,
       musaAdaptorSymMulticastCreate, musaAdaptorSymMulticastBind,
       musaAdaptorSymMulticastTeardown, musaAdaptorSymMulticastFree,
+      NULL, // flagcxResult_t (*getLastError)();
 };
 
 #endif // USE_MUSA_ADAPTOR

--- a/flagcx/adaptor/device/ppu_cuda_adaptor.cc
+++ b/flagcx/adaptor/device/ppu_cuda_adaptor.cc
@@ -686,6 +686,7 @@ struct flagcxDeviceAdaptor ppucudaAdaptor {
       ppucudaAdaptorSymMulticastSupported, ppucudaAdaptorSymMulticastCreate,
       ppucudaAdaptorSymMulticastBind, ppucudaAdaptorSymMulticastTeardown,
       ppucudaAdaptorSymMulticastFree,
+      NULL, // flagcxResult_t (*getLastError)();
 };
 
 #endif // USE_PPU_ADAPTOR

--- a/flagcx/adaptor/device/ptpu_adaptor.cc
+++ b/flagcx/adaptor/device/ptpu_adaptor.cc
@@ -423,5 +423,6 @@ struct flagcxDeviceAdaptor ptpuAdaptor {
       // DMA buffer
       ptpuAdaptorDmaSupport, ptpuAdaptorGetHandleForAddressRange,
       ptpuAdaptorHostRegister, ptpuAdaptorHostUnregister,
+      NULL, // flagcxResult_t (*getLastError)();
 };
 #endif // USE_SUNRISE_ADAPTOR

--- a/flagcx/adaptor/device/tops_adaptor.cc
+++ b/flagcx/adaptor/device/tops_adaptor.cc
@@ -489,6 +489,7 @@ struct flagcxDeviceAdaptor topsAdaptor {
       topsAdaptorSymFlatUnmap, topsAdaptorSymMulticastSupported,
       topsAdaptorSymMulticastCreate, topsAdaptorSymMulticastBind,
       topsAdaptorSymMulticastTeardown, topsAdaptorSymMulticastFree,
+      NULL, // flagcxResult_t (*getLastError)();
 };
 
 #endif // USE_ENFLAME_ADAPTOR

--- a/flagcx/adaptor/device/tsmicro_adaptor.cc
+++ b/flagcx/adaptor/device/tsmicro_adaptor.cc
@@ -471,6 +471,7 @@ struct flagcxDeviceAdaptor tsmicroAdaptor {
       tsmicroAdaptorSymMulticastSupported, tsmicroAdaptorSymMulticastCreate,
       tsmicroAdaptorSymMulticastBind, tsmicroAdaptorSymMulticastTeardown,
       tsmicroAdaptorSymMulticastFree,
+      NULL, // flagcxResult_t (*getLastError)();
 };
 
 #endif // USE_TSM_ADAPTOR

--- a/flagcx/adaptor/include/flagcx_device_adaptor.h
+++ b/flagcx/adaptor/include/flagcx_device_adaptor.h
@@ -243,6 +243,8 @@ struct flagcxDeviceAdaptor_latest {
   // Release the multicast object handle returned by symMulticastCreate.
   // Must be called after all ranks have torn down their mappings.
   flagcxResult_t (*symMulticastFree)(void *mcHandle);
+
+  flagcxResult_t (*getLastError)();
 };
 
 #define flagcxDeviceAdaptor flagcxDeviceAdaptor_latest

--- a/flagcx/core/flagcx_p2p.cc
+++ b/flagcx/core/flagcx_p2p.cc
@@ -92,8 +92,10 @@ void loadGlobalConfig(FlagcxP2pGlobalConfig &c) {
                       4, "P2P_QPS_PER_CONN");
   c.workersPerPool = clampParam<int>(flagcxParamP2pWorkersPerPool(), 1, 8, 4,
                                      "P2P_WORKERS_PER_POOL");
+  c.workersPerPool = std::min(c.workersPerPool, c.qpsPerConn);
   c.shardCount =
       clampParam<int>(flagcxParamP2pShardCount(), 1, 64, 8, "P2P_SHARD_COUNT");
+  c.shardCount = std::max(c.shardCount, c.workersPerPool);
   c.sharedCqDepth = clampParam<size_t>(flagcxParamP2pCqDepth(), 1, 1u << 20,
                                        4096, "P2P_CQ_DEPTH");
   c.maxWrPerPost = clampParam<size_t>(flagcxParamP2pMaxWrPerPost(), 1, 1024,

--- a/flagcx/core/flagcx_p2p.cc
+++ b/flagcx/core/flagcx_p2p.cc
@@ -1477,7 +1477,7 @@ static int detectPtrTypeAndMaybeCacheIpc(void *ptr, char *ipcHandleBuf,
     deviceAdaptor->ipcMemHandleFree(handle);
     return FLAGCX_PTR_CUDA;
   }
-
+  if (deviceAdaptor->getLastError) deviceAdaptor->getLastError();
   deviceAdaptor->ipcMemHandleFree(handle);
   return FLAGCX_PTR_HOST;
 }
@@ -2632,10 +2632,21 @@ bool flagcxP2pEngineConnIsLocal(FlagcxP2pConn *conn) {
   return conn != NULL && conn->isLocal;
 }
 
-int flagcxP2pEngineReg(FlagcxP2pEngine *engine, uintptr_t data, size_t size,
-                       FlagcxP2pMr &mrId) {
+int flagcxP2pEngineRegEx(FlagcxP2pEngine *engine, uintptr_t data, size_t size,
+                         int hintType, FlagcxP2pMr &mrId) {
   if (engine == NULL || data == 0)
     return -1;
+
+  auto resolvePtrType = [&](char *ipcHandleBuf,
+                            uint32_t *ipcHandleSize) -> int {
+    if (hintType == FLAGCX_PTR_HOST || hintType == FLAGCX_PTR_CUDA) {
+      if (ipcHandleSize)
+        *ipcHandleSize = 0;
+      return hintType;
+    }
+    return detectPtrTypeAndMaybeCacheIpc(reinterpret_cast<void *>(data),
+                                         ipcHandleBuf, ipcHandleSize);
+  };
 
   if (!flagcxParamMrSortedLookup()) {
     /* Legacy: mutex + hash maps */
@@ -2666,8 +2677,7 @@ int flagcxP2pEngineReg(FlagcxP2pEngine *engine, uintptr_t data, size_t size,
     entry.ibDevN = ibDevN;
 
     setEngineDevice(engine);
-    entry.ptrType = detectPtrTypeAndMaybeCacheIpc(
-        reinterpret_cast<void *>(data), entry.ipcHandle, &entry.ipcHandleSize);
+    entry.ptrType = resolvePtrType(entry.ipcHandle, &entry.ipcHandleSize);
     entry.hasIpc = entry.ptrType == FLAGCX_PTR_CUDA && entry.ipcHandleSize > 0;
 
     if (engine->adaptor->regMr(&devCtx, reinterpret_cast<void *>(data), size,
@@ -2721,8 +2731,7 @@ int flagcxP2pEngineReg(FlagcxP2pEngine *engine, uintptr_t data, size_t size,
   memset(ipcHandle, 0, sizeof(ipcHandle));
 
   setEngineDevice(engine);
-  int ptrType = detectPtrTypeAndMaybeCacheIpc(reinterpret_cast<void *>(data),
-                                              ipcHandle, &ipcHandleSize);
+  int ptrType = resolvePtrType(ipcHandle, &ipcHandleSize);
   bool hasIpc = ptrType == FLAGCX_PTR_CUDA && ipcHandleSize > 0;
 
   /* Register with adaptor */
@@ -2764,6 +2773,11 @@ int flagcxP2pEngineReg(FlagcxP2pEngine *engine, uintptr_t data, size_t size,
   mrId = assignedId;
   pthread_mutex_unlock(&gMrLifecycleMutex);
   return 0;
+}
+
+int flagcxP2pEngineReg(FlagcxP2pEngine *engine, uintptr_t data, size_t size,
+                       FlagcxP2pMr &mrId) {
+  return flagcxP2pEngineRegEx(engine, data, size, 0, mrId);
 }
 
 void flagcxP2pEngineMrDestroy(FlagcxP2pEngine *engine, FlagcxP2pMr mr) {
@@ -3474,6 +3488,21 @@ int flagcxP2pRpcRegister(void *engine, uint64_t addr, uint64_t size,
   const int rc = flagcxP2pEngineReg(reinterpret_cast<FlagcxP2pEngine *>(engine),
                                     static_cast<uintptr_t>(addr),
                                     static_cast<size_t>(size), mrId);
+  if (rc != 0)
+    return rc;
+  *mrIdOut = mrId;
+  return 0;
+}
+
+int flagcxP2pRpcRegisterHost(void *engine, uint64_t addr, uint64_t size,
+                             uint64_t *mrIdOut) {
+  if (mrIdOut == NULL)
+    return -1;
+  FlagcxP2pMr mrId = 0;
+  const int rc = flagcxP2pEngineRegEx(
+      reinterpret_cast<FlagcxP2pEngine *>(engine),
+      static_cast<uintptr_t>(addr), static_cast<size_t>(size),
+      FLAGCX_PTR_HOST, mrId);
   if (rc != 0)
     return rc;
   *mrIdOut = mrId;

--- a/flagcx/core/flagcx_p2p.cc
+++ b/flagcx/core/flagcx_p2p.cc
@@ -1477,7 +1477,8 @@ static int detectPtrTypeAndMaybeCacheIpc(void *ptr, char *ipcHandleBuf,
     deviceAdaptor->ipcMemHandleFree(handle);
     return FLAGCX_PTR_CUDA;
   }
-  if (deviceAdaptor->getLastError) deviceAdaptor->getLastError();
+  if (deviceAdaptor->getLastError)
+    deviceAdaptor->getLastError();
   deviceAdaptor->ipcMemHandleFree(handle);
   return FLAGCX_PTR_HOST;
 }
@@ -3500,9 +3501,8 @@ int flagcxP2pRpcRegisterHost(void *engine, uint64_t addr, uint64_t size,
     return -1;
   FlagcxP2pMr mrId = 0;
   const int rc = flagcxP2pEngineRegEx(
-      reinterpret_cast<FlagcxP2pEngine *>(engine),
-      static_cast<uintptr_t>(addr), static_cast<size_t>(size),
-      FLAGCX_PTR_HOST, mrId);
+      reinterpret_cast<FlagcxP2pEngine *>(engine), static_cast<uintptr_t>(addr),
+      static_cast<size_t>(size), FLAGCX_PTR_HOST, mrId);
   if (rc != 0)
     return rc;
   *mrIdOut = mrId;

--- a/flagcx/include/flagcx_p2p.h
+++ b/flagcx/include/flagcx_p2p.h
@@ -619,7 +619,7 @@ int flagcxP2pRpcRegister(void *engine, uint64_t addr, uint64_t size,
                          uint64_t *mrIdOut);
 
 /* Same interface as flagcxP2pRpcRegister, but on chips/adaptors whose runtime
-   cannot reset the current error state, this host entry avoids producing the 
+   cannot reset the current error state, this host entry avoids producing the
    error at all. */
 int flagcxP2pRpcRegisterHost(void *engine, uint64_t addr, uint64_t size,
                              uint64_t *mrIdOut);

--- a/flagcx/include/flagcx_p2p.h
+++ b/flagcx/include/flagcx_p2p.h
@@ -618,6 +618,12 @@ int flagcxP2pRpcStartServer(void *engine);
 int flagcxP2pRpcRegister(void *engine, uint64_t addr, uint64_t size,
                          uint64_t *mrIdOut);
 
+/* Same interface as flagcxP2pRpcRegister, but on chips/adaptors whose runtime
+   cannot reset the current error state, this host entry avoids producing the 
+   error at all. */
+int flagcxP2pRpcRegisterHost(void *engine, uint64_t addr, uint64_t size,
+                             uint64_t *mrIdOut);
+
 /* Get (or lazily establish) a cached connection to "host:port". */
 void *flagcxP2pRpcGetConn(void *engine, const char *session);
 

--- a/plugin/interservice/flagcx_wrapper.py
+++ b/plugin/interservice/flagcx_wrapper.py
@@ -419,6 +419,10 @@ class FLAGCXLibrary:
             flagcxP2pEngine_t, ctypes.c_uint64, ctypes.c_uint64,
             ctypes.POINTER(ctypes.c_uint64)
         ]),
+        Function("flagcxP2pRpcRegisterHost", ctypes.c_int, [
+            flagcxP2pEngine_t, ctypes.c_uint64, ctypes.c_uint64,
+            ctypes.POINTER(ctypes.c_uint64)
+        ]),
         Function("flagcxP2pRpcGetConn", flagcxP2pConn_t, [
             flagcxP2pEngine_t, ctypes.c_char_p
         ]),
@@ -447,9 +451,12 @@ class FLAGCXLibrary:
             so_path = os.path.join(flagcx_path, "lib", "libflagcx.so")
             if os.path.isfile(so_path):
                 return so_path
+            build_so_path = os.path.join(flagcx_path, "build", "lib", "libflagcx.so")
+            if os.path.isfile(build_so_path):
+                return build_so_path
             raise FileNotFoundError(
-                f"FLAGCX_PATH is set to '{flagcx_path}' but "
-                f"'{so_path}' does not exist. "
+                f"FLAGCX_PATH is set to '{flagcx_path}' but neither "
+                f"'{so_path}' nor '{build_so_path}' exists. "
                 f"Please build FlagCX or check FLAGCX_PATH."
             )
         # 2. Fall back to <repo_root>/build/lib/libflagcx.so
@@ -816,6 +823,17 @@ class FLAGCXLibrary:
         if rc != 0:
             raise RuntimeError(
                 f"flagcxP2pRegister failed (addr={hex(addr)}, size={size})")
+        return mr_id.value
+
+    def flagcxP2pRegisterHost(self, engine: flagcxP2pEngine_t,
+                              addr: int, size: int) -> int:
+        mr_id = ctypes.c_uint64(0)
+        rc = self._funcs["flagcxP2pRpcRegisterHost"](
+            engine, ctypes.c_uint64(addr), ctypes.c_uint64(size),
+            ctypes.byref(mr_id))
+        if rc != 0:
+            raise RuntimeError(
+                f"flagcxP2pRegisterHost failed (addr={hex(addr)}, size={size})")
         return mr_id.value
 
     def flagcxP2pGetConn(self, engine: flagcxP2pEngine_t,


### PR DESCRIPTION
### PR Category

CRL (Communication Runtime Layer)

### PR Types

Bug Fixes

### PR Description

Registering a host buffer went through `detectPtrTypeAndMaybeCacheIpc`, whose probing IPC call leaves a sticky error in the device runtime. On chips whose runtime cannot clear that state, all later device calls fail.

- Add `getLastError` to the device adaptor (implemented for CUDA) to clear the sticky error after the IPC probe.
- Add `flagcxP2pEngineRegEx` / `flagcxP2pRpcRegisterHost`, which take an explicit pointer-type hint so host registration skips the IPC probe entirely and never produces the error.
- Expose `flagcxP2pRegisterHost` in the interservice Python wrapper, and let it also locate `libflagcx.so` under `$FLAGCX_PATH/build/lib`.
