### PR TITLE
[PAL] Add NPU device support for FlagCX Ascend communicator

### DIFF
--- a/makefiles/ascend.mk
+++ b/makefiles/ascend.mk
@@ -19,4 +19,4 @@ ADAPTOR_FLAG := -DUSE_ASCEND_ADAPTOR
 
 PLATFORM_KERNEL_DIR  :=
 PLATFORM_KERNEL_SRCS :=
-PLATFORM_EXTRA_SRCS  :=
+PLATFORM_EXTRA_SRCS  := flagcx/adaptor/device_api/default_dev_api_backend.cc

--- a/plugin/interservice/flagcx_wrapper.py
+++ b/plugin/interservice/flagcx_wrapper.py
@@ -867,7 +867,7 @@ class FLAGCXLibrary:
 
     def adaptor_stream_copy(self, old_stream):
         new_stream = flagcxStream_t()
-        raw_stream = getattr(old_stream, 'musa_stream', old_stream.cuda_stream)
+        raw_stream = getattr(old_stream, 'musa_stream', getattr(old_stream, 'npu_stream', getattr(old_stream, 'cuda_stream', 0)))
         self.FLAGCX_CHECK(self.devHandle.contents.streamCopy(ctypes.byref(new_stream), ctypes.c_void_p(raw_stream)))
         return new_stream
 

--- a/plugin/interservice/flagcx_wrapper.py
+++ b/plugin/interservice/flagcx_wrapper.py
@@ -459,7 +459,13 @@ class FLAGCXLibrary:
                 f"'{so_path}' nor '{build_so_path}' exists. "
                 f"Please build FlagCX or check FLAGCX_PATH."
             )
-        # 2. Fall back to <repo_root>/build/lib/libflagcx.so
+        # 2. Check alongside the installed flagcx Python package
+        #    (build.sh copies libflagcx.so into the package directory)
+        pkg_dir = os.path.dirname(os.path.abspath(__file__))
+        pkg_so = os.path.join(pkg_dir, "libflagcx.so")
+        if os.path.isfile(pkg_so):
+            return pkg_so
+        # 3. Fall back to <repo_root>/build/lib/libflagcx.so
         repo_root = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "..", "..")
         )
@@ -469,8 +475,9 @@ class FLAGCXLibrary:
         raise FileNotFoundError(
             f"Cannot find libflagcx.so. Searched:\n"
             f"  - $FLAGCX_PATH/lib/libflagcx.so (FLAGCX_PATH not set)\n"
-            f"  - {so_path} (not found)\n"
-            f"Please set FLAGCX_PATH or build FlagCX first."
+            f"  - {pkg_so} (not in package)\n"
+            f"  - {so_path} (not in source tree)\n"
+            f"Please set FLAGCX_PATH or reinstall flagcx."
         )
 
     def __init__(self, so_file: Optional[str] = None):

--- a/plugin/torch/_build_config.py
+++ b/plugin/torch/_build_config.py
@@ -182,6 +182,18 @@ def get_device_config(adaptor_flag):
         import torch_npu
         pytorch_npu_install_path = os.path.dirname(os.path.abspath(torch_npu.__file__))
         pytorch_library_path = os.path.join(pytorch_npu_install_path, "lib")
+        # CANN toolkit headers must come BEFORE torch_npu bundled third_party
+        # ACL headers (torch_npu 2.11.0 bundles newer ACL headers incompatible
+        # with CANN 8.5.1).  We also symlink torch_npu's third_party/acl/inc/acl
+        # to CANN's acl/ directory (see install.sh), but adding the CANN include
+        # path here is a belt-and-suspenders fix for hccl.h etc.
+        cann_home = os.environ.get("ASCEND_HOME_PATH", "")
+        if cann_home:
+            import platform as _pf
+            _arch = "aarch64-linux" if _pf.machine().startswith("aarch") else "x86_64-linux"
+            _cann_inc = os.path.join(cann_home, _arch, "include")
+            if os.path.isdir(_cann_inc):
+                include_dirs += [_cann_inc]
         include_dirs += [os.path.join(pytorch_npu_install_path, "include")]
         library_dirs += [pytorch_library_path]
         libs += ["torch_npu"]

--- a/plugin/torch/flagcx/include/backend_flagcx.hpp
+++ b/plugin/torch/flagcx/include/backend_flagcx.hpp
@@ -231,7 +231,7 @@ public:
 #ifdef USE_NVIDIA_ADAPTOR
     devName = "cuda";
 #elif USE_ASCEND_ADAPTOR
-    devName = "cann";
+    devName = "npu";
 #elif USE_ILUVATAR_COREX_ADAPTOR
     devName = "cuda";
 #elif USE_CAMBRICON_ADAPTOR


### PR DESCRIPTION
### PR Category
PAL (Portable Abstraction Layer)

### PR Types
Bug Fixes, New Features

### PR Description

The FlagCX Ascend adaptor was added in commit #196 (2025-07-22) but has never been CI-tested or successfully built end-to-end. Four bugs prevent `libflagcx.so` from building and the torch plugin from working on Ascend 910B NPU:

**1. `makefiles/ascend.mk` — Missing `PLATFORM_EXTRA_SRCS`**

Commit #522 (2026-07-30) introduced the `device_api/` refactor but only updated `nvidia.mk`. All non-NVIDIA `.mk` files (including `ascend.mk`) have empty `PLATFORM_EXTRA_SRCS`, causing `undefined symbol: devApiBackend` when loading `libflagcx.so`.

Fix: Add `default_dev_api_backend.cc` to `PLATFORM_EXTRA_SRCS`.

**2. `backend_flagcx.hpp` — Wrong device name `"cann"` → `"npu"`**

The Ascend adaptor sets `devName = "cann"`, but `torch_npu` registers the device type as `"npu"` via `PrivateUse1` (from v2.5.1 through v2.11.0). `torch.device("cann")` is not recognized by PyTorch, causing `RuntimeError: Expected one of cpu, cuda, ..., privateuseone device type`.

Fix: Change `devName` from `"cann"` to `"npu"`.

**3. `_build_config.py` — Missing CANN include path**

The Ascend adaptor config only adds `torch_npu`'s include directory, but not the CANN toolkit's include path (containing `hccl.h` and other essential headers). Additionally, `torch_npu` 2.11.0 bundles newer ACL headers (with types like `aclmdlRITask`) that are incompatible with CANN 8.5.1, causing compile errors.

Fix: Prepend `ASCEND_HOME_PATH/$ARCH-linux/include` to `include_dirs` before `torch_npu`'s bundled headers. The code auto-detects architecture (`x86_64-linux` or `aarch64-linux`).

**4. `flagcx_wrapper.py` — NPU Stream attribute access**

`adaptor_stream_copy()` accesses `old_stream.cuda_stream` directly, but NPU `Stream` objects have `npu_stream` (not `cuda_stream`), causing `AttributeError: 'Stream' object has no attribute 'cuda_stream'`.

Fix: Use `getattr` chain: `musa_stream` → `npu_stream` → `cuda_stream` → 0.

Additionally, `_find_default_library()` now checks the installed flagcx package directory for `libflagcx.so` (before falling back to source tree), enabling the industry-standard pattern where `.so` files ship inside the Python package (like `torch`/`torch_npu`).

### Testing

**Environment**: Ascend 910B2C x86_64 / CANN 8.5.1 / torch_npu 2.11.0

```bash
# Build
cd FlagCX
FLAGCX_ADAPTOR=ascend make
cd plugin/torch && pip install --no-build-isolation .

# Verify
python3 -c "import flagcx; print('flagcx OK')"
python3 -c "from plugin.interservice.flagcx_wrapper import FLAGCXLibrary; print('wrapper OK')"
python3 -c "import torch; print(torch.distributed.is_backend_available('flagcx'))"
# → True
```

Tested end-to-end with vllm-plugin-FL on Qwen3.6-35B-A3B (4-card TP=4):
- `backend=flagcx` (HCCL, not NCCL)
- `communicator=CommunicatorFL`
- Correct inference output
